### PR TITLE
[patch] Fix ROKS deprovision loop exit logic

### DIFF
--- a/ibm/mas_devops/roles/ocp_deprovision/tasks/providers/roks.yml
+++ b/ibm/mas_devops/roles/ocp_deprovision/tasks/providers/roks.yml
@@ -50,9 +50,12 @@
   debug:
     msg: "Cluster {{ cluster_name }} does not exist so there is no action to take"
 
-
 # 5. Wait for the deprovision to complete
 # -----------------------------------------------------------------------------
+# Note that the CLI doesn't work how you would expect it to ...
+# when the requested cluster isn't there, instead of rc=1, we sometimes
+# (but not always) get a rc=0 anyway.  In these cases the stdout array
+# will contain two entries "0" and "Retrieving cluster $clusterName"
 - name: "roks : Wait for cluster to be deprovisioned"
   when: cluster_found is defined
   shell: |
@@ -62,4 +65,4 @@
   register: cluster_get
   retries: 30
   delay: 60 # 60s * 30 retries = 30 mins
-  until: cluster_get.stdout == "1"
+  until: cluster_get.stdout == "1" or cluster_get.stdout_lines | length == 2


### PR DESCRIPTION
The loop is not exiting as expected when a cluster is already deprovisioned.