### PR TITLE
Update roks.yml to increase retries for deploy

### DIFF
--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/roks.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/roks.yml
@@ -119,7 +119,7 @@
   until:
     - roks_cluster_completion.rc == 0
     - (roks_cluster_completion.stdout | from_json).state == 'normal'
-  retries: 40
+  retries: 60
   delay: 60
 
 - name: "roks: Debug final cluster state"


### PR DESCRIPTION
Seeing timeouts but then the cluster is soon ready after that. A few more retries should do it.