### PR TITLE
[minor] Add ocp_verify role and associated playbook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,14 +5,14 @@
 ```bash
 cd ibm/mas_devops
 
-ansible-galaxy collection build --force && ansible-galaxy collection install ibm-mas_devops-4.0.1.tar.gz -p /home/david/.ansible/collections --force
+ansible-galaxy collection build --force && ansible-galaxy collection install ibm-mas_devops-4.1.0.tar.gz -p /home/david/.ansible/collections --force
 
 ansible-playbook ../../playbook.yml
 ```
 
 ```bash
 ansible-galaxy collection build --force
-ansible-galaxy collection publish ibm-mas_devops-4.0.1.tar.gz --token=$ANSIBLE_GALAXY_TOKEN
+ansible-galaxy collection publish ibm-mas_devops-4.1.0.tar.gz --token=$ANSIBLE_GALAXY_TOKEN
 ```
 
 ## Style Guide

--- a/build/README.md
+++ b/build/README.md
@@ -39,6 +39,7 @@ ROLE=cp4d_install; ln -s ../../ibm/mas_devops/roles/$ROLE/README.md $ROLE.md
 ROLE=install_operator; ln -s ../../ibm/mas_devops/roles/$ROLE/README.md $ROLE.md
 ROLE=ocp_login; ln -s ../../ibm/mas_devops/roles/$ROLE/README.md $ROLE.md
 ROLE=ocp_setup_mas_deps; ln -s ../../ibm/mas_devops/roles/$ROLE/README.md $ROLE.md
+ROLE=ocp_verify; ln -s ../../ibm/mas_devops/roles/$ROLE/README.md $ROLE.md
 ROLE=suite_app_configure; ln -s ../../ibm/mas_devops/roles/$ROLE/README.md $ROLE.md
 ROLE=suite_config; ln -s ../../ibm/mas_devops/roles/$ROLE/README.md $ROLE.md
 ROLE=suite_verify; ln -s ../../ibm/mas_devops/roles/$ROLE/README.md $ROLE.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ ansible-galaxy collection install ibm.mas_devops
 ## Change Log
 Note that links to pull requests prior to public release of the code (4.0) direct to IBM GitHub Enterprise, and will only be accessible to IBM employees.
 
