### PR TITLE
[patch] Fix various issues with manage db2 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pipelines/dev/
 pipelines/samples/sample-pipelinesettings-roks-donotcommit.yaml
 image/ansible-devops/ibm-mas_devops.tar.gz
 ibm/mas_devops/runAnsible.sh
+pipelines/samples/sample-pipelinesettings-roks-mas86-donotcommit.yaml

--- a/ibm/mas_devops/roles/cp4d_db2wh/README.md
+++ b/ibm/mas_devops/roles/cp4d_db2wh/README.md
@@ -44,7 +44,7 @@ Required.  Name of the database instance, note that this is the instance **name*
 Version of the DB2 Warehouse instance to be created.
 
 - Environment Variable: `DB2WH_VERSION`
-- Default: `11.5.6.0-cn3`
+- Default: `11.5.5.1-cn3-x86_64` (CloudPak for Data v3.5), `11.5.6.0-cn3` (CloudPak for Data v4)
 
 ### db2wh_table_org
 The way database tables will be organized. It can be set to either `ROW` or `COLUMN`.

--- a/ibm/mas_devops/roles/cp4d_db2wh/defaults/main.yml
+++ b/ibm/mas_devops/roles/cp4d_db2wh/defaults/main.yml
@@ -3,7 +3,12 @@
 # -----------------------------------------------------------------------------------------------------------------
 db2wh_instance_name: "{{ lookup('env', 'DB2WH_INSTANCE_NAME') }}" # e.g. db2w-iot or db2w-manage
 db2wh_dbname: "{{ lookup('env', 'DB2WH_VERSION') | default('BLUDB', true) }}"
-db2wh_version: "{{ lookup('env', 'DB2WH_VERSION') | default('11.5.6.0-cn3', true) }}"
+db2wh_version: "{{ lookup('env', 'DB2WH_VERSION') }}"
+
+default_db2wh_version:
+  cpd35: 11.5.5.1-cn3-x86_64
+  cpd40: 11.5.6.0-cn3
+
 db2wh_table_org: "{{ lookup('env', 'DB2WH_TABLE_ORG') | default('ROW', true) }}" # e.g ROW or COLUMN
 
 # Configure meta storage for db2 (CP4D v3.5 and v4.0)

--- a/ibm/mas_devops/roles/cp4d_db2wh/tasks/cpd35/get_db2_certificate.yml
+++ b/ibm/mas_devops/roles/cp4d_db2wh/tasks/cpd35/get_db2_certificate.yml
@@ -7,13 +7,18 @@
     api_version: v1
     kind: Secret
     name: "internal-tls"
-    namespace: "{{db2wh_namespace}}"
-  register: _db2u_instance_certificates
+    namespace: "{{ db2wh_namespace }}"
+  register: db2u_instance_certificates
+
+- name: "Fail if we couldn't find the certificates"
+  when: db2u_instance_certificates.resources is not defined or db2u_instance_certificates.resources | length == 0
+  fail:
+    msg: "Unable to retrieve the certificates for Db2 from '{{ db2wh_namespace }}/internal-tls' Secret"
 
 - name: Set Db2wh certificates as Facts
+  when:
+    - db2u_instance_certificates.resources is defined
+    - db2u_instance_certificates.resources | length > 0
   set_fact:
     # We need to use certificate.pem rather than tls.crt when we create the JdbcCfg for MAS
-    db2wh_certificate: "{{ _db2u_instance_certificates.resources[0].data['certificate.pem'] | b64decode }}"
-  when:
-    - _db2u_instance_certificates is defined
-    - (_db2u_instance_certificates.resources | length > 0)
+    db2wh_certificate: "{{ db2u_instance_certificates.resources[0].data['certificate.pem'] | b64decode }}"

--- a/ibm/mas_devops/roles/cp4d_db2wh/tasks/cpd35/get_db2_ssl_port.yml
+++ b/ibm/mas_devops/roles/cp4d_db2wh/tasks/cpd35/get_db2_ssl_port.yml
@@ -1,22 +1,23 @@
 ---
 # -----------------------------------------------------------------------------
-# Set DB2 SSL Port (cp4d_db_ssl_port) into Facts
+# Set DB2 SSL Port (db2wh_ssl_port) into Facts
 # -----------------------------------------------------------------------------
 - name: Get the k8s Service info of DB2 database {{ db2wh_instance_name }}
   community.kubernetes.k8s_info:
     api_version: v1
     kind: Service
-    name: "{{ db2_svc_name }}"
+    name: "{{ db2wh_svc_name }}"
     namespace: "{{ db2wh_namespace }}"
   register: cp4d_db2_service_info
 
-# - debug: var=cp4d_db2_service_info
+# Check whether we found a the service
+- name: "Fail if we couldn't find the service"
+  when: cp4d_db2_service_info.resources is not defined or cp4d_db2_service_info.resources | length == 0
+  fail:
+    msg: "Unable to retrieve the service info for Db2 from '{{ db2wh_namespace }}/{{ db2wh_svc_name }}' Service"
 
 - set_fact:
     cp4d_db_port_list: "{{ cp4d_db2_service_info.resources[0].spec.ports }}"
-
-# - debug:
-#     msg: "{{ cp4d_db_port_list }}"
 
 - name: Get the SSL port of DB2 database {{ db2wh_instance_name }} from k8s Service info
   vars:
@@ -26,8 +27,11 @@
   when: item.name == 'ssl-server'
   with_items: "{{ cp4d_db_port_list }}"
 
-# - debug:
-#     msg: "NodePort: {{ sslNodePort }}"
+# Check whether we found a port named `ssl-server' in the service
+- name: "Fail if we couldn't find the 'ssl-server' port in the Service"
+  when: sslNodePort is not defined
+  fail:
+    msg: "Unable to retrieve the port number for 'ssl-server' port in the '{{ db2wh_namespace }}/{{ db2wh_svc_name }}' Service"
 
 - set_fact:
-    cp4d_db_ssl_port: "{{ sslNodePort }}"
+    db2wh_ssl_port: "{{ sslNodePort }}"

--- a/ibm/mas_devops/roles/cp4d_db2wh/tasks/cpd35/provision-instance.yml
+++ b/ibm/mas_devops/roles/cp4d_db2wh/tasks/cpd35/provision-instance.yml
@@ -22,11 +22,12 @@
 - name: "Debug information"
   debug:
     msg:
-      - "mas_instance_id ................. {{ mas_instance_id }}"
-      - "mas_config_dir .................. {{ mas_config_dir }}"
-      - "mas_config_scope ................ {{ mas_config_scope }}"
-      - "mas_workspace_id ................ {{ mas_workspace_id }}"
-      - "mas_application_id .............. {{ mas_application_id }}"
+      - "mas_instance_id ................. {{ mas_instance_id | default('<undefined>') }}"
+      - "mas_config_dir .................. {{ mas_config_dir | default('<undefined>')  }}"
+      - "mas_config_scope ................ {{ mas_config_scope | default('<undefined>')  }}"
+      - "mas_workspace_id ................ {{ mas_workspace_id | default('<undefined>')  }}"
+      - "mas_application_id .............. {{ mas_application_id | default('<undefined>')  }}"
+
       - "cpd_api_username ................ {{ cpd_api_username }}"
 
       - "cpd_db_config_configmap_name .... {{ cpd_db_config_configmap_name }}"
@@ -76,26 +77,21 @@
     msg: "{{ create_db2_database_output }}"
 
 
-# 5. Wait for DB creation (when creation status is 202)
+# 5a. Wait for DB creation (when creation status is 202)
 # -----------------------------------------------------------------------------
 - name: Wait for DB creation to be completed for {{ db2wh_instance_name }} and apply patch if needed
+  when: create_db2_database_output.status == 202
   block:
-    - debug: var=create_db2_database_output.json.id
-    - set_fact:
-        db2_pod_name: "c-db2wh-{{ create_db2_database_output.json.id }}-db2u-0"
-        db2_svc_name: "c-db2wh-{{ create_db2_database_output.json.id }}-db2u-engn-svc"
-        cp4d_db_id: "{{ create_db2_database_output.json.id }}"
-    - set_fact:
-        cp4d_db_svc: "{{ db2_svc_name }}.{{ db2wh_namespace }}.svc"
-    - name: Set a default value for cp4d_db_ssl_port if it's not specified
+    - name: "Save the Db2 instance Id to a fact"
       set_fact:
