### PR TITLE
[patch] Add kubernetes module to collection dependencies

### DIFF
--- a/ibm/mas_devops/galaxy.yml
+++ b/ibm/mas_devops/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: ibm
 name: mas_devops
-version: 4.1.2
+version: 4.1.3
 readme: README.md
 authors:
   - David Parker <parkerda@uk.ibm.com>
@@ -15,7 +15,8 @@ tags:
   - ibm
   - mas
   - rhocp
-dependencies: {}
+dependencies:
+  "community.kubernetes": ">=1.2.1,<2.0.0"
 repository: https://github.com/ibm-mas/ansible-devops
 documentation: https://ibm-mas.github.io/ansible-devops/
 homepage: https://ibm-mas.github.io/ansible-devops/


### PR DESCRIPTION
Error reported in the sponsored user program:

```
ansible-playbook playbooks/fullstack-roks.yml
    [WARNING]: running playbook inside collection ibm.mas_devops
    [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
    ERROR! couldn't resolve module/action 'community.kubernetes.k8s_info'. This often indicates a misspelling, missing collection, or incorrect module path.

    The error appears to be in '/home/labs/.ansible/collections/ansible_collections/ibm/mas_devops/roles/ocp_verify/tasks/main.yml': line 7, column 3, but may
    be elsewhere in the file depending on the exact syntax problem.

    The offending line appears to be:

    # to fail
    - name: Check if Red Hat Catalog is ready
    ^ here
```

The metadata in our collection needs to declare a dependency on community.kubernetes so that it is installed automatically when customer installs our collection.

Note how `community.kubernetes` is checked now during the install of `ibm.mas_devops`:

```
Using /etc/ansible/ansible.cfg as config file
Starting galaxy collection install process
Process install dependency map
Starting collection install process
Installing 'ibm.mas_devops:4.1.3' to '/home/david/.ansible/collections/ansible_collections/ibm/mas_devops'
ibm.mas_devops (4.1.3) was installed successfully
Skipping 'community.kubernetes' as it is already installed
```