### PR TITLE
[patch] Fix CIS integration to support multiple MAS instances

### DIFF
--- a/ibm/mas_devops/roles/suite_dns/templates/cis/production-cert.yml.j2
+++ b/ibm/mas_devops/roles/suite_dns/templates/cis/production-cert.yml.j2
@@ -1,7 +1,7 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: cis-letsencrypt-production
+  name: cis-letsencrypt-production-{{ mas_instance_id }}
 spec:
   acme:
     email: "{{ cis_email }}"

--- a/ibm/mas_devops/roles/suite_dns/templates/cis/staging-cert.yml.j2
+++ b/ibm/mas_devops/roles/suite_dns/templates/cis/staging-cert.yml.j2
@@ -1,7 +1,7 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: cis-letsencrypt-staging
+  name: cis-letsencrypt-staging-{{ mas_instance_id }}
 spec:
   acme:
     email: "{{ cis_email }}"


### PR DESCRIPTION
Per discussion with MAS team, the change to the templates will remove the current limitation in the certificate templates in order to allow for multiple CIS instances for different MAS instances in the same cluster.