### PR TITLE
[patch] Fixes for Travis -> Actions migration

### DIFF
--- a/build/bin/.env.sh
+++ b/build/bin/.env.sh
@@ -44,7 +44,7 @@ export NO_RELEASE_BUILD_REGEXP="\+build"
 
 # Semver control overrides for maintenance branches
 # - On a maintenance branch minor and major commits are banned as it would take the branch out of scope
-if [[ "${TRAVIS_BRANCH}" =~ $MAINTENANCE_BRANCH_REGEXP ]]; then
+if [[ "${GITHUB_REF_NAME}" =~ $MAINTENANCE_BRANCH_REGEXP ]]; then
   export SEMVER_MAX_RELEASE_LEVEL=patch
 fi
 

--- a/build/bin/docker-build.sh
+++ b/build/bin/docker-build.sh
@@ -45,8 +45,8 @@ echo "BUILDPATH ...... $BUILDPATH"
 echo "DOCKERFILE ..... $DOCKERFILE"
 echo "EXTRA_PARAMS ... $EXTRA_PARAMS"
 echo "VERSION_LABEL .. $DOCKER_TAG"
-echo "RELEASE_LABEL .. $TRAVIS_BUILD_NUMBER"
-echo "VCS_REF ........ $TRAVIS_COMMIT"
+echo "RELEASE_LABEL .. $GITHUB_RUN_ID"
+echo "VCS_REF ........ $GITHUB_SHA"
 echo "VCS_URL ........ https://github.com/$GITHUB_REPOSITORY"
 
 # ARM64 builds need a different setup
@@ -54,16 +54,16 @@ if [[ $EXTRA_PARAMS =~ "AARCH64" ]]; then
   docker run --privileged yen3/binfmt-register set aarch64
   docker build \
   --build-arg VERSION_LABEL=$DOCKER_TAG \
-  --build-arg RELEASE_LABEL=$TRAVIS_BUILD_NUMBER \
-  --build-arg VCS_REF=$TRAVIS_COMMIT \
+  --build-arg RELEASE_LABEL=$GITHUB_RUN_ID \
+  --build-arg VCS_REF=$GITHUB_SHA \
   --build-arg VCS_URL=https://github.ibm.com/$GITHUB_REPOSITORY \
   -t $NAMESPACE/$IMAGE $EXTRA_PARAMS -f $DOCKERFILE $BUILDPATH
   docker run --privileged yen3/binfmt-register clear aarch64
 else
   docker build \
     --build-arg VERSION_LABEL=$DOCKER_TAG \
-    --build-arg RELEASE_LABEL=$TRAVIS_BUILD_NUMBER \
-    --build-arg VCS_REF=$TRAVIS_COMMIT \
+    --build-arg RELEASE_LABEL=$GITHUB_RUN_ID \
+    --build-arg VCS_REF=$GITHUB_SHA \
     --build-arg VCS_URL=https://github.com/$GITHUB_REPOSITORY \
     -t $NAMESPACE/$IMAGE $EXTRA_PARAMS -f $DOCKERFILE $BUILDPATH
 fi

--- a/build/bin/git-release.sh
+++ b/build/bin/git-release.sh
@@ -8,10 +8,8 @@ source $DIR/.functions.sh
 
 # 1. Check whether this is a pull request
 # -----------------------------------------------------------------------------
-# The pull request number if the current job is a pull request, "false" if
-# it's not a pull request.
-if [[ "${TRAVIS_PULL_REQUEST}" != "false" ]]; then
-  echo "Build is for a pull request so skip release publication"
+if [[ ! -z "${GITHUB_HEAD_REF}" ]]; then
+  echo "Build is for a pull request so skip asset release"
   exit 0
 fi
 

--- a/build/bin/git-upload-asset.sh
+++ b/build/bin/git-upload-asset.sh
@@ -14,7 +14,8 @@ else
   exit 64
 fi
 
-# The pull request number if the current job is a pull request, "false" if it's not a pull request.
+# 1. Check whether this is a pull request
+# -----------------------------------------------------------------------------
 if [[ ! -z "${GITHUB_HEAD_REF}" ]]; then
   echo "Build is for a pull request so skip asset release"
   exit 0

--- a/build/bin/initbuild.sh
+++ b/build/bin/initbuild.sh
@@ -111,14 +111,14 @@ elif [[ "${SEMVER_RELEASE_LEVEL}" =~ ^(major|minor|patch)$ ]]; then
   semver bump $SEMVER_RELEASE_LEVEL &>/dev/null
   echo "${SEMVER_RELEASE_LEVEL} bump from ${SEMVER_LAST_TAG} to $(semver)"
 else
-  semver bump build build.$TRAVIS_BUILD_NUMBER &>/dev/null
+  semver bump build build.$GITHUB_RUN_ID &>/dev/null
   echo "build bump from ${SEMVER_LAST_TAG} to $(semver)"
 fi
 
 
 # 2. Tweak version string for pre-release builds
 # -----------------------------------------------------------------------------
-if [[ "${TRAVIS_BRANCH}" =~ $RELEASE_BRANCH_REGEXP ]]; then
+if [[ "${GITHUB_REF_NAME}" =~ $RELEASE_BRANCH_REGEXP ]]; then
   # Release mode
   VERSION=$(semver)
 else


### PR DESCRIPTION
A number of `TRAVIS_` environment variables remained unconverted to their `GITHUB_` equivalents.  This should resolve the problems with master branch builds generating `pre.master` builds instead of real release builds.