### PR TITLE
[patch] Additional debug for bascfg task

### DIFF
--- a/ibm/mas_devops/roles/bas_install/tasks/bascfg.yml
+++ b/ibm/mas_devops/roles/bas_install/tasks/bascfg.yml
@@ -52,16 +52,41 @@
     namespace: openshift-ingress
   register: _bas_certificates_result
 
+
+# 2. Check whether all the lookups succeeded
+# -----------------------------------------------------------------------------
+- name: "Check whether we found the bas-endpoint route"
+  when: _bas_endpoint.resources | len == 0
+  fail:
+    msg: "Failed looking up BAS endpoint route"
+
+- name: "Check whether we found the secret containing the BAS segment key"
+  when: _bas_segmentKey_result.resources | len == 0
+  fail:
+    msg: "Failed looking up secret containing BAS segment key"
+
+- name: "Check whether we found the secret containing the BAS API key"
+  when: _bas_apiKey_result.resources | len == 0
+  fail:
+    msg: "Failed looking up secret containing BAS API key"
+
+- name: "Check whether we found the secret containing the BAS certificates"
+  when: _bas_certificates_result.resources | len == 0
+  fail:
+    msg: "Failed looking up secret containing BAS certificates"
+
+
+
+# 3. Write out the config to the local filesystem
+# -----------------------------------------------------------------------------
 - name: Set facts for BASCfg
   no_log: true
   set_fact:
-    bas_segment_key: "{{_bas_segmentKey_result.resources[0].data.segmentkey | b64decode}}"
-    bas_api_key: "{{_bas_apiKey_result.resources[0].data.apikey | b64decode }}"
+    bas_segment_key: "{{ _bas_segmentKey_result.resources[0].data.segmentkey | b64decode}}"
+    bas_api_key: "{{ _bas_apiKey_result.resources[0].data.apikey | b64decode }}"
     bas_endpoint_url: "https://{{_bas_endpoint.resources[0].spec.host}}"
-    bas_tls_crt: "{{_bas_certificates_result.resources[0].data['tls.crt'] | b64decode | regex_findall('(-----BEGIN .+?-----(?s).+?-----END .+?-----)', multiline=True, ignorecase=True)  }}"
+    bas_tls_crt: "{{ _bas_certificates_result.resources[0].data['tls.crt'] | b64decode | regex_findall('(-----BEGIN .+?-----(?s).+?-----END .+?-----)', multiline=True, ignorecase=True) }}"
 
-# 2. Write out the config to the local filesystem
-# -----------------------------------------------------------------------------
 - name: Copy BASCfg to filesytem
   when:
     - mas_instance_id is defined


### PR DESCRIPTION
It's hard to determine what went wrong when the only error message is:

```
TASK [ibm.mas_devops.bas_install : Extract cluster name] ***********************
Thursday 09 December 2021 17:41:55 +0000 (0:00:00.996) 0:35:35.557 *****
ok: [localhost] => {
"msg": [
"Cluster Domain ...................... fvtdev-6f1620198115433da1cac8216c06779b-0000.eu-gb.containers.appdomain.cloud"
]
}
TASK [ibm.mas_devops.bas_install : set_fact] ***********************************
Thursday 09 December 2021 17:41:55 +0000 (0:00:00.034) 0:35:35.592 *****
ok: [localhost] => {"ansible_facts": {"temp": "fvtdev-6f1620198115433da1cac8216c06779b-0000"}, "changed": false}
TASK [ibm.mas_devops.bas_install : Lookup Certificate for BAS] *****************
Thursday 09 December 2021 17:41:55 +0000 (0:00:00.055) 0:35:35.647 *****
ok: [localhost] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}
TASK [ibm.mas_devops.bas_install : Set facts for BASCfg] ***********************
Thursday 09 December 2021 17:41:56 +0000 (0:00:01.021) 0:35:36.669 *****
fatal: [localhost]: FAILED! => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result"}
NO MORE HOSTS LEFT *************************************************************
PLAY RECAP *********************************************************************
localhost : ok=22 changed=7 unreachable=0 failed=1 skipped=3 rescued=0 ignored=0
Thursday 09 December 2021 17:41:56 +0000 (0:00:00.080) 0:35:36.749 ***** 
```

This won't solve the problem, but should make it a little bit easier to work out what has happened.