### PR TITLE
[patch] Implement variable timeouts for app mgmt

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,14 +5,14 @@
 ```bash
 cd ibm/mas_devops
 
-ansible-galaxy collection build --force && ansible-galaxy collection install ibm-mas_devops-5.0.0.tar.gz -p /home/david/.ansible/collections --force
+ansible-galaxy collection build --force && ansible-galaxy collection install ibm-mas_devops-5.0.1.tar.gz -p /home/david/.ansible/collections --force
 
 ansible-playbook ../../playbook.yml
 ```
 
 ```bash
 ansible-galaxy collection build --force
-ansible-galaxy collection publish ibm-mas_devops-5.0.0.tar.gz --token=$ANSIBLE_GALAXY_TOKEN
+ansible-galaxy collection publish ibm-mas_devops-5.0.1.tar.gz --token=$ANSIBLE_GALAXY_TOKEN
 ```
 
 ## Style Guide

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,11 +47,11 @@ ansible-galaxy collection install ibm.mas_devops
 Note that links to pull requests prior to public release of the code (4.0) direct to IBM GitHub Enterprise, and will only be accessible to IBM employees.
 
 - `5.0` Multiple Updates:
-  - Add support for AI Applications' must-gather tooling ([#91](https://github.com/ibm-mas/ansible-devops/pull/91))
-  - Migrate airgap support into ibm.mas_airgap collection ([#38](https://github.com/ibm-mas/ansible-devops/pull/38))
-  - Support for Assist application ([#76](https://github.com/ibm-mas/ansible-devops/pull/76))
-  - Significant refactoring for CP4D support ([#68](https://github.com/ibm-mas/ansible-devops/pull/68))
-  - Migrate build system to GitHub Actions ([#68](https://github.com/ibm-mas/ansible-devops/pull/68))
+    - Add support for AI Applications' must-gather tooling ([#91](https://github.com/ibm-mas/ansible-devops/pull/91))
+    - Migrate airgap support into ibm.mas_airgap collection ([#38](https://github.com/ibm-mas/ansible-devops/pull/38))
+    - Support for Assist application ([#76](https://github.com/ibm-mas/ansible-devops/pull/76))
+    - Significant refactoring for CP4D support ([#68](https://github.com/ibm-mas/ansible-devops/pull/68))
+    - Migrate build system to GitHub Actions ([#68](https://github.com/ibm-mas/ansible-devops/pull/68))
 - `4.5` Add support for Manage ([#61](https://github.com/ibm-mas/ansible-devops/pull/61))
 - `4.4` Add CP4D and DB2W playbooks ([#51](https://github.com/ibm-mas/ansible-devops/pull/51))
 - `4.3` Add support for playbook junit result generation ([#39](https://github.com/ibm-mas/ansible-devops/pull/39))

--- a/ibm/mas_devops/README.md
+++ b/ibm/mas_devops/README.md
@@ -7,11 +7,11 @@
 Note that links to pull requests prior to public release of the code (4.0) direct to IBM GitHub Enterprise, and will only be accessible to IBM employees.
 
 - `5.0` Multiple Updates:
-  - Add support for AI Applications' must-gather tooling ([#91](https://github.com/ibm-mas/ansible-devops/pull/91))
-  - Migrate airgap support into ibm.mas_airgap collection ([#38](https://github.com/ibm-mas/ansible-devops/pull/38))
-  - Support for Assist application ([#76](https://github.com/ibm-mas/ansible-devops/pull/76))
-  - Significant refactoring for CP4D support ([#68](https://github.com/ibm-mas/ansible-devops/pull/68))
-  - Migrate build system to GitHub Actions ([#68](https://github.com/ibm-mas/ansible-devops/pull/68))
+    - Add support for AI Applications' must-gather tooling ([#91](https://github.com/ibm-mas/ansible-devops/pull/91))
+    - Migrate airgap support into ibm.mas_airgap collection ([#38](https://github.com/ibm-mas/ansible-devops/pull/38))
+    - Support for Assist application ([#76](https://github.com/ibm-mas/ansible-devops/pull/76))
+    - Significant refactoring for CP4D support ([#68](https://github.com/ibm-mas/ansible-devops/pull/68))
+    - Migrate build system to GitHub Actions ([#68](https://github.com/ibm-mas/ansible-devops/pull/68))
 - `4.5` Add support for Manage ([#61](https://github.com/ibm-mas/ansible-devops/pull/61))
 - `4.4` Add CP4D and DB2W playbooks ([#51](https://github.com/ibm-mas/ansible-devops/pull/51))
 - `4.3` Add support for playbook junit result generation ([#39](https://github.com/ibm-mas/ansible-devops/pull/39))

--- a/ibm/mas_devops/galaxy.yml
+++ b/ibm/mas_devops/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: ibm
 name: mas_devops
-version: 5.0.0
+version: 5.0.1
 readme: README.md
 authors:
   - David Parker <parkerda@uk.ibm.com>

--- a/ibm/mas_devops/roles/suite_app_configure/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_configure/tasks/main.yml
@@ -61,9 +61,9 @@
       status: "True"
       type: Ready
     wait_sleep: 30
-    wait_timeout: 300 # 5 minutes before we give up and fall back into the retry loop
+    wait_timeout: "{{ mas_app_cfg_timeout }}" # before we give up and fall back into the retry loop
   register: app_ws_cr_result
-  retries: 60 # 5 mins each loop * 50 loops = 5 hours
+  retries: "{{ mas_app_cfg_retries }}"
   delay: 0
   until:
     - app_ws_cr_result.resources is defined

--- a/ibm/mas_devops/roles/suite_app_configure/vars/assist.yml
+++ b/ibm/mas_devops/roles/suite_app_configure/vars/assist.yml
@@ -5,3 +5,6 @@ mas_app_ws_kind: AssistWorkspace
 mas_app_ws_spec:
   bindings:
     watsondiscovery: application
+
+mas_app_cfg_timeout: 120  # 2 minutes before we give up and fall back into the retry loop
+mas_app_cfg_retries: 10   # 2 mins each loop * 10 loops =~ 20 minutes

--- a/ibm/mas_devops/roles/suite_app_configure/vars/health.yml
+++ b/ibm/mas_devops/roles/suite_app_configure/vars/health.yml
@@ -22,3 +22,6 @@ mas_app_ws_spec:
   #  languages:
   #    baseLang: {{ base_language }}
   #    secondaryLangs: [{{ secondary_languages }}]
+
+mas_app_cfg_timeout: 120  # 2 minutes before we give up and fall back into the retry loop
+mas_app_cfg_retries: 10   # 2 mins each loop * 10 loops =~ 20 minutes

--- a/ibm/mas_devops/roles/suite_app_configure/vars/iot.yml
+++ b/ibm/mas_devops/roles/suite_app_configure/vars/iot.yml
@@ -3,3 +3,6 @@ mas_app_ws_fqn: iotworkspaces.iot.ibm.com
 mas_app_ws_apiversion: iot.ibm.com/v1
 mas_app_ws_kind: IoTWorkspace
 mas_app_ws_spec: {}
+
+mas_app_cfg_timeout: 60  # 1 minute before we give up and fall back into the retry loop
+mas_app_cfg_retries: 10  # 1 mins each loop * 10 loops =~ 10 minutes

--- a/ibm/mas_devops/roles/suite_app_configure/vars/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_configure/vars/manage.yml
@@ -6,3 +6,6 @@ mas_app_ws_spec:
   bindings:
     jdbc: "{{ mas_appws_jdbc_binding | default( 'system' , true) }}"
   components: "{{ mas_appws_components | default({'base': {'version': 'latest'}}, true) }}"
+
+mas_app_cfg_timeout: 360  # 6 minutes before we give up and fall back into the retry loop
+mas_app_cfg_retries: 30   # 2 mins each loop * 10 loops =~ 3 hours

--- a/ibm/mas_devops/roles/suite_app_configure/vars/monitor.yml
+++ b/ibm/mas_devops/roles/suite_app_configure/vars/monitor.yml
@@ -6,3 +6,6 @@ mas_app_ws_spec:
   bindings:
     iot: workspace
     jdbc: system
+
+mas_app_cfg_timeout: 120  # 2 minutes before we give up and fall back into the retry loop
+mas_app_cfg_retries: 10   # 2 mins each loop * 10 loops =~ 20 minutes

--- a/ibm/mas_devops/roles/suite_app_configure/vars/mso.yml
+++ b/ibm/mas_devops/roles/suite_app_configure/vars/mso.yml
@@ -5,3 +5,6 @@ mas_app_ws_kind: MSOWorkspace
 mas_app_ws_spec:
   bindings:
     manage: workspace
+
+mas_app_cfg_timeout: 120  # 2 minutes before we give up and fall back into the retry loop
+mas_app_cfg_retries: 10   # 2 mins each loop * 10 loops =~ 20 minutes

--- a/ibm/mas_devops/roles/suite_app_configure/vars/predict.yml
+++ b/ibm/mas_devops/roles/suite_app_configure/vars/predict.yml
@@ -7,3 +7,6 @@ mas_app_ws_spec:
     health: workspace
     monitor: workspace
     watsonstudio: system
+
+mas_app_cfg_timeout: 120  # 2 minutes before we give up and fall back into the retry loop
+mas_app_cfg_retries: 10   # 2 mins each loop * 10 loops =~ 20 minutes

--- a/ibm/mas_devops/roles/suite_app_configure/vars/safety.yml
+++ b/ibm/mas_devops/roles/suite_app_configure/vars/safety.yml
@@ -3,3 +3,6 @@ mas_app_ws_fqn: safetyworkspaces.apps.mas.ibm.com
 mas_app_ws_apiversion: apps.mas.ibm.com/v1
 mas_app_ws_kind: SafetyWorkspace
 mas_app_ws_spec: {}
+
+mas_app_cfg_timeout: 120  # 2 minutes before we give up and fall back into the retry loop
+mas_app_cfg_retries: 10   # 2 mins each loop * 10 loops =~ 20 minutes

--- a/ibm/mas_devops/roles/suite_app_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/main.yml
@@ -112,9 +112,9 @@
       status: "True"
       type: Ready
     wait_sleep: 30
-    wait_timeout: 300 # 5 minutes before we give up and fall back into the retry loop
+    wait_timeout: "{{ mas_app_install_timeout }}" # before we give up and fall back into the retry loop
   register: app_cr_result
-  retries: 40 # 5 mins each loop * 40 loops =~ 2 hours
+  retries: "{{ mas_app_install_retries }}"
   delay: 0
   until:
     - app_cr_result.resources is defined

--- a/ibm/mas_devops/roles/suite_app_install/vars/assist.yml
+++ b/ibm/mas_devops/roles/suite_app_install/vars/assist.yml
@@ -6,3 +6,6 @@ mas_app_kind: AssistApp
 mas_app_spec:
   bindings:
     objectstorage: system
+
+mas_app_install_timeout: 120  # 2 minutes before we give up and fall back into the retry loop
+mas_app_install_retries: 10   # 2 mins each loop * 10 loops =~ 20 minutes

--- a/ibm/mas_devops/roles/suite_app_install/vars/health.yml
+++ b/ibm/mas_devops/roles/suite_app_install/vars/health.yml
@@ -4,3 +4,6 @@ mas_app_fqn: healthapps.apps.mas.ibm.com
 mas_app_api_version: apps.mas.ibm.com/v1
 mas_app_kind: HealthApp
 mas_app_spec: {}
+
+mas_app_install_timeout: 120  # 2 minutes before we give up and fall back into the retry loop
+mas_app_install_retries: 10   # 2 mins each loop * 10 loops =~ 20 minutes

--- a/ibm/mas_devops/roles/suite_app_install/vars/iot.yml
+++ b/ibm/mas_devops/roles/suite_app_install/vars/iot.yml
@@ -8,3 +8,6 @@ mas_app_spec:
     jdbc: system
     mongo: system
     kafka: system
+
+mas_app_install_timeout: 120  # 2 minutes before we give up and fall back into the retry loop
+mas_app_install_retries: 20   # 2 mins each loop * 20 loops =~ 40 minutes

--- a/ibm/mas_devops/roles/suite_app_install/vars/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_install/vars/manage.yml
@@ -4,3 +4,6 @@ mas_app_fqn: manageapps.apps.mas.ibm.com
 mas_app_api_version: apps.mas.ibm.com/v1
 mas_app_kind: ManageApp
 mas_app_spec: {}
+
+mas_app_install_timeout: 120  # 2 minutes before we give up and fall back into the retry loop
+mas_app_install_retries: 10   # 2 mins each loop * 10 loops =~ 20 minutes

--- a/ibm/mas_devops/roles/suite_app_install/vars/monitor.yml
+++ b/ibm/mas_devops/roles/suite_app_install/vars/monitor.yml
@@ -6,3 +6,6 @@ mas_app_kind: MonitorApp
 mas_app_spec:
   bindings:
     mongo: system
+
+mas_app_install_timeout: 120  # 2 minutes before we give up and fall back into the retry loop
+mas_app_install_retries: 10   # 2 mins each loop * 10 loops =~ 20 minutes

--- a/ibm/mas_devops/roles/suite_app_install/vars/mso.yml
+++ b/ibm/mas_devops/roles/suite_app_install/vars/mso.yml
@@ -6,3 +6,6 @@ mas_app_kind: MSOApp
 mas_app_spec:
   bindings:
     mongo: system
+
+mas_app_install_timeout: 120  # 2 minutes before we give up and fall back into the retry loop
+mas_app_install_retries: 10   # 2 mins each loop * 10 loops =~ 20 minutes

--- a/ibm/mas_devops/roles/suite_app_install/vars/predict.yml
+++ b/ibm/mas_devops/roles/suite_app_install/vars/predict.yml
@@ -6,3 +6,6 @@ mas_app_kind: PredictApp
 mas_app_spec:
   bindings:
     jdbc: system
+
+mas_app_install_timeout: 120  # 2 minutes before we give up and fall back into the retry loop
+mas_app_install_retries: 10   # 2 mins each loop * 10 loops =~ 20 minutes

--- a/ibm/mas_devops/roles/suite_app_install/vars/safety.yml
+++ b/ibm/mas_devops/roles/suite_app_install/vars/safety.yml
@@ -7,3 +7,6 @@ mas_app_spec:
   bindings:
     jdbc: system
   components: {}
+
+mas_app_install_timeout: 120  # 2 minutes before we give up and fall back into the retry loop
+mas_app_install_retries: 10   # 2 mins each loop * 10 loops =~ 20 minutes

--- a/pipelines/samples/sample-pipeline.yaml
+++ b/pipelines/samples/sample-pipeline.yaml
@@ -264,10 +264,13 @@ spec:
         - name: settings
           workspace: shared-settings
 
-    # 11. Install IBM MAS IoT application
+
+    # 11 Configure Kafka in MAS
     # -------------------------------------------------------------------------
-    # 11.1 Configure Kafka in MAS
     - name: cfg-suite-kafka
+      params:
+        - name: junit_suite_name
+          value: cfg-suite-kafka
       taskRef:
         kind: ClusterTask
         name: mas-devops-configure-suite
@@ -280,7 +283,9 @@ spec:
         - name: settings
           workspace: shared-settings
 
-    # 11.2 Install IoT
+    # 12. Install IBM MAS IoT application
+    # -------------------------------------------------------------------------
+    # 12.1 Install IoT
     - name: install-iot
       params:
         - name: mas_app_id
@@ -299,7 +304,7 @@ spec:
         - name: settings
           workspace: shared-settings
 
-    # 11.3 Configure IoT workspace
+    # 12.2 Configure IoT workspace
     - name: cfg-iot
       params:
         - name: mas_app_id
@@ -313,9 +318,9 @@ spec:
         - name: settings
           workspace: shared-settings
 
-    # 12. Install IBM MAS Monitor application
+    # 13. Install IBM MAS Monitor application
     # -------------------------------------------------------------------------
-    # 12.1 Install Monitor
+    # 13.1 Install Monitor
     - name: install-monitor
       params:
         - name: mas_app_id
@@ -333,7 +338,7 @@ spec:
         - name: settings
           workspace: shared-settings
 
-    # 12.2 Configure Monitor workspace
+    # 13.2 Configure Monitor workspace
     - name: cfg-monitor
       params:
         - name: mas_app_id
@@ -347,9 +352,9 @@ spec:
         - name: settings
           workspace: shared-settings
 
-    # 13. Install IBM MAS Safety application
+    # 14. Install IBM MAS Safety application
     # -------------------------------------------------------------------------
-    # 13.1 Install Safety
+    # 14.1 Install Safety
     - name: install-safety
       params:
         - name: mas_app_id
@@ -367,7 +372,7 @@ spec:
         - name: settings
           workspace: shared-settings
 
-    # 13.2 Configure Safety workspace
+    # 14.2 Configure Safety workspace
     - name: cfg-safety
       params:
         - name: mas_app_id
@@ -381,9 +386,9 @@ spec:
         - name: settings
           workspace: shared-settings
 
-    # 104. Install IBM MAS Manage application
+    # 15. Install IBM MAS Manage application
     # -------------------------------------------------------------------------
-    # 14.1 Manage Install
+    # 15.1 Manage Install
     - name: install-manage
       params:
         - name: mas_app_id
@@ -402,7 +407,7 @@ spec:
         - name: settings
           workspace: shared-settings
 
-    # 14.2 Configure Manage workspace
+    # 15.2 Configure Manage workspace
     - name: cfg-manage
       params:
         - name: mas_app_id
@@ -416,9 +421,9 @@ spec:
         - name: settings
           workspace: shared-settings
 
-    # 15. Predict
+    # 16. Predict
     # -------------------------------------------------------------------------
-    # 15.1 Predict Install
+    # 16.1 Predict Install
     - name: install-predict
       params:
         - name: mas_app_id
@@ -436,7 +441,7 @@ spec:
         - name: settings
           workspace: shared-settings
 
-    # 15.2 Configure Predict workspace
+    # 16.2 Configure Predict workspace
     - name: cfg-predict
       params:
         - name: mas_app_id
@@ -450,9 +455,9 @@ spec:
         - name: settings
           workspace: shared-settings
 
-    # 16. MSO
+    # 17. MSO
     # -------------------------------------------------------------------------
-    # 16.1 MSO Install
+    # 17.1 MSO Install
     - name: install-mso
       params:
         - name: mas_app_id
@@ -471,7 +476,7 @@ spec:
         - name: settings
           workspace: shared-settings
 
-    # 16.2 Configure MSO workspace
+    # 17.2 Configure MSO workspace
     - name: cfg-mso
       params:
         - name: mas_app_id


### PR DESCRIPTION
The time it takes various applications to install and configure can vary widly, implement support for per-application timeouts to make failure states less painful to the user by reducing the time they must wait before the ansible collection gives up retrying.