### PR TITLE
[patch] Do not duplicate CN in MongoCE CA and cert

### DIFF
--- a/ibm/mas_devops/roles/mongodb/files/ca.cnf
+++ b/ibm/mas_devops/roles/mongodb/files/ca.cnf
@@ -1,0 +1,21 @@
+[req]
+#req_extensions = v3_req
+distinguished_name = req_distinguished_name
+prompt = no
+
+# Extensions to add to a CA certificate request
+[ v3_ca ]
+keyUsage               = critical,keyCertSign,cRLSign
+basicConstraints       = critical,CA:true,pathlen:0
+subjectKeyIdentifier   = hash
+authorityKeyIdentifier = keyid,issuer
+certificatePolicies    = 1.2.3.4
+
+
+[req_distinguished_name]
+countryName         = US
+stateOrProvinceName = NY
+localityName        = New York
+organizationName    = Example, LLC
+commonName          = Mongo CA
+emailAddress        = test@example.com

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community.yml
@@ -83,9 +83,10 @@
     - ca_cfgmap_info.resources | length == 0
   vars:
     openssl_cfg: "{{ role_path }}/files/openssl.cnf"
+    openssl_ca_cfg: "{{ role_path }}/files/ca.cnf"
     file_prefix: "/tmp/mongoce-"
   shell: |
-    openssl req -config {{ openssl_cfg }} -days 3650 -nodes -x509 -newkey rsa:2048 -subj "/C=US/ST=NY/L=New York/O=Example, LLC/CN=Mongo CA" -extensions v3_ca -keyout {{ file_prefix }}ca.key -out {{ file_prefix }}ca.pem
+    openssl req -config {{ openssl_ca_cfg }} -days 3650 -nodes -x509 -newkey rsa:2048 -subj "/C=US/ST=NY/L=New York/O=Example, LLC/CN=Mongo CA" -extensions v3_ca -keyout {{ file_prefix }}ca.key -out {{ file_prefix }}ca.pem
 
 - name: "mongodb/community : Create new server cert"
   when:


### PR DESCRIPTION
This is a fix for:

https://github.com/ibm-mas/ansible-devops/issues/94

It will ensure that the self-signed CA and server certificate contain different CNs. If the CA and server certificate have the same CN hostname validation seems to fail in some instances when creating a secure connection. 