### PR TITLE
[patch] Add BAS storage classes validation

### DIFF
--- a/ibm/mas_devops/playbooks/dependencies/install-bas.yml
+++ b/ibm/mas_devops/playbooks/dependencies/install-bas.yml
@@ -5,8 +5,8 @@
     # BAS Configuration
     bas_namespace: "{{ lookup('env', 'BAS_NAMESPACE') | default('ibm-bas', true) }}"
 
-    bas_persistent_storage_class: "{{ lookup('env', 'BAS_PERSISTENT_STORAGE_CLASS') | default('ibmc-file-bronze-gid') }}"
-    bas_meta_storage_class: "{{ lookup('env', 'BAS_META_STORAGE_CLASS') | default('ibmc-block-bronze')}}"
+    bas_persistent_storage_class: "{{ lookup('env', 'BAS_PERSISTENT_STORAGE_CLASS') }}"
+    bas_meta_storage_class: "{{ lookup('env', 'BAS_META_STORAGE_CLASS') }}"
 
     bas_username: "{{ lookup('env', 'BAS_USERNAME') | default('basuser', true) }}"
     bas_password: "{{ lookup('env', 'BAS_PASSWORD') }}"

--- a/ibm/mas_devops/playbooks/dependencies/install-bas.yml
+++ b/ibm/mas_devops/playbooks/dependencies/install-bas.yml
@@ -5,8 +5,8 @@
     # BAS Configuration
     bas_namespace: "{{ lookup('env', 'BAS_NAMESPACE') | default('ibm-bas', true) }}"
 
-    bas_persistent_storage_class: "{{ lookup('env', 'BAS_PERSISTENT_STORAGE_CLASS') }}"
-    bas_meta_storage_class: "{{ lookup('env', 'BAS_META_STORAGE_CLASS') }}"
+    bas_persistent_storage_class: "{{ lookup('env', 'BAS_PERSISTENT_STORAGE_CLASS') | default('ibmc-file-bronze-gid') }}"
+    bas_meta_storage_class: "{{ lookup('env', 'BAS_META_STORAGE_CLASS') | default('ibmc-block-bronze')}}"
 
     bas_username: "{{ lookup('env', 'BAS_USERNAME') | default('basuser', true) }}"
     bas_password: "{{ lookup('env', 'BAS_PASSWORD') }}"

--- a/ibm/mas_devops/roles/bas_install/README.md
+++ b/ibm/mas_devops/roles/bas_install/README.md
@@ -8,8 +8,8 @@ Role Variables
 
 ###### Primary settings
 - `bas_namespace` Optional - Defines the targetted cluster namespace/project where BAS will be installed. If not provided, default BAS namespace will be 'ibm-bas'.
-- `bas_persistent_storage_class` Required - Storage class where BAS will be installed - for IBM Cloud clusters, `ibmc-file-bronze-gid` will be used by default.
-- `bas_meta_storage_class` Required - Storage class where BAS internal components such as Kafka service will be installed - for IBM Cloud, `ibmc-block-bronze` will be used by default.
+- `bas_persistent_storage_class` Required - Storage class where BAS will be installed - for IBM Cloud clusters, `ibmc-file-bronze-gid` can be used.
+- `bas_meta_storage_class` Required - Storage class where BAS internal components such as Kafka service will be installed - for IBM Cloud clusters, `ibmc-block-bronze` can be used.
 - `bas_username` Optional - BAS default username. If not provided, default username will be 'basuser'
 - `bas_password` Optional - BAS default password. If not provided, a random 15 character password will be generated
 - `bas_grafana_username` Optional - BAS default username for Grafana service. If not provided, default username will be 'basuser'

--- a/ibm/mas_devops/roles/bas_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/bas_install/tasks/main.yml
@@ -2,6 +2,16 @@
 
 # Check for required facts
 # -----------------------------------------------------------------------------
+- name: "Fail if BAS persistent storage class has not been provided"
+  when: bas_persistent_storage_class is not defined or bas_persistent_storage_class == ""
+  fail:
+    msg: "bas_persistent_storage_class property has not been set"
+
+- name: "Fail if BAS block storage class has not been provided"
+  when: bas_meta_storage_class is not defined or bas_meta_storage_class == ""
+  fail:
+    msg: "bas_meta_storage_class property has not been set"
+
 - name: "Fail if BAS email has not been provided"
   when: bas_contact.email is not defined or bas_contact.email == ""
   fail:
@@ -16,7 +26,6 @@
   when: bas_contact.lastName is not defined or bas_contact.lastName == ""
   fail:
     msg: "bas_contact.lastName property has not been set"
-
 
 # 1. Generate BAS related passwords if none provided
 # -----------------------------------------------------------------------------
@@ -38,8 +47,8 @@
   debug:
     msg:
       - "BAS Namespace ...................... {{ bas_namespace }}"
-      - "BAS Persistent Storage Class........ {{bas_persistent_storage_class}}"
-      - "BAS Metadata Storage Class ......... {{bas_meta_storage_class}}"
+      - "BAS Persistent Storage Class........ {{ bas_persistent_storage_class }}"
+      - "BAS Metadata Storage Class ......... {{ bas_meta_storage_class }}"
 
 
 # 3. Create BAS project


### PR DESCRIPTION
The BAS install role does not check for required parameters being provided, when these are missed instead of providing the user with a nice clear error message the BAS install will fail and they must debug what happened.

This update will ensure that the installation is aborted instantly if either of the required storage classes are not defined.