+- `4.1` Add `ocp_verify` role and associated playbook ([#20](https://github.com/ibm-mas/ansible-devops/pull/20))
 - `4.0` Initial Public Release on ibm.mas_devops ([#5](https://github.com/ibm-mas/ansible-devops/pull/5))
 - `3.3` Support configurable SLS settings ([#53](https://github.ibm.com/maximoappsuite/mas-devops-ansible/pull/53))
 - `3.2` Add support for BAS ([#44](https://github.ibm.com/maximoappsuite/mas-devops-ansible/pull/44))

--- a/docs/roles/ocp_verify.md
+++ b/docs/roles/ocp_verify.md
@@ -1,0 +1,1 @@
+../../ibm/mas_devops/roles/ocp_verify/README.md

--- a/ibm/mas_devops/README.md
+++ b/ibm/mas_devops/README.md
@@ -6,6 +6,7 @@
 ## Change Log
 Note that links to pull requests prior to public release of the code (4.0) direct to IBM GitHub Enterprise, and will only be accessible to IBM employees.
 
+- `4.1` Add `ocp_verify` role and associated playbook ([#20](https://github.com/ibm-mas/ansible-devops/pull/20))
 - `4.0` Initial Public Release on ibm.mas_devops ([#5](https://github.com/ibm-mas/ansible-devops/pull/5))
 - `3.3` Support configurable SLS settings ([#53](https://github.ibm.com/maximoappsuite/mas-devops-ansible/pull/53))
 - `3.2` Adding support to BAS ([#44](https://github.ibm.com/maximoappsuite/mas-devops-ansible/pull/44))

--- a/ibm/mas_devops/galaxy.yml
+++ b/ibm/mas_devops/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: ibm
 name: mas_devops
-version: 4.0.1
+version: 4.1.0
 readme: README.md
 authors:
   - David Parker <parkerda@uk.ibm.com>

--- a/ibm/mas_devops/playbooks/lite-manage-roks.yml
+++ b/ibm/mas_devops/playbooks/lite-manage-roks.yml
@@ -14,7 +14,6 @@
   import_playbook: dependencies/install-mongodb-ce.yml
   vars:
     mongodb_storage_class: ibmc-block-gold
-    mas_config_dir: "{{ lookup('env', 'MAS_CONFIG_DIR') }}"
 
 
 # 3. Install CP4D services & configure Db2
@@ -23,7 +22,6 @@
   import_playbook: cp4d/install-db2.yml
   vars:
     cpd_storage_class: ibmc-file-gold-gid
-    mas_config_dir: "{{ lookup('env', 'MAS_CONFIG_DIR') }}"
 
 # Temporary hack for Manage, because the operator is missing critical
 # database configuration that requires manual intervention to set up.

--- a/ibm/mas_devops/playbooks/ocp/verify-roks.yml
+++ b/ibm/mas_devops/playbooks/ocp/verify-roks.yml
@@ -1,0 +1,9 @@
+---
+- hosts: localhost
+  vars:
+    cluster_name: "{{ lookup('env', 'CLUSTER_NAME')}}"
+    cluster_type: roks
+    ibmcloud_apikey: "{{ lookup('env', 'IBMCLOUD_APIKEY') }}"
+    ibmcloud_resourcegroup: "{{ lookup('env', 'IBMCLOUD_RESOURCEGROUP') | default('Default', true) }}"
+  roles:
+    - ibm.mas_devops.ocp_verify

--- a/ibm/mas_devops/roles/ocp_setup_mas_deps/README.md
+++ b/ibm/mas_devops/roles/ocp_setup_mas_deps/README.md
@@ -1,7 +1,8 @@
 ocp_setup_mas_deps
 ==================
 
-This role provides support to install operators that are required by MAS to work. The role will deploy Service Binding Operator in all namespaces and Cert Manager in the cert-manager namespace.
+This role provides support to install operators that are required by MAS to work. The role will deploy Service Binding Operator in all namespaces and Cert Manager in the cert-manager namespace.  The role declares a dependency on `ocp_verify` to ensure that the RedHat Operator Catalog is installed and ready before we try to install the Service Binding Operator from that catalog.
+
 
 Role Variables
 --------------

--- a/ibm/mas_devops/roles/ocp_verify/README.md
+++ b/ibm/mas_devops/roles/ocp_verify/README.md
@@ -1,0 +1,42 @@
+ocp_verify
+==========
+
+This role will verify that a provisioned OCP cluster is ready to be setup for MAS.
+
+In IBMCloud ROKS we have seen delays of over an hour before the Red Hat Operator catalog is ready to use.  This will cause attempts to install anything from that CatalogSource to fail as the timeouts built into those roles are designed to catch problems with an install, rather than a half-provisioned cluster that is not properly ready to use.
+
+
+Role Variables
+--------------
+The role requires no variables itself, but depends on the `ibm.mas_devops.ocp_login` role, and as such inherits it's requirements.
+
+- `cluster_name` Gives a name for the provisioning cluster
+- `cluster_type` quickburn | roks
+
+#### ROKS specific facts
+- `ibmcloud_apikey` APIKey to be used by ibmcloud login comand
+
+#### Fyre specific facts
+- `username` Required when cluster type is quickburn
+- `password` Required when cluster type is quickburn
+
+
+Example Playbook
+----------------
+
+```yaml
+- hosts: localhost
+  vars:
+    cluster_name: "{{ lookup('env', 'CLUSTER_NAME')}}"
+    cluster_type: roks
+    ibmcloud_apikey: "{{ lookup('env', 'IBMCLOUD_APIKEY') }}"
+    ibmcloud_resourcegroup: "{{ lookup('env', 'IBMCLOUD_RESOURCEGROUP') | default('Default', true) }}"
+  roles:
+    - ibm.mas_devops.ocp_verify
+```
+
+
+License
+-------
+
+EPL-2.0

--- a/ibm/mas_devops/roles/ocp_verify/meta/main.yml
+++ b/ibm/mas_devops/roles/ocp_verify/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
   author: David Parker (@durera)
-  description: Install operator catalogs, deploy SBO and cert-manager operators, and configure cluster monitoring in the target OCP cluster.
+  description: Verify the target OCP cluster is ready
   company: IBM
 
   license: EPL-2.0
@@ -20,4 +20,3 @@ galaxy_info:
 
 dependencies:
   - role: ibm.mas_devops.ocp_login
-  - role: ibm.mas_devops.ocp_verify

--- a/ibm/mas_devops/roles/ocp_verify/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_verify/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+# 1. Check for the Red Hat Catalog Source
+# -----------------------------------------------------------------------------
+# In IBMCloud ROKS we have seen delays of over an hour before the catalog is
+# ready to use.  This will cause attempts to install e.g. SBO from OperatorHub
+# to fail
+- name: Check if Red Hat Catalog is ready
+  community.kubernetes.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    name: redhat-operators
+    namespace: openshift-marketplace
+    kind: CatalogSource
+  register: redhat_catalog_info
+  retries: 90 # ~approx 1 1/2 hours before we give up
+  delay: 60 # seconds
+  until:
+    - redhat_catalog_info.resources is defined
+    - redhat_catalog_info.resources | length > 0
+    - redhat_catalog_info.resources[0].status.connectionState.lastObservedState == "READY"


### PR DESCRIPTION
Closes #20

- Create new role `ocp_verify` that checks (and waits) for the RedHat Operator Catalog to be ready.  This is primarily to avoid issues in IBM Cloud ROKS where it can be upwards of an hour after a cluster is provisioned until the catalog is available
- Create a new playbook `ocp/verify-roks.yml` that can be used to directly invoke this role
- Add the role as a dependency to the `ocp_setup_mas_deps` role to ensure that the cluster is ready before we attempt to insall SBO from the RedHat Operator Catalog.