### PR TITLE
[patch] externalize Service Binding Operator subscription settings

### DIFF
--- a/ibm/mas_devops/playbooks/ocp/configure-ocp.yml
+++ b/ibm/mas_devops/playbooks/ocp/configure-ocp.yml
@@ -11,6 +11,10 @@
     artifactory_username: "{{ lookup('env', 'W3_USERNAME') | lower }}"
     artifactory_apikey: "{{ lookup('env', 'ARTIFACTORY_APIKEY') }}"
 
+    sbo_channel: "{{ lookup('env', 'SBO_CHANNEL') | default('preview', true) }}"
+    sbo_startingcsv: "{{ lookup('env', 'SBO_STARTINGCSV') | default('service-binding-operator.v0.8.0', true) }}"
+    sbo_plan_approval: "{{ lookup('env', 'SBO_PLAN_APPROVAL') | default('Manual', true) }}"
+
     # --- OAuth settings ----------------------------------------------------------------------------------------
     # optionally you can provide information to setup github oauth in the cluster
     # oauth:

--- a/ibm/mas_devops/roles/ocp_setup_mas_deps/README.md
+++ b/ibm/mas_devops/roles/ocp_setup_mas_deps/README.md
@@ -7,7 +7,9 @@ This role provides support to install operators that are required by MAS to work
 Role Variables
 --------------
 
-TODO: Finish documentation
+- `sbo_channel` Catalog channel used to obtain the Service Binding Operator.
+- `sbo_startingcsv` Starting version for the Service Binding Operator subscription.
+- `sbo_plan_approval` Update strategy for the Service Binding Operator subscription.
 
 
 Example Playbook

--- a/ibm/mas_devops/roles/ocp_setup_mas_deps/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_setup_mas_deps/defaults/main.yml
@@ -1,0 +1,4 @@
+# By default we still install 0.8.0
+sbo_channel: preview
+sbo_startingcsv: service-binding-operator.v0.8.0
+sbo_plan_approval: Manual

--- a/ibm/mas_devops/roles/ocp_setup_mas_deps/templates/sbo/subscription.yaml
+++ b/ibm/mas_devops/roles/ocp_setup_mas_deps/templates/sbo/subscription.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     operators.coreos.com/rh-service-binding-operator.openshift-operators: ''
 spec:
-  channel: preview
-  installPlanApproval: Manual
+  channel: {{ sbo_channel }}
+  installPlanApproval: {{ sbo_plan_approval }}
   name: rh-service-binding-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: service-binding-operator.v0.8.0
+  startingCSV: {{ sbo_startingcsv }}


### PR DESCRIPTION
Currently the Service Binding Operator subscription is hard coded to the preview channel with a starting version of 0.8 and and update strategy of manual. As Maximo Application Suite matures the need to move away from Service Binding Operator v0.8 will be required. 

This PR externalizes three variables from the `oc_setup_mas_deps`role:

- sbo_channel
- sbo_startingcsv
- sbo_plan_approval

The defaults for these new variables will remain:

```yaml
sbo_channel: preview
sbo_startingcsv: service-binding-operator.v0.8.0
sbo_plan_approval: Manual
```

The configure-ocp playbook allows them to be overridden by checking for the following environment variables at runtime:


SBO_CHANNEL
SBO_STARTINGCSV
SBO_PLAN_APPROVAL

