### PR TITLE
[patch] Increase manage appws timeout and fix db2wh_svc_fqn generation

### DIFF
--- a/ibm/mas_devops/roles/cp4d_db2wh/tasks/cpd35/provision-instance.yml
+++ b/ibm/mas_devops/roles/cp4d_db2wh/tasks/cpd35/provision-instance.yml
@@ -136,7 +136,7 @@
 - name: "Set service name and fqn from the instance ID"
   set_fact:
     db2wh_svc_name: "c-db2wh-{{ db2wh_instance_id }}-db2u-engn-svc"
-    db2wh_svc_fqn: "{{ cp4d_db_config_info.resources[0].data.db2wh_svc_fqn }}"
+    db2wh_svc_fqn: "{{ db2wh_svc_name }}.{{ db2wh_namespace }}.svc"
 
 
 # 7. Wait till DB2 status is RUNNING

--- a/ibm/mas_devops/roles/suite_app_configure/vars/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_configure/vars/manage.yml
@@ -7,5 +7,5 @@ mas_app_ws_spec:
     jdbc: "{{ mas_appws_jdbc_binding | default( 'system' , true) }}"
   components: "{{ mas_appws_components | default({'base': {'version': 'latest'}}, true) }}"
 
-mas_app_cfg_timeout: 360  # 6 minutes before we give up and fall back into the retry loop
-mas_app_cfg_retries: 30   # 2 mins each loop * 10 loops =~ 3 hours
+mas_app_cfg_timeout: 480  # 8 minutes before we give up and fall back into the retry loop
+mas_app_cfg_retries: 30   # 8 mins each loop * 40 loops =~ 4 hours (Manage is really slow to set up)

--- a/pipelines/CONTRIBUTING.md
+++ b/pipelines/CONTRIBUTING.md
@@ -1,59 +1,46 @@
-## Development
+# Development Guide
 
+## 1. Provision Cluster and Install OpenShift Pipelines Operator
+Provision the cluster and perform the CP4D worker node hack (technically only required for CP4D v4):
 
-### Build new container image
 ```bash
-export VERSION=4.5.1-pre.branch
-cp ibm/mas_devops/ibm-mas_devops-$VERSION.tar.gz image/ansible-devops/ibm-mas_devops.tar.gz
-docker build -t quay.io/ibmmas/ansible-devops:$VERSION image/ansible-devops
-docker push quay.io/ibmmas/ansible-devops:$VERSION
+export IBMCLOUD_APIKEY=xxx
+export CLUSTER_NAME=xxx
+ansible-playbook ibm/mas_devops/playbooks/ocp/provision-roks.yml && ansible-playbook ibm/mas_devops/playbooks/cp4d/hack-worker-nodes.yml
 ```
 
+### 2. Install Pipelines feature
+Sooner rather than later (and ahead of public release of the Tekton pipelines), we will fold this into the OCP provisioning role so that clusters have this capability "out of the box".
 
-### Build new tekton images
 ```bash
-export DEV_MODE=true
-export VERSION=5.1.0-pre.branch
-cd pipelines
-bash bin/build-pipelines.sh
+bash pipelines/bin/install-pipelines.sh
 ```
 
-### Install Pipelines feature & ClusterTask definitions
-```bash
-cd pipelines
-bash bin/install-pipelines.sh
-# Wait until the pipelines operator is installed
-oc apply -f ibm-mas_devops-clustertasks-$VERSION.yaml
-```
-
-### Install and run sample pipeline
-First, make a copy of `pipelines/samples/sample-pipelinesettings-roks.yaml` and set the real values as appropriate.  If you name it `pipelines/samples/sample-pipelinesettings-roks-donotcommit.yaml` then it will already be in the gitignore file
+### 3. Set up the Pipeline Namespace
+First, make a copy of `pipelines/samples/sample-pipelinesettings-roks.yaml` and set the real values as appropriate.  If you name it `pipelines/samples/sample-pipelinesettings-roks-donotcommit.yaml` then it will already be in the gitignore file.
 
 ```bash
-cd pipelines
 oc new-project mas-sample-pipelines
-oc apply -f samples/sample-pipelinesettings-roks-donotcommit.yaml
+oc apply -f pipelines/samples/sample-pipelinesettings-roks-donotcommit.yaml
 
 oc create secret generic pipeline-additional-configs --from-file=/home/david/masconfig/workspace_masdev.yaml
 oc create secret generic pipeline-sls-entitlement --from-file=/home/david/masconfig/entitlement.lic
-
-oc apply -f samples/sample-pipeline.yaml
-oc create -f samples/sample-pipelinerun-dev.yaml
 ```
 
 
