### PR TITLE
[patch] fix sls secret registrationKey

### DIFF
--- a/ibm/mas_devops/roles/sls_install/tasks/bootstrap.yml
+++ b/ibm/mas_devops/roles/sls_install/tasks/bootstrap.yml
@@ -11,4 +11,4 @@
       stringData:
         licensingId: "{{ (bootstrap.license_id is defined or bootstrap.license_id is defined == '') | ternary(bootstrap.license_id, omit ) }}"
         licensingKey: "{{  (bootstrap.entitlement_file is defined or bootstrap.entitlement_file is defined == '') | ternary(lookup('file', bootstrap.entitlement_file), omit) }}"
-        registration_key: "{{ (bootstrap.registration_key is defined  or bootstrap.registration_key == '') | ternary(bootstrap.registration_key, omit) }}"
+        registrationKey: "{{ (bootstrap.registration_key is defined  or bootstrap.registration_key == '') | ternary(bootstrap.registration_key, omit) }}"


### PR DESCRIPTION
Update the {{sls_instance_name}}-bootstrap secret's key name "registration_key" to "registrationKey"