-        cp4d_db_ssl_port: ""
-      when: cp4d_db_ssl_port is undefined
+        db2wh_instance_id: "{{ create_db2_database_output.json.id }}"
+
     - name: Save the DB2 database id in a DB config ConfigMap {{ cpd_db_config_configmap_name }}-{{ db2wh_instance_name }} under {{ db2wh_namespace }} namespace
       community.kubernetes.k8s:
         state: present
         namespace: "{{ db2wh_namespace }}"
         definition: "{{ lookup('template', 'templates/cpd35/cp4d_db2_database_config.yaml.j2') | from_yaml }}"
+
     # Patch the db2u StatefulSet to avoid DB2 pod getting stuck in 0/1 state during installation
     - name: Patch the db2u StatefulSet to avoid DB2 pod getting stuck in 0/1 state during installation
       block:
@@ -111,15 +107,16 @@
         - name: Apply DB2 StatefulSet patch
           shell: oc patch $(oc get sts -lcomponent=db2wh -oname -n="{{ db2wh_namespace }}" | grep db2wh) -n="{{ db2wh_namespace }}" -p='{ "spec":{ "template":{ "spec":{ "containers":[ { "name":"db2u", "tty":false } ] } } } }'
       when: apply_db2u_sts_patch|default(false)|bool
+
     - name: Wait for the creation of DB2 database {{ db2wh_instance_name }}
       pause:
         minutes: 5
-  when: create_db2_database_output.status == 202
 
 
-# 6. Get info of DB2 database if it already exists (when creation status is 409)
+# 5b. Get info of DB2 database if it already exists (when creation status is 409)
 # -----------------------------------------------------------------------------
 - name: Get info of DB2 database {{ db2wh_instance_name }} if it already exists (if above creation code was 409)
+  when: create_db2_database_output.status == 409
   block:
     - name: "Read the DB2 database config from the DB config ConfigMap {{ cpd_db_config_configmap_name }}"
       community.kubernetes.k8s_info:
@@ -131,19 +128,22 @@
 
     - name: "Read the DB2 database ID for {{ db2wh_instance_name }} from DB config ConfigMap data"
       set_fact:
-        cp4d_db_id: "{{ cp4d_db_config_info.resources[0].data.cp4d_db_id }}"
-        db2_pod_name: "c-db2wh-{{ cp4d_db_config_info.resources[0].data.cp4d_db_id }}-db2u-0"
-        db2_svc_name: "c-db2wh-{{ cp4d_db_config_info.resources[0].data.cp4d_db_id }}-db2u-engn-svc"
-    - set_fact:
-        cp4d_db_svc: "{{ db2_svc_name }}.{{ db2wh_namespace }}.svc"
-  when: create_db2_database_output.status == 409
+        db2wh_instance_id: "{{ cp4d_db_config_info.resources[0].data.db2wh_instance_id }}"
+
+
+# 6. Generate the name and fqn of the service now we know the instance ID
+# -----------------------------------------------------------------------------
+- name: "Set service name and fqn from the instance ID"
+  set_fact:
+    db2wh_svc_name: "c-db2wh-{{ db2wh_instance_id }}-db2u-engn-svc"
+    db2wh_svc_fqn: "{{ cp4d_db_config_info.resources[0].data.db2wh_svc_fqn }}"
 
 
 # 7. Wait till DB2 status is RUNNING
 # -----------------------------------------------------------------------------
 - name: "Wait till status of DB2 database {{ db2wh_instance_name }} is RUNNING"
   uri:
-    url: "https://{{ cp4d_host }}/zen-data/v3/service_instances/{{ cp4d_db_id }}?include_service_status=true"
+    url: "https://{{ cp4d_host }}/zen-data/v3/service_instances/{{ db2wh_instance_id }}?include_service_status=true"
     validate_certs: no
     method: GET
     headers:
@@ -157,7 +157,7 @@
   delay: 60
 
 
-# 8. Set DB2 SSL Port (cp4d_db_ssl_port) into Facts
+# 8. Set DB2 SSL Port (db2wh_ssl_port) into Facts
 # -----------------------------------------------------------------------------
 - include_tasks: "{{ role_path }}/tasks/cpd35/get_db2_ssl_port.yml"
 
@@ -186,19 +186,47 @@
     - mas_config_dir != ""
   include_vars: "vars/jdbccfg/{{ mas_config_scope }}.yml"
 
+- name: Lookup db2wh instance password
+  when:
+    - mas_instance_id is defined
+    - mas_instance_id != ""
+    - mas_config_dir is defined
+    - mas_config_dir != ""
+  community.kubernetes.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: "c-db2wh-{{ db2wh_instance_id  }}-instancepassword"
+    namespace: "{{ db2wh_namespace }}"
+  register: db2u_instance_password
+
+- name: Debug expected facts (1)
+  debug:
+    msg: "db2wh_ssl_port ... {{ db2wh_ssl_port }}"
+
+- name: Debug expected facts (1)
+  debug:
+    msg: "db2wh_svc_fqn ... {{ db2wh_svc_fqn }}"
+
+- name: Debug expected facts (1)
+  debug:
+    msg: "password ... {{ db2u_instance_password.resources[0].data.password }}"
+
+- name: Set additional Facts for JdbcCfg
+  when:
+    - mas_instance_id is defined
+    - mas_instance_id != ""
+    - mas_config_dir is defined
+    - mas_config_dir != ""
+  set_fact:
+    db2wh_jdbc_password: "{{ db2u_instance_password.resources[0].data.password | b64decode }}"
+    db2wh_jdbc_url: "jdbc:db2://{{ db2wh_svc_fqn }}:{{ db2wh_ssl_port }}/BLUDB:sslConnection=true;"
+
 - name: Create JDBCCfg yml definition into {{ mas_config_dir }} folder
   when:
     - mas_instance_id is defined
     - mas_instance_id != ""
     - mas_config_dir is defined
     - mas_config_dir != ""
-  vars:
-    db2wh_jdbc_url: "jdbc:db2://{{ cp4d_db_svc }}:{{ cp4d_db_ssl_port }}/BLUDB:sslConnection=true;"
-    # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    # TODO: Verify this is correct.  Are we really meant to use the same credentials we used to create the database to connect to it?
-    # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    db2wh_jdbc_username: "{{ cpd_api_username }}"
-    db2wh_jdbc_password: "{{ cpd_api_password }}"
   ansible.builtin.template:
     src: suite_jdbccfg.yml
     dest: "{{ mas_config_dir }}/jdbc-{{ db2wh_instance_name | lower }}-{{ db2wh_namespace }}.yml"

--- a/ibm/mas_devops/roles/cp4d_db2wh/tasks/cpd35/provision-instance.yml
+++ b/ibm/mas_devops/roles/cp4d_db2wh/tasks/cpd35/provision-instance.yml
@@ -54,6 +54,10 @@
 
 # 4. Create a DB2 database instance
 # -----------------------------------------------------------------------------
+- name: "Debug Db2 instance create API request body - {{ db2w_instance_name }}"
+  debug:
+    msg: "{{ lookup('template','templates/cpd35/create_db.json.j2') }}"
+
 - name: Create the DB2 database instance in CP4D - {{ db2wh_instance_name }}
   uri:
     url: "https://{{ cp4d_host }}/zen-data/v3/service_instances"
@@ -117,14 +121,15 @@
 # -----------------------------------------------------------------------------
 - name: Get info of DB2 database {{ db2wh_instance_name }} if it already exists (if above creation code was 409)
   block:
-    - name: Read the DB2 database config from the DB config ConfigMap {{ cpd_db_config_configmap_name }}
+    - name: "Read the DB2 database config from the DB config ConfigMap {{ cpd_db_config_configmap_name }}"
       community.kubernetes.k8s_info:
         api_version: v1
         kind: ConfigMap
         name: "{{ cpd_db_config_configmap_name }}-{{ db2wh_instance_name }}"
         namespace: "{{ db2wh_namespace }}"
       register: cp4d_db_config_info
-    - name: Read the DB2 database ID for {{ db2wh_instance_name }} from DB config ConfigMap data
+
+    - name: "Read the DB2 database ID for {{ db2wh_instance_name }} from DB config ConfigMap data"
       set_fact:
         cp4d_db_id: "{{ cp4d_db_config_info.resources[0].data.cp4d_db_id }}"
         db2_pod_name: "c-db2wh-{{ cp4d_db_config_info.resources[0].data.cp4d_db_id }}-db2u-0"

--- a/ibm/mas_devops/roles/cp4d_db2wh/tasks/cpd35/provision-instance.yml
+++ b/ibm/mas_devops/roles/cp4d_db2wh/tasks/cpd35/provision-instance.yml
@@ -141,7 +141,7 @@
 
 # 7. Wait till DB2 status is RUNNING
 # -----------------------------------------------------------------------------
-- name: Wait till status of DB2 database {{ db2wh_instance_name }} is RUNNING
+- name: "Wait till status of DB2 database {{ db2wh_instance_name }} is RUNNING"
   uri:
     url: "https://{{ cp4d_host }}/zen-data/v3/service_instances/{{ cp4d_db_id }}?include_service_status=true"
     validate_certs: no
@@ -152,7 +152,7 @@
     status_code: 200
     timeout: 30
   register: db_status
-  until: "'{{ db_status.json.service_instance.metadata.status }}' == 'RUNNING'"
+  until: db_status.json.service_instance.metadata.status == 'RUNNING'
   retries: 60
   delay: 60
 

--- a/ibm/mas_devops/roles/cp4d_db2wh/tasks/cpd40/provision-instance.yml
+++ b/ibm/mas_devops/roles/cp4d_db2wh/tasks/cpd40/provision-instance.yml
@@ -75,7 +75,7 @@
   community.kubernetes.k8s_info:
     api_version: db2u.databases.ibm.com/v1
     name: "{{ db2wh_instance_name | lower }}"
-    namespace: "{{db2wh_namespace}}"
+    namespace: "{{ db2wh_namespace }}"
     kind: Db2uCluster
   register: db2_cluster_lookup
   until:
@@ -99,7 +99,7 @@
     api_version: v1
     kind: Secret
     name: "internal-tls"
-    namespace: "{{db2wh_namespace}}"
+    namespace: "{{ db2wh_namespace }}"
   register: _db2u_instance_certificates
 
 - name: Lookup db2wh Engn Service
@@ -107,7 +107,7 @@
     api_version: v1
     kind: Service
     name: "c-{{db2wh_instance_name | lower}}-db2u-engn-svc"
-    namespace: "{{db2wh_namespace}}"
+    namespace: "{{ db2wh_namespace }}"
   register: _db2u_instance_engn_svc
   until:
     - _db2u_instance_engn_svc.resources[0] is defined

--- a/ibm/mas_devops/roles/cp4d_db2wh/tasks/main.yml
+++ b/ibm/mas_devops/roles/cp4d_db2wh/tasks/main.yml
@@ -31,11 +31,21 @@
   set_fact:
     cpd_version: cpd40
 
+
+# 2. Set db2wh_version if none provided by the user
+# -----------------------------------------------------------------------------
+- name: Set db2wh_version if none provided by the user
+  when: db2wh_version is not defined or db2wh_version == ''
+  set_fact:
+    db2wh_version: "{{ default_db2wh_version[cpd_version] }}"
+
 - debug:
-    msg: "CPD Version ........................... {{ cpd_version }}"
+    msg:
+      - "CPD Version ........................... {{ cpd_version }}"
+      - "DB2WH Version ......................... {{ db2wh_version }}"
 
 
-# 2. Load var files
+# 3. Load var files
 # -----------------------------------------------------------------------------
 - name: Load variables
   include_vars: "vars/{{ cpd_version }}.yml"

--- a/ibm/mas_devops/roles/cp4d_db2wh/templates/cpd35/cp4d_db2_database_config.yaml.j2
+++ b/ibm/mas_devops/roles/cp4d_db2wh/templates/cpd35/cp4d_db2_database_config.yaml.j2
@@ -3,6 +3,4 @@ kind: ConfigMap
 metadata:
   name: "{{ cpd_db_config_configmap_name }}-{{ db2wh_instance_name }}"
 data:
-  cp4d_db_id: "{{ cp4d_db_id }}"
-  cp4d_db_svc_name: "{{ cp4d_db_svc }}"
-  cp4d_db_ssl_port: "{{ cp4d_db_ssl_port }}"
+  db2wh_instance_id: "{{ db2wh_instance_id }}"

--- a/ibm/mas_devops/roles/cp4d_db2wh/templates/cpd35/create_db.json.j2
+++ b/ibm/mas_devops/roles/cp4d_db2wh/templates/cpd35/create_db.json.j2
@@ -1,257 +1,251 @@
 {
-  "addon_type":"db2wh",
-  "display_name":"{{ db2wh_instance_name }}",
-  "namespace":"{{ db2wh_namespace }}",
+  "addon_type": "db2wh",
+  "display_name": "{{ db2wh_instance_name }}",
+  "namespace": "{{ db2wh_namespace }}",
   "addon_version": "{{ db2wh_version }}",
   "create_arguments":{
-    "resources":{
-      "cpu":"4.0",
-      "memory":"16.0"
+    "resources": {
+      "cpu": "4.0",
+      "memory": "16.0"
     },
-    "parameters":{
-
-    },
-    "description":"Db2 Warehouse {{ db2wh_version }}",
-    "metadata":{
-      "api-console":[
-
-      ],
-      "repositories":[
+    "parameters":{},
+    "description": "Db2 Warehouse {{ db2wh_version }}",
+    "metadata": {
+      "api-console": [],
+      "repositories": [
         {
-            "repository":"image-registry.openshift-image-registry.svc:5000/cpd-meta-ops/db2u.graph",
-            "repository-key":"images.graph.image.repository",
-            "tag":"11.5.5.1-cn3-4193",
-            "tag-key":"images.graph.image.tag"
+            "repository": "image-registry.openshift-image-registry.svc:5000/cpd-meta-ops/db2u.graph",
+            "repository-key": "images.graph.image.repository",
+            "tag": "11.5.5.1-cn3-4193",
+            "tag-key": "images.graph.image.tag"
         },
         {
-            "repository":"image-registry.openshift-image-registry.svc:5000/cpd-meta-ops/db2u.hurricane",
-            "repository-key":"images.hurricane.image.repository",
-            "tag":"11.5.5.1-cn3-4193",
-            "tag-key":"images.hurricane.image.tag"
+            "repository": "image-registry.openshift-image-registry.svc:5000/cpd-meta-ops/db2u.hurricane",
+            "repository-key": "images.hurricane.image.repository",
+            "tag": "11.5.5.1-cn3-4193",
+            "tag-key": "images.hurricane.image.tag"
         },
         {
-            "repository":"image-registry.openshift-image-registry.svc:5000/cpd-meta-ops/db2u.auxiliary.auth",
-            "repository-key":"images.auth.image.repository",
-            "tag":"11.5.5.1-cn3-4193",
-            "tag-key":"images.auth.image.tag"
+            "repository": "image-registry.openshift-image-registry.svc:5000/cpd-meta-ops/db2u.auxiliary.auth",
+            "repository-key": "images.auth.image.repository",
+            "tag": "11.5.5.1-cn3-4193",
+            "tag-key": "images.auth.image.tag"
         },
         {
-            "repository":"image-registry.openshift-image-registry.svc:5000/cpd-meta-ops/db2u.rest",
-            "repository-key":"images.rest.image.repository",
-            "tag":"11.5.5.1-cn3-4193",
-            "tag-key":"images.rest.image.tag"
+            "repository": "image-registry.openshift-image-registry.svc:5000/cpd-meta-ops/db2u.rest",
+            "repository-key": "images.rest.image.repository",
+            "tag": "11.5.5.1-cn3-4193",
+            "tag-key": "images.rest.image.tag"
         },
         {
-            "repository":"image-registry.openshift-image-registry.svc:5000/cpd-meta-ops/etcd",
-            "repository-key":"images.etcd.image.repository",
-            "tag":"3.4.14-4193",
-            "tag-key":"images.etcd.image.tag"
+            "repository": "image-registry.openshift-image-registry.svc:5000/cpd-meta-ops/etcd",
+            "repository-key": "images.etcd.image.repository",
+            "tag": "3.4.14-4193",
+            "tag-key": "images.etcd.image.tag"
         },
         {
-            "repository":"image-registry.openshift-image-registry.svc:5000/cpd-meta-ops/db2u.instdb",
-            "repository-key":"images.instdb.image.repository",
-            "tag":"11.5.5.1-cn3-4193",
-            "tag-key":"images.instdb.image.tag"
+            "repository": "image-registry.openshift-image-registry.svc:5000/cpd-meta-ops/db2u.instdb",
+            "repository-key": "images.instdb.image.repository",
+            "tag": "11.5.5.1-cn3-4193",
+            "tag-key": "images.instdb.image.tag"
         },
         {
-            "repository":"image-registry.openshift-image-registry.svc:5000/cpd-meta-ops/db2u",
-            "repository-key":"images.db2u.image.repository",
-            "tag":"11.5.5.1-cn3-4193",
-            "tag-key":"images.db2u.image.tag"
+            "repository": "image-registry.openshift-image-registry.svc:5000/cpd-meta-ops/db2u",
+            "repository-key": "images.db2u.image.repository",
+            "tag": "11.5.5.1-cn3-4193",
+            "tag-key": "images.db2u.image.tag"
         },
         {
-            "repository":"image-registry.openshift-image-registry.svc:5000/cpd-meta-ops/db2u.bigsql.mariadb",
-            "repository-key":"images.mariadb.image.repository",
-            "tag":"11.5.5.1-cn3-4193",
-            "tag-key":"images.mariadb.image.tag"
+            "repository": "image-registry.openshift-image-registry.svc:5000/cpd-meta-ops/db2u.bigsql.mariadb",
+            "repository-key": "images.mariadb.image.repository",
+            "tag": "11.5.5.1-cn3-4193",
+            "tag-key": "images.mariadb.image.tag"
         },
         {
-            "repository":"image-registry.openshift-image-registry.svc:5000/cpd-meta-ops/db2u.tools",
-            "repository-key":"images.tools.image.repository",
-            "tag":"11.5.5.1-cn3-4193",
-            "tag-key":"images.tools.image.tag"
+            "repository": "image-registry.openshift-image-registry.svc:5000/cpd-meta-ops/db2u.tools",
+            "repository-key": "images.tools.image.repository",
+            "tag": "11.5.5.1-cn3-4193",
+            "tag-key": "images.tools.image.tag"
         }
       ],
-      "api-database-status":{
-        "label":"api-database-status",
-        "scripts":[
+      "api-database-status": {
+        "label": "api-database-status",
+        "scripts": [
           "/tools/status/icp4dstatus.sh"
         ],
-        "value":"db2wh-api"
+        "value": "db2wh-api"
       },
-      "table-org":"{{ db2wh_table_org }}",
-      "set-kernel-params":true,
-      "chart":"ibm-db2wh-prod-3.5.9-x86_64.tgz",
-      "user":"bluadmin",
-      "database-name":"{{ db2wh_dbname }}",
-      "display-name":"{{ db2wh_instance_name }}",
-      "name":"Db2 Warehouse",
-      "version":"{{ db2wh_version }}",
-      "console-port":8443,
-      "jdbc-port":50000,
-      "secure-jdbc-port":50001,
-      "type":"db2wh",
-      "architecture":"x86_64",
-      "namespace":"{{ db2wh_namespace }}",
-      "cpu":4,
-      "mem":16,
-      "dedicated":false,
-      "node-label-value":"database-db2wh",
-      "hadr":null,
-      "support-4k":false,
-      "support-hostpath-in-chart":false,
-      "selected-storage-option":[
+      "table-org": "{{ db2wh_table_org }}",
+      "set-kernel-params": true,
+      "chart": "ibm-db2wh-prod-3.5.9-x86_64.tgz",
+      "user": "bluadmin",
+      "database-name": "{{ db2wh_dbname }}",
+      "display-name": "{{ db2wh_instance_name }}",
+      "name": "Db2 Warehouse",
+      "version": "{{ db2wh_version }}",
+      "console-port": 8443,
+      "jdbc-port": 50000,
+      "secure-jdbc-port": 50001,
+      "type": "db2wh",
+      "architecture": "x86_64",
+      "namespace": "{{ db2wh_namespace }}",
+      "cpu": 4,
+      "mem": 16,
+      "dedicated": false,
+      "node-label-value": "database-db2wh",
+      "hadr": null,
+      "support-4k": false,
+      "support-hostpath-in-chart": false,
+      "selected-storage-option": [
         {
-          "dbstorage":"metaStorage",
-          "description":"System storage contains the information used by the database management system to manage and configure the database.",
-          "label":"System storage",
-          "objectStorageTypes":null,
-          "storage":"metadata"
+          "dbstorage": "metaStorage",
+          "description": "System storage contains the information used by the database management system to manage and configure the database.",
+          "label": "System storage",
+          "objectStorageTypes": null,
+          "storage": "metadata"
         },
         {
-          "dbstorage":"dataStorage",
-          "description":"User storage defines the location for your database data.",
-          "enableStorageClassAccessMode":true,
-          "label":"User storage",
-          "objectStorageTypes":null,
-          "storage":"shared"
+          "dbstorage": "dataStorage",
+          "description": "User storage defines the location for your database data.",
+          "enableStorageClassAccessMode": true,
+          "label": "User storage",
+          "objectStorageTypes": null,
+          "storage": "shared"
         },
         {
-          "dbstorage":"backupStorage",
-          "description":"Backup storage defines the location for your backup data.",
-          "label":"Backup storage",
-          "objectStorageTypes":null,
-          "showClaims":"all",
-          "storage":"shared"
+          "dbstorage": "backupStorage",
+          "description": "Backup storage defines the location for your backup data.",
+          "label": "Backup storage",
+          "objectStorageTypes": null,
+          "showClaims": "all",
+          "storage": "shared"
         }
       ],
-      "api-external-console":null,
-      "console-url":"console/",
-      "mem-unit":"GiB",
-      "constraint":"hard",
-      "worker-node":1,
-      "icon":"IBM",
-      "additional-menu-options":[
-
-      ],
-      "connectivity-url":[
+      "api-external-console": null,
+      "console-url": "console/",
+      "mem-unit": "GiB",
+      "constraint": "hard",
+      "worker-node": 1,
+      "icon": "IBM",
+      "additional-menu-options": [],
+      "connectivity-url": [
         {
-          "id":"jdbc",
-          "label":"JDBC Connection URL"
+          "id": "jdbc",
+          "label": "JDBC Connection URL"
         }
       ],
-      "api-database-jdbc":{
-        "label":"api-database-jdbc",
-        "value":"-db2u-engn-svc"
+      "api-database-jdbc": {
+        "label": "api-database-jdbc",
+        "value": "-db2u-engn-svc"
       },
-      "monitoring-check-detail":[
+      "monitoring-check-detail": [
         {
-          "percentage-completed":5,
-          "remaining-mins-left":5,
-          "stage-info":[
+          "percentage-completed": 5,
+          "remaining-mins-left": 5,
+          "stage-info": [
             {
-              "completed-state":"true",
-              "formation-state":"OK",
-              "formation-suffix":"instdb",
-              "formation-type":"Job",
-              "pod-label":"api-progress",
-              "pod-type-check":"LABEL",
-              "pod-value":"db2wh-api",
-              "state-type-check":"INIT_READINESS"
+              "completed-state": "true",
+              "formation-state": "OK",
+              "formation-suffix": "instdb",
+              "formation-type": "Job",
+              "pod-label": "api-progress",
+              "pod-type-check": "LABEL",
+              "pod-value": "db2wh-api",
+              "state-type-check": "INIT_READINESS"
             }
           ],
-          "stage-name":"Preparing the worker nodes",
-          "stage-number":1
+          "stage-name": "Preparing the worker nodes",
+          "stage-number": 1
         },
         {
-          "percentage-completed":30,
-          "remaining-mins-left":4,
-          "stage-info":[
+          "percentage-completed": 30,
+          "remaining-mins-left": 4,
+          "stage-info": [
             {
-              "completed-state":"true",
-              "formation-state":"Converging",
-              "formation-suffix":"restore-morph",
-              "formation-type":"Job",
-              "pod-label":"api-progress",
-              "pod-type-check":"LABEL",
-              "pod-value":"db2wh-api",
-              "state-type-check":"CONTAINERS_READINESS"
+              "completed-state": "true",
+              "formation-state": "Converging",
+              "formation-suffix": "restore-morph",
+              "formation-type": "Job",
+              "pod-label": "api-progress",
+              "pod-type-check": "LABEL",
+              "pod-value": "db2wh-api",
+              "state-type-check": "CONTAINERS_READINESS"
             }
           ],
-          "stage-name":"Configuring the database services",
-          "stage-number":2
+          "stage-name": "Configuring the database services",
+          "stage-number": 2
         },
         {
-          "percentage-completed":60,
-          "remaining-mins-left":2,
-          "stage-info":[
+          "percentage-completed": 60,
+          "remaining-mins-left": 2,
+          "stage-info": [
             {
-              "completed-state":"true",
-              "formation-state":"OK",
-              "formation-suffix":"restore-morph",
-              "formation-type":"Job",
-              "pod-name":"-ibm-unified-console-api",
-              "pod-type-check":"NAME",
-              "state-type-check":"CONTAINERS_READINESS"
+              "completed-state": "true",
+              "formation-state": "OK",
+              "formation-suffix": "restore-morph",
+              "formation-type": "Job",
+              "pod-name": "-ibm-unified-console-api",
+              "pod-type-check": "NAME",
+              "state-type-check": "CONTAINERS_READINESS"
             }
           ],
-          "stage-name":"Starting the database",
-          "stage-number":3
+          "stage-name": "Starting the database",
+          "stage-number": 3
         }
       ],
-      "storage-configmap-name":"db2wh-storage-configmap",
-      "mln-count":1,
-      "database-configuration":{
-        "registry":{
-          "DB2_WORKLOAD":"ANALYTICS"
+      "storage-configmap-name": "db2wh-storage-configmap",
+      "mln-count": 1,
+      "database-configuration": {
+        "registry": {
+          "DB2_WORKLOAD": "ANALYTICS"
         }
       },
       "storage-class":[
         {
-          "label":"metaStorage",
-          "name":"{{ db2wh_meta_storage_class }}"
+          "label": "metaStorage",
+          "name": "{{ db2wh_meta_storage_class }}"
         },
         {
-          "label":"dataStorage",
-          "name":"{{ db2wh_user_storage_class }}"
+          "label": "dataStorage",
+          "name": "{{ db2wh_user_storage_class }}"
         },
         {
-          "label":"backupStorage",
-          "name":"{{ db2wh_backup_storage_class }}"
+          "label": "backupStorage",
+          "name": "{{ db2wh_backup_storage_class }}"
         }
       ],
       "size":[
         {
-          "label":"metaStorage",
-          "value":"{{ db2wh_meta_storage_size_gb }}"
+          "label": "metaStorage",
+          "value": {{ db2wh_meta_storage_size_gb }}
         },
         {
-          "label":"dataStorage",
-          "value":"{{ db2wh_user_storage_size_gb }}"
+          "label": "dataStorage",
+          "value": {{ db2wh_user_storage_size_gb }}
         },
         {
-          "label":"backupStorage",
-          "value":"{{ db2wh_backup_storage_size_gb }}"
+          "label": "backupStorage",
+          "value": {{ db2wh_backup_storage_size_gb }}
         }
       ],
       "storage-class-access-mode":[
         {
-          "label":"metaStorage",
-          "name":"ReadWriteMany"
+          "label": "metaStorage",
+          "name": "ReadWriteMany"
         },
         {
-          "label":"dataStorage",
-          "name":"ReadWriteOnce"
+          "label": "dataStorage",
+          "name": "ReadWriteOnce"
         },
         {
-          "label":"backupStorage",
-          "name":"ReadWriteMany"
+          "label": "backupStorage",
+          "name": "ReadWriteMany"
         }
       ]
     },
-    "owner_username":""
+    "owner_username": ""
   },
-  "transientFields":{
+  "transientFields": {
 
   }
 }

--- a/ibm/mas_devops/roles/cp4d_db2wh/vars/cpd35.yml
+++ b/ibm/mas_devops/roles/cp4d_db2wh/vars/cpd35.yml
@@ -1,2 +1,3 @@
 ---
 db2wh_namespace: 'cpd-meta-ops'
+db2wh_jdbc_username: db2inst1

--- a/ibm/mas_devops/roles/cp4d_db2wh_manage_hack/README.md
+++ b/ibm/mas_devops/roles/cp4d_db2wh_manage_hack/README.md
@@ -3,6 +3,8 @@ cp4d_db2wh_manage_hack
 
 This role shouldn't need to exist, it should be part of the Manage operator, but is not so we have to do it as a seperate step in the install flow for now.  The role will perform some initial setup on the Db2 instance that is needed to prepare it for use with the Manage application and supports both CP4D version 3.5 and 4.0.
 
+The role will copy a bash script (setupdb.sh) into the Db2 pod and execute it inside the container, this script will perform a number of configuration changes to the database as well as configuring the tablespaces for Maximo Manage because the operator is not yet able to do this itself.
+
 Role Variables
 --------------
 ### cpd_version

--- a/ibm/mas_devops/roles/cp4d_db2wh_manage_hack/tasks/main.yml
+++ b/ibm/mas_devops/roles/cp4d_db2wh_manage_hack/tasks/main.yml
@@ -84,6 +84,7 @@
 # TODO: We should do this locally, connecting to the Db2 instance using the route
 # that we have created.  Execing into a container is considered bad practice in
 # production environment, and we want this collection to be production friendly.
+#
 # However given that we want to get all of this moved into the manage operator
 # ASAP, there is little point investing the effort to fix this in this collection,
 # rather that effort should be put into migrating this code into the manage
@@ -110,36 +111,24 @@
 
 # 6. Prepare database for use with Maximo TPAE
 # -----------------------------------------------------------------------------
-
-# If the file already exists in the container, then we have already ran this command
-- name: "Check for existence of /tmp/setupdb.sh in pod"
-  shell: |
-    oc exec -it -n {{ db2wh_pod_namespace }} {{ db2wh_pod_name }} -- bash -c "ls /tmp | grep setupdb.sh | wc -l"
-  register: setupdb_file_check
-
-- name: Create dbsetup script in local /tmp
-  when: setupdb_file_check.stdout == "0"
+- name: Create setupdb script in local /tmp
   ansible.builtin.template:
     src: setupdb.sh.j2
     dest: /tmp/setupdb.sh
+    mode: '777'
 
 - name: Copy the setupdb script into the db2 pod
-  when: setupdb_file_check.stdout == "0"
-  shell: oc cp /tmp/setupdb.sh {{ db2wh_pod_namespace }}/{{ db2wh_pod_name }}:/tmp/setupdb.sh
+  shell: "oc cp /tmp/setupdb.sh {{ db2wh_pod_namespace }}/{{ db2wh_pod_name }}:/tmp/setupdb.sh"
 
-- name: Make the setupdb script executable
-  when: setupdb_file_check.stdout == "0"
-  shell: oc exec -n {{db2wh_pod_namespace}} {{db2wh_pod_name}} -- bash -c "chmod 755 /tmp/setupdb.sh"
-
+# The log file will also be available inside the pod /tmp/setupdb.log
+# The script will exit early if /tmp/setupdb_complete exists to avoid unnecessarily re-running
+# the setup, however this file will be lost after pod restarts.
 - name: Run setupdb to prepare Db2 for use with Maximo TPAE
-  when: setupdb_file_check.stdout == "0"
-  shell: oc exec -n {{db2wh_pod_namespace}} {{db2wh_pod_name}} -- su -lc /tmp/setupdb.sh db2inst1
+  shell: oc exec -n {{db2wh_pod_namespace}} {{db2wh_pod_name}} -- su -lc '/tmp/setupdb.sh | tee /tmp/setupdb.log' db2inst1
   register: prepare_cmds_status
 
 - name: "Database setup debug information"
-  when: setupdb_file_check.stdout == "0"
   debug:
     msg:
-      - "Setup already ran ...................... {{ setupdb_file_check.stdout }}"
       - "Result (stdout) ........................ {{ prepare_cmds_status.stdout }}"
       - "result (stderr) ........................ {{ prepare_cmds_status.stderr }}"

--- a/ibm/mas_devops/roles/cp4d_db2wh_manage_hack/tasks/main.yml
+++ b/ibm/mas_devops/roles/cp4d_db2wh_manage_hack/tasks/main.yml
@@ -124,11 +124,16 @@
 # Following line removed:
 # db2 GRANT DBADM,CREATETAB,BINDADD,CONNECT,CREATE_NOT_FENCED_ROUTINE,IMPLICIT_SCHEMA,
 #   LOAD,CREATE_EXTERNAL_ROUTINE,QUIESCE_CONNECT,SECADM ON DATABASE TO USER {{ db2wh_username }}
+#
+# We also removed these statements due to error:
+# SQL0554N  An authorization ID cannot grant a privilege or authority to itself
+# db2 GRANT USE OF TABLESPACE MAXDATA TO USER {{ db2wh_username }}
+# db2 GRANT CREATEIN,DROPIN,ALTERIN ON SCHEMA {{ db2wh_schema }} TO USER {{ db2wh_username }}
 
 - name: Prepare db2 for use with Maximo TPAE
   when: setupdb_file_check.stdout == "0"
   shell: |
-    oc exec -it -n {{ db2wh_pod_namespace }} {{ db2wh_pod_name }} -- bash -c "cat << EOF > /tmp/setupdb.sh
+    oc exec -n {{ db2wh_pod_namespace }} {{ db2wh_pod_name }} -- bash -c "cat << EOF > /tmp/setupdb.sh
     db2 connect to {{ db2wh_dbname }}
     db2 update db cfg for {{ db2wh_dbname }} using dft_table_org ROW
     db2 update db cfg for {{ db2wh_dbname }} using AUTO_MAINT ON DEFERRED
@@ -176,16 +181,13 @@
     db2 CREATE REGULAR TABLESPACE MAXDATA PAGESIZE 32 K MANAGED BY AUTOMATIC STORAGE INITIALSIZE 5000 M BUFFERPOOL MAXBUFPOOL
     db2 CREATE TEMPORARY TABLESPACE MAXTEMP PAGESIZE 32 K MANAGED BY AUTOMATIC STORAGE BUFFERPOOL MAXBUFPOOL
     db2 CREATE REGULAR TABLESPACE MAXINDEX PAGESIZE 32 K MANAGED BY AUTOMATIC STORAGE INITIALSIZE 5000 M BUFFERPOOL MAXBUFPOOL
-    db2 GRANT USE OF TABLESPACE MAXDATA TO USER {{ db2wh_username }}
     db2 create schema {{ db2wh_schema }} authorization {{ db2wh_username }}
-    db2 GRANT USE OF TABLESPACE MAXDATA TO USER {{ db2wh_username }}
-    db2 GRANT CREATEIN,DROPIN,ALTERIN ON SCHEMA {{ db2wh_schema }} TO USER {{ db2wh_username }}
     db2stop force
     sleep 10
     db2start
     EOF"
-    oc exec -it -n {{db2wh_pod_namespace}} {{db2wh_pod_name}} -- bash -c "chmod 755 /tmp/setupdb.sh"
-    oc exec -it -n {{db2wh_pod_namespace}} {{db2wh_pod_name}} -- su -lc /tmp/setupdb.sh db2inst1
+    oc exec -n {{db2wh_pod_namespace}} {{db2wh_pod_name}} -- bash -c "chmod 755 /tmp/setupdb.sh"
+    oc exec -n {{db2wh_pod_namespace}} {{db2wh_pod_name}} -- su -lc /tmp/setupdb.sh db2inst1
   register: prepare_cmds_status
 
 

--- a/ibm/mas_devops/roles/cp4d_db2wh_manage_hack/tasks/main.yml
+++ b/ibm/mas_devops/roles/cp4d_db2wh_manage_hack/tasks/main.yml
@@ -68,7 +68,7 @@
 - name: "[CP4D v3.5] Read the DB2 database ID for {{ db2wh_instance_name }} from DB config ConfigMap data"
   when: cpd_version == 'cpd35'
   set_fact:
-    db2wh_instance_id: "db2wh-{{ cp4d_db_config_info.resources[0].data.cp4d_db_id }}"
+    db2wh_instance_id: "db2wh-{{ cp4d_db_config_info.resources[0].data.db2wh_instance_id }}"
 
 
 # 4b. Determine Db2 instance ID from name - CP4D v4.0
@@ -114,82 +114,27 @@
 # If the file already exists in the container, then we have already ran this command
 - name: "Check for existence of /tmp/setupdb.sh in pod"
   shell: |
-    oc exec -it -n {{ db2wh_pod_namespace }} {{ db2wh_pod_name }} -- bash -c "ls /tmp/setupdb.sh | wc -l"
+    oc exec -it -n {{ db2wh_pod_namespace }} {{ db2wh_pod_name }} -- bash -c "ls /tmp | grep setupdb.sh | wc -l"
   register: setupdb_file_check
 
-# Note that we have removed the standard GRANT command, as in the context of this playbook the
-# {{db2wh_username}} user already owns the schema:
-#
-# db2 create schema {{ db2wh_schema }} authorization {{ db2wh_username }}
-# Following line removed:
-# db2 GRANT DBADM,CREATETAB,BINDADD,CONNECT,CREATE_NOT_FENCED_ROUTINE,IMPLICIT_SCHEMA,
-#   LOAD,CREATE_EXTERNAL_ROUTINE,QUIESCE_CONNECT,SECADM ON DATABASE TO USER {{ db2wh_username }}
-#
-# We also removed these statements due to error:
-# SQL0554N  An authorization ID cannot grant a privilege or authority to itself
-# db2 GRANT USE OF TABLESPACE MAXDATA TO USER {{ db2wh_username }}
-# db2 GRANT CREATEIN,DROPIN,ALTERIN ON SCHEMA {{ db2wh_schema }} TO USER {{ db2wh_username }}
-
-- name: Prepare db2 for use with Maximo TPAE
+- name: Create dbsetup script in local /tmp
   when: setupdb_file_check.stdout == "0"
-  shell: |
-    oc exec -n {{ db2wh_pod_namespace }} {{ db2wh_pod_name }} -- bash -c "cat << EOF > /tmp/setupdb.sh
-    db2 connect to {{ db2wh_dbname }}
-    db2 update db cfg for {{ db2wh_dbname }} using dft_table_org ROW
-    db2 update db cfg for {{ db2wh_dbname }} using AUTO_MAINT ON DEFERRED
-    db2 update db cfg for {{ db2wh_dbname }} using AUTO_TBL_MAINT ON DEFERRED
-    db2 update db cfg for {{ db2wh_dbname }} using AUTO_RUNSTATS ON DEFERRED
-    db2 update db cfg for {{ db2wh_dbname }} using AUTO_REORG ON DEFERRED
-    db2 update db cfg for {{ db2wh_dbname }} using AUTO_DB_BACKUP ON DEFERRED
-    db2 update db cfg for {{ db2wh_dbname }} using CATALOGCACHE_SZ 800 DEFERRED
-    db2 update db cfg for {{ db2wh_dbname }} using CHNGPGS_THRESH 40 DEFERRED
-    db2 update db cfg for {{ db2wh_dbname }} using DBHEAP AUTOMATIC
-    db2 update db cfg for {{ db2wh_dbname }} using LOCKLIST AUTOMATIC DEFERRED
-    db2 update db cfg for {{ db2wh_dbname }} using LOGBUFSZ 1024 DEFERRED
-    db2 update db cfg for {{ db2wh_dbname }} using LOCKTIMEOUT 300 DEFERRED
-    db2 update db cfg for {{ db2wh_dbname }} using LOGPRIMARY 20 DEFERRED
-    db2 update db cfg for {{ db2wh_dbname }} using LOGSECOND 100 DEFERRED
-    db2 update db cfg for {{ db2wh_dbname }} using LOGFILSIZ 8192 DEFERRED
-    db2 update db cfg for {{ db2wh_dbname }} using SOFTMAX 1000 DEFERRED
-    db2 update db cfg for {{ db2wh_dbname }} using MAXFILOP 61440 DEFERRED
-    db2 update db cfg for {{ db2wh_dbname }} using PCKCACHESZ AUTOMATIC DEFERRED
-    db2 update db cfg for {{ db2wh_dbname }} using STAT_HEAP_SZ AUTOMATIC DEFERRED
-    db2 update db cfg for {{ db2wh_dbname }} using STMTHEAP AUTOMATIC DEFERRED
-    db2 update db cfg for {{ db2wh_dbname }} using UTIL_HEAP_SZ 10000 DEFERRED
-    db2 update db cfg for {{ db2wh_dbname }} using DATABASE_MEMORY AUTOMATIC DEFERRED
-    db2 update db cfg for {{ db2wh_dbname }} using AUTO_STMT_STATS OFF DEFERRED
-    db2 update db cfg for {{ db2wh_dbname }} using STMT_CONC LITERALS DEFERRED
-    db2 update alert cfg for database on {{ db2wh_dbname }} using db.db_backup_req SET THRESHOLDSCHECKED YES
-    db2 update alert cfg for database on {{ db2wh_dbname }} using db.tb_reorg_req SET THRESHOLDSCHECKED YES
-    db2 update alert cfg for database on {{ db2wh_dbname }} using db.tb_runstats_req SET THRESHOLDSCHECKED YES
-    db2 update dbm cfg using PRIV_MEM_THRESH 32767 DEFERRED
-    db2 update dbm cfg using KEEPFENCED NO DEFERRED
-    db2 update dbm cfg using NUMDB 2 DEFERRED
-    db2 update dbm cfg using RQRIOBLK 65535 DEFERRED
-    db2 update dbm cfg using HEALTH_MON OFF DEFERRED
-    db2 update dbm cfg using AGENT_STACK_SZ 1000 DEFERRED
-    db2 update dbm cfg using MON_HEAP_SZ AUTOMATIC DEFERRED
-    db2 update db cfg using DDL_CONSTRAINT_DEF Yes
-    db2set DB2_SKIPINSERTED=ON
-    db2set DB2_INLIST_TO_NLJN=YES
-    db2set DB2_MINIMIZE_LISTPREFETCH=Y
-    db2set DB2_EVALUNCOMMITTED=YES
-    db2set DB2_FMP_COMM_HEAPSZ=65536
-    db2set DB2_SKIPDELETED=ON
-    db2set DB2_USE_ALTERNATE_PAGE_CLEANING=ON
-    db2 CREATE BUFFERPOOL MAXBUFPOOL IMMEDIATE SIZE 4096 AUTOMATIC PAGESIZE 32 K
-    db2 CREATE REGULAR TABLESPACE MAXDATA PAGESIZE 32 K MANAGED BY AUTOMATIC STORAGE INITIALSIZE 5000 M BUFFERPOOL MAXBUFPOOL
-    db2 CREATE TEMPORARY TABLESPACE MAXTEMP PAGESIZE 32 K MANAGED BY AUTOMATIC STORAGE BUFFERPOOL MAXBUFPOOL
-    db2 CREATE REGULAR TABLESPACE MAXINDEX PAGESIZE 32 K MANAGED BY AUTOMATIC STORAGE INITIALSIZE 5000 M BUFFERPOOL MAXBUFPOOL
-    db2 create schema {{ db2wh_schema }} authorization {{ db2wh_username }}
-    db2stop force
-    sleep 10
-    db2start
-    EOF"
-    oc exec -n {{db2wh_pod_namespace}} {{db2wh_pod_name}} -- bash -c "chmod 755 /tmp/setupdb.sh"
-    oc exec -n {{db2wh_pod_namespace}} {{db2wh_pod_name}} -- su -lc /tmp/setupdb.sh db2inst1
-  register: prepare_cmds_status
+  ansible.builtin.template:
+    src: setupdb.sh.j2
+    dest: /tmp/setupdb.sh
 
+- name: Copy the setupdb script into the db2 pod
+  when: setupdb_file_check.stdout == "0"
+  shell: oc cp /tmp/setupdb.sh {{ db2wh_pod_namespace }}/{{ db2wh_pod_name }}:/tmp/setupdb.sh
+
+- name: Make the setupdb script executable
+  when: setupdb_file_check.stdout == "0"
+  shell: oc exec -n {{db2wh_pod_namespace}} {{db2wh_pod_name}} -- bash -c "chmod 755 /tmp/setupdb.sh"
+
+- name: Run setupdb to prepare Db2 for use with Maximo TPAE
+  when: setupdb_file_check.stdout == "0"
+  shell: oc exec -n {{db2wh_pod_namespace}} {{db2wh_pod_name}} -- su -lc /tmp/setupdb.sh db2inst1
+  register: prepare_cmds_status
 
 - name: "Database setup debug information"
   when: setupdb_file_check.stdout == "0"

--- a/ibm/mas_devops/roles/cp4d_db2wh_manage_hack/templates/setupdb.sh.j2
+++ b/ibm/mas_devops/roles/cp4d_db2wh_manage_hack/templates/setupdb.sh.j2
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Note that we have removed the standard GRANT command, as in the context of this playbook the
+# {{db2wh_username}} user already owns the schema:
+#
+# db2 create schema {{ db2wh_schema }} authorization {{ db2wh_username }}
+#
+# Also, the following line was removed:
+# db2 GRANT DBADM,CREATETAB,BINDADD,CONNECT,CREATE_NOT_FENCED_ROUTINE,IMPLICIT_SCHEMA,
+#   LOAD,CREATE_EXTERNAL_ROUTINE,QUIESCE_CONNECT,SECADM ON DATABASE TO USER {{ db2wh_username }}
+#
+# We also removed these statements due to similar error because we are running as the user that owns these anyway:
+# SQL0554N  An authorization ID cannot grant a privilege or authority to itself
+# db2 GRANT USE OF TABLESPACE MAXDATA TO USER {{ db2wh_username }}
+# db2 GRANT CREATEIN,DROPIN,ALTERIN ON SCHEMA {{ db2wh_schema }} TO USER {{ db2wh_username }}
+
+db2 connect to {{ db2wh_dbname }}
+db2 update db cfg for {{ db2wh_dbname }} using dft_table_org ROW
+db2 update db cfg for {{ db2wh_dbname }} using AUTO_MAINT ON DEFERRED
+db2 update db cfg for {{ db2wh_dbname }} using AUTO_TBL_MAINT ON DEFERRED
+db2 update db cfg for {{ db2wh_dbname }} using AUTO_RUNSTATS ON DEFERRED
+db2 update db cfg for {{ db2wh_dbname }} using AUTO_REORG ON DEFERRED
+db2 update db cfg for {{ db2wh_dbname }} using AUTO_DB_BACKUP ON DEFERRED
+db2 update db cfg for {{ db2wh_dbname }} using CATALOGCACHE_SZ 800 DEFERRED
+db2 update db cfg for {{ db2wh_dbname }} using CHNGPGS_THRESH 40 DEFERRED
+db2 update db cfg for {{ db2wh_dbname }} using DBHEAP AUTOMATIC
+db2 update db cfg for {{ db2wh_dbname }} using LOCKLIST AUTOMATIC DEFERRED
+db2 update db cfg for {{ db2wh_dbname }} using LOGBUFSZ 1024 DEFERRED
+db2 update db cfg for {{ db2wh_dbname }} using LOCKTIMEOUT 300 DEFERRED
+db2 update db cfg for {{ db2wh_dbname }} using LOGPRIMARY 20 DEFERRED
+db2 update db cfg for {{ db2wh_dbname }} using LOGSECOND 100 DEFERRED
+db2 update db cfg for {{ db2wh_dbname }} using LOGFILSIZ 8192 DEFERRED
+db2 update db cfg for {{ db2wh_dbname }} using SOFTMAX 1000 DEFERRED
+db2 update db cfg for {{ db2wh_dbname }} using MAXFILOP 61440 DEFERRED
+db2 update db cfg for {{ db2wh_dbname }} using PCKCACHESZ AUTOMATIC DEFERRED
+db2 update db cfg for {{ db2wh_dbname }} using STAT_HEAP_SZ AUTOMATIC DEFERRED
+db2 update db cfg for {{ db2wh_dbname }} using STMTHEAP AUTOMATIC DEFERRED
+db2 update db cfg for {{ db2wh_dbname }} using UTIL_HEAP_SZ 10000 DEFERRED
+db2 update db cfg for {{ db2wh_dbname }} using DATABASE_MEMORY AUTOMATIC DEFERRED
+db2 update db cfg for {{ db2wh_dbname }} using AUTO_STMT_STATS OFF DEFERRED
+db2 update db cfg for {{ db2wh_dbname }} using STMT_CONC LITERALS DEFERRED
+db2 update alert cfg for database on {{ db2wh_dbname }} using db.db_backup_req SET THRESHOLDSCHECKED YES
+db2 update alert cfg for database on {{ db2wh_dbname }} using db.tb_reorg_req SET THRESHOLDSCHECKED YES
+db2 update alert cfg for database on {{ db2wh_dbname }} using db.tb_runstats_req SET THRESHOLDSCHECKED YES
+db2 update dbm cfg using PRIV_MEM_THRESH 32767 DEFERRED
+db2 update dbm cfg using KEEPFENCED NO DEFERRED
+db2 update dbm cfg using NUMDB 2 DEFERRED
+db2 update dbm cfg using RQRIOBLK 65535 DEFERRED
+db2 update dbm cfg using HEALTH_MON OFF DEFERRED
+db2 update dbm cfg using AGENT_STACK_SZ 1000 DEFERRED
+db2 update dbm cfg using MON_HEAP_SZ AUTOMATIC DEFERRED
+db2 update db cfg using DDL_CONSTRAINT_DEF Yes
+db2set DB2_SKIPINSERTED=ON
+db2set DB2_INLIST_TO_NLJN=YES
+db2set DB2_MINIMIZE_LISTPREFETCH=Y
+db2set DB2_EVALUNCOMMITTED=YES
+db2set DB2_FMP_COMM_HEAPSZ=65536
+db2set DB2_SKIPDELETED=ON
+db2set DB2_USE_ALTERNATE_PAGE_CLEANING=ON
+db2 CREATE BUFFERPOOL MAXBUFPOOL IMMEDIATE SIZE 4096 AUTOMATIC PAGESIZE 32 K
+db2 CREATE REGULAR TABLESPACE MAXDATA PAGESIZE 32 K MANAGED BY AUTOMATIC STORAGE INITIALSIZE 5000 M BUFFERPOOL MAXBUFPOOL
+db2 CREATE TEMPORARY TABLESPACE MAXTEMP PAGESIZE 32 K MANAGED BY AUTOMATIC STORAGE BUFFERPOOL MAXBUFPOOL
+db2 CREATE REGULAR TABLESPACE MAXINDEX PAGESIZE 32 K MANAGED BY AUTOMATIC STORAGE INITIALSIZE 5000 M BUFFERPOOL MAXBUFPOOL
+db2 create schema {{ db2wh_schema }} authorization {{ db2wh_username }}
+db2stop force
+sleep 10
+db2start

--- a/ibm/mas_devops/roles/cp4d_db2wh_manage_hack/templates/setupdb.sh.j2
+++ b/ibm/mas_devops/roles/cp4d_db2wh_manage_hack/templates/setupdb.sh.j2
@@ -14,6 +14,12 @@
 # db2 GRANT USE OF TABLESPACE MAXDATA TO USER {{ db2wh_username }}
 # db2 GRANT CREATEIN,DROPIN,ALTERIN ON SCHEMA {{ db2wh_schema }} TO USER {{ db2wh_username }}
 
+if [ -f "/tmp/setupdb_complete" ]; then
+  echo "Aborting run.  /tmp/setupdb_complete exists; this script has already been executed"
+  exit 0
+fi
+
+set -e
 db2 connect to {{ db2wh_dbname }}
 db2 update db cfg for {{ db2wh_dbname }} using dft_table_org ROW
 db2 update db cfg for {{ db2wh_dbname }} using AUTO_MAINT ON DEFERRED
@@ -57,11 +63,23 @@ db2set DB2_EVALUNCOMMITTED=YES
 db2set DB2_FMP_COMM_HEAPSZ=65536
 db2set DB2_SKIPDELETED=ON
 db2set DB2_USE_ALTERNATE_PAGE_CLEANING=ON
+
+# These will fail if re-running the script, but I don't know enough about Db2 to make them idempotent
+# so for now we will ignore failures in them
+set +e
 db2 CREATE BUFFERPOOL MAXBUFPOOL IMMEDIATE SIZE 4096 AUTOMATIC PAGESIZE 32 K
 db2 CREATE REGULAR TABLESPACE MAXDATA PAGESIZE 32 K MANAGED BY AUTOMATIC STORAGE INITIALSIZE 5000 M BUFFERPOOL MAXBUFPOOL
 db2 CREATE TEMPORARY TABLESPACE MAXTEMP PAGESIZE 32 K MANAGED BY AUTOMATIC STORAGE BUFFERPOOL MAXBUFPOOL
 db2 CREATE REGULAR TABLESPACE MAXINDEX PAGESIZE 32 K MANAGED BY AUTOMATIC STORAGE INITIALSIZE 5000 M BUFFERPOOL MAXBUFPOOL
 db2 create schema {{ db2wh_schema }} authorization {{ db2wh_username }}
+
+set -e
 db2stop force
 sleep 10
 db2start
+
+echo "COMPLETE" > /tmp/setupdb_complete
+chmod a+rw /tmp/setupdb_complete
+
+# If we get this far, then we can consider the setup a success
+exit 0

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -7,29 +7,32 @@ To learn more about Tekton refer to the excellent material here: https://redhat-
 ## ClusterTasks
 
 # CP4D Management
-- Install CP4D - dependencies/install-cp4d.yaml
-- Install Db2 Warehouse (via undocumented API!) - dependencies/install-db2-api.yaml
-- Install Db2 Warehouse - dependencies/install-db2.yaml
+- [Create Db2 Warehouse Instance](tasks/dependencies/create-db2-instance.yaml)
+- [Install CP4D with Db2 Warehouse service enabled](tasks/dependencies/install-db2.yaml)
+- [Install CP4D with Db2 Warehouse & Watson Studio services enabled](tasks/dependencies/install-fullstack.yaml)
+- [Install CP4D with Watson Studio services enabled](tasks/dependencies/install-watsonstudio.yaml)
 
 ### Dependency Management
-- Install AMQStreams - dependencies/install-amqstreams.yaml
-- Install Behavior Analytics Service - bas/install-bas.yaml
-- Install MongoDb CE - dependencies/install-mongodb-ce.yaml
-- Install IBM Suite License Service - sls/install-sls.yaml
+- [Install AMQStreams](tasks/dependencies/install-amqstreams.yaml)
+- [Install Behavior Analytics Service](tasks/bas/install-bas.yaml)
+- [Install MongoDb CE](tasks/dependencies/install-mongodb-ce.yaml)
+- [Install IBM Suite License Service](tasks/sls/install-sls.yaml)
 
 ### MAS Management
-- Configure Application - mas/configure-app.yaml
-- Configure MAS Core - mas/configure-suite.yaml
-- Manage Db2 Database Configuration Hack - mas/hack-manage-db2.yaml
-- Install Application - mas/install-app.yaml
-- Install MAS Core - mas/install-suite.yaml
+- [Configure Application](tasks/mas/configure-app.yaml)
+- [Configure MAS Core](tasks/mas/configure-suite.yaml)
+- [Manage Db2 Database Configuration Hack](tasks/mas/hack-manage-db2.yaml)
+- [Install Application](tasks/mas/install-app.yaml)
+- [Install MAS Core](tasks/mas/install-suite.yaml)
 
 ### OCP Management
-- Configure OCP Cluster - ocp/configure-ocp.yaml
+- [Configure OCP Cluster for MAS](tasks/ocp/configure-ocp.yaml)
 
 
-## Install Pipeline Operator
-After provisioning and logging into the cluster, you can use the install script provided: `bin/install-pipelines.sh`, or just create the subscription below:
+### Usage
+
+### 1. Provision Cluster and Install OpenShift Pipelines Operator
+After provisioning and logging into the cluster, you can use the install script provided: `bin/install-pipelines.sh`:
 
 ```bash
 export IBMCLOUD_APIKEY=xxx
@@ -39,21 +42,8 @@ ansible-playbook playbooks/cp4d/hack-worker-nodes.yml
 bin/install-pipelines.sh
 ```
 
-```yaml
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-    name: openshift-pipelines-operator
-    namespace: openshift-operators
-spec:
-    channel: stable
-    name: openshift-pipelines-operator-rh
-    source: redhat-operators
-    sourceNamespace: openshift-marketplace
-```
 
-
-# Build and Install the MAS Pipeline Task Definitions
+# 2. Build and Install the MAS Pipeline Task Definitions
 ```
 export DEV_MODE=true
 export VERSION=5.1.0
@@ -63,9 +53,8 @@ cd pipelines
 oc apply -f ibm-mas_devops-clustertasks-5.1.0.yaml
 ```
 
-
-# Install and run the MAS Sample Pipeline
-Modify the `samples/sample-pipelinesettings.yaml` file to populate it with your own settings before applying it to the cluster
+# 3. Install and run the MAS Sample Pipeline
+Modify the [sample-pipelinesettings.yaml](samples/sample-pipelinesettings.yaml) to populate it with your own settings before applying it to the cluster, and optionally customize the parameters in [sample-pipelinerun-mas86.yaml](samples/sample-pipelinerun-mas86.yaml) if you wish to adjust the subscription channels for the MAS applications.
 
 ```bash
 oc new-project mas-sample-pipelines

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -47,10 +47,10 @@ bin/install-pipelines.sh
 ```
 export DEV_MODE=true
 export VERSION=5.1.0
-pipelines/bin/build-pipelines.sh
 
 cd pipelines
-oc apply -f ibm-mas_devops-clustertasks-5.1.0.yaml
+bin/build-pipelines.sh
+oc apply -f ibm-mas_devops-clustertasks-$VERSION.yaml
 ```
 
 # 3. Install and run the MAS Sample Pipeline

--- a/pipelines/bin/install-pipelines.sh
+++ b/pipelines/bin/install-pipelines.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
-set -e
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 SAMPLES_DIR=$(realpath $DIR/../samples)
 oc apply -f $SAMPLES_DIR/subscription.yaml
 
-# TODO: do while STATE != ready
-# otherwise the CRD lookup will fail, as the timeout only helps AFTER the CRD initially exists
-# STATE=$(oc get subscription  openshift-pipelines-operator -n openshift-operators -o=jsonpath="{.status.state}")
+oc get crd tasks.tekton.dev &> /dev/null
+LOOKUP_RESULT=$?
+while [ "$LOOKUP_RESULT" == "1" ]; do
+  echo "Waiting 5s for tasks.tekton.dev CRD to be installed before checking again ..."
+  sleep 5
+  oc get crd tasks.tekton.dev &> /dev/null
+  LOOKUP_RESULT=$?
+done
 
 echo "Wait for Pipeline operator to be ready"
 oc wait --for=condition=Established  crd tasks.tekton.dev  --timeout=30m


### PR DESCRIPTION
- Previous approach was just to ignore errors, which masked real errors as well
- Add more missing documentation #3
- Intelligent defaulting of db2 version for 3.5 and 4.0 cp4d
- Insert multiple failure conditions into the code to correctly raise errors when expected conditions are not met
- consolidation of variable naming
- move setupdb definition into a template and use `oc cp` command to copy it into the container instead of stdin redirect with `oc exec`
- Fix username/password for cpd v3.5 JdbcCfg, as it was being set to entirely the wrong thing and would be unuseable for any applications
- #89 