-### Rebuild
-Each time you want to modify and retry a pipeline run, use the following:
+### 4. Development Loop
+Each time you want to modify and test a pipeline run, use the following:
 
 ```bash
-cd pipelines
+export DEV_MODE=true
+export VERSION=5.1.0
 
-# Update the settings secret
-oc apply -f samples/sample-pipelinesettings-roks-donotcommit.yaml
+# Update the settings secret (if you changed any global settings)
+oc apply -f pipelines/samples/sample-pipelinesettings-roks-donotcommit.yaml
 
-# Build and update the clustertasks
-bash bin/build-pipelines.sh && oc apply -f ibm-mas_devops-clustertasks-$VERSION.yaml
+# Build and update the clustertasks (if you changed any task definitions)
+bash pipelines/bin/build-pipelines.sh && oc apply -f pipelines/ibm-mas_devops-clustertasks-$VERSION.yaml
 
 # Update the pipeline definition and start a new run
-oc apply -f samples/sample-pipeline.yaml && oc create -f samples/sample-pipelinerun-dev.yaml
+oc apply -f pipelines/samples/sample-pipeline.yaml && oc create -f pipelines/samples/sample-pipelinerun-dev.yaml
 ```

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -4,6 +4,8 @@ These pipelines are all powered by the container image in this same repository, 
 
 To learn more about Tekton refer to the excellent material here: https://redhat-scholars.github.io/tekton-tutorial/tekton-tutorial/index.html
 
+This aspect of the project is still in active development and should be considered pre-release.  However, we are using these extensively in our own development, so they should be pretty reliable given we use them multiple times every day in our automation frameworks.
+
 ## ClusterTasks
 
 # CP4D Management
@@ -30,6 +32,7 @@ To learn more about Tekton refer to the excellent material here: https://redhat-
 
 
 ### Usage
+All commands assume you are in the root directory where you have cloned this repository.
 
 ### 1. Provision Cluster and Install OpenShift Pipelines Operator
 After provisioning and logging into the cluster, you can use the install script provided: `bin/install-pipelines.sh`:
@@ -37,9 +40,9 @@ After provisioning and logging into the cluster, you can use the install script 
 ```bash
 export IBMCLOUD_APIKEY=xxx
 export CLUSTER_NAME=xxx
-ansible-playbook playbooks/ocp/provision-roks.yml
-ansible-playbook playbooks/cp4d/hack-worker-nodes.yml
-bin/install-pipelines.sh
+ansible-playbook ibm/mas_devops/playbooks/ocp/provision-roks.yml
+ansible-playbook ibm/mas_devops/playbooks/cp4d/hack-worker-nodes.yml
+pipelines/bin/install-pipelines.sh
 ```
 
 
@@ -48,9 +51,8 @@ bin/install-pipelines.sh
 export DEV_MODE=true
 export VERSION=5.1.0
 
-cd pipelines
-bin/build-pipelines.sh
-oc apply -f ibm-mas_devops-clustertasks-$VERSION.yaml
+pipelines/bin/build-pipelines.sh
+oc apply -f pipelines/ibm-mas_devops-clustertasks-$VERSION.yaml
 ```
 
 # 3. Install and run the MAS Sample Pipeline
@@ -58,7 +60,7 @@ Modify the [sample-pipelinesettings.yaml](samples/sample-pipelinesettings.yaml) 
 
 ```bash
 oc new-project mas-sample-pipelines
-oc apply -f samples/sample-pipelinesettings.yaml
+oc apply -f pipelines/samples/sample-pipelinesettings.yaml
 
 oc create secret generic pipeline-additional-configs \
   --from-file=/home/david/masconfig/workspace_masdev.yaml
@@ -66,6 +68,6 @@ oc create secret generic pipeline-additional-configs \
 oc create secret generic pipeline-sls-entitlement \
   --from-file=/home/david/masconfig/entitlement.lic
 
-oc apply -f samples/sample-pipeline.yaml
-oc create -f samples/sample-pipelinerun-mas86.yaml
+oc apply -f pipelines/samples/sample-pipeline.yaml
+oc create -f pipelines/samples/sample-pipelinerun-mas86.yaml
 ```


### PR DESCRIPTION
A couple of small fixes and updates to developer documentation:
- Add 1 hour to manage workspace config timeout.  Manage application workspace configuration takes a really long time, increase the timeout from 3 to 4 hours.
- Fix generation of `db2wh_svc_fqn` variable, this was still referring to a configmap lookup instead of simply computing it from the one value that we need to lookup - the instance ID.