### PR TITLE
[patch] Fix suite verify & add docs

### DIFF
--- a/.github/workflows/ansible-publish.yml
+++ b/.github/workflows/ansible-publish.yml
@@ -1,4 +1,4 @@
-name: Publish Ansible Collection to Galaxy
+name: Publish Ansible Collection
 on:
   push:
     branches-ignore:
@@ -6,7 +6,7 @@ on:
     tags:
       - '**'
 jobs:
-  galaxy-publish:
+  ansible-publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,11 +30,13 @@ jobs:
           $GITHUB_WORKSPACE/build/bin/build-collection.sh
 
       - name: Upload Ansible Collection
-        uses: actions/upload-artifact@v2
+        uses: svenstaro/upload-release-action@v2
         with:
-          name: ibm-mas_devops-${{ env.VERSION }}.tar.gz
-          path: ${{ github.workspace }}/ibm/mas_devops/ibm-mas_devops-${{ env.VERSION }}.tar.gz
-          retention-days: 30
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ github.workspace }}/ibm/mas_devops/ibm-mas_devops-${{ env.VERSION }}.tar.gz
+          asset_name: ibm-mas_devops-${{ env.VERSION }}.tar.gz
+          tag: ${{ github.ref }}
+          overwrite: true
 
       # Publish
       - name: Publish Collection

--- a/.github/workflows/tekton-publish.yml
+++ b/.github/workflows/tekton-publish.yml
@@ -1,0 +1,38 @@
+name: Publish Tekton Defintion
+on:
+  push:
+    branches-ignore:
+      - '**'
+    tags:
+      - '**'
+jobs:
+  tekton-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.1
+
+      - name: Initialise the build system
+        run: |
+          chmod u+x $GITHUB_WORKSPACE/build/bin/*.sh
+          $GITHUB_WORKSPACE/build/bin/initbuild.sh
+          source $GITHUB_WORKSPACE/build/bin/.functions.sh
+          python -m pip install -q ansible==2.10.3 yamllint
+
+      - name: Initialise the build system
+        run: |
+          chmod u+x $GITHUB_WORKSPACE/build/bin/*.sh
+          $GITHUB_WORKSPACE/build/bin/initbuild.sh
+          source $GITHUB_WORKSPACE/build/bin/.functions.sh
+
+      - name: Build the ClusterTasks definition file
+        run: $GITHUB_WORKSPACE/pipelines/bin/build-pipelines.sh
+
+      - name: Upload Tekton Definitions
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ github.workspace }}/pipelines/ibm-mas_devops-clustertasks-${{ env.VERSION }}.yaml
+          asset_name: ibm-mas_devops-clustertasks-${{ env.VERSION }}.yaml
+          tag: ${{ github.ref }}
+          overwrite: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,20 @@
 # Contributing
 
+Note that during a build the version of the ansible collection is automatically adjusted to the correct version.  For local development will we always target the "next major" as the version, this is just a convenient placeholder string that works for local development; all released collections will automatically set this version to the correct value for the release.
+
 ## Building the collection locally
 
 ```bash
 cd ibm/mas_devops
 
-ansible-galaxy collection build --force && ansible-galaxy collection install ibm-mas_devops-5.1.5.tar.gz -p /home/david/.ansible/collections --force
+ansible-galaxy collection build --force && ansible-galaxy collection install ibm-mas_devops-6.0.0.tar.gz -p /home/david/.ansible/collections --force
 
 ansible-playbook ../../playbook.yml
 ```
 
 ```bash
 ansible-galaxy collection build --force
-ansible-galaxy collection publish ibm-mas_devops-5.1.5.tar.gz --token=$ANSIBLE_GALAXY_TOKEN
+ansible-galaxy collection publish ibm-mas_devops-6.0.0.tar.gz --token=$ANSIBLE_GALAXY_TOKEN
 ```
 
 ## Style Guide

--- a/ibm/mas_devops/galaxy.yml
+++ b/ibm/mas_devops/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: ibm
 name: mas_devops
-version: 5.1.5
+version: 6.0.0
 readme: README.md
 authors:
   - David Parker <parkerda@uk.ibm.com>

--- a/ibm/mas_devops/playbooks/mas/verify.yml
+++ b/ibm/mas_devops/playbooks/mas/verify.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  any_errors_fatal: true
+  roles:
+    - ibm.mas_devops.suite_verify

--- a/ibm/mas_devops/roles/suite_verify/README.md
+++ b/ibm/mas_devops/roles/suite_verify/README.md
@@ -1,20 +1,38 @@
 suite_verify
 ============
 
-TODO: Summarize role
+Verify a MAS installation is ready to use.  This role will also print out the Admin Dashboard URL and the username and password of the superuser.  If you want to disable these credentials being written to the output set the `mas_hide_superuser_credentials` to `True`.
 
 Role Variables
 --------------
 
-TODO: Finish documentation
+### mas_instance_id
+Required.  The instance ID of the Maximo Application Suite installation to verify.
+
+- Environment Variable: `MAS_INSTANCE_ID`
+- Default Value: None
+
+### mas_hide_superuser_credentials
+Set this to `True` if you want to disable the display of the superuser credentials as part of the verify.  When this is enabled the debug will only identify the name of the secret containing the credentials rather than displaying the actual values.
+
+- Environment Variable: `MAS_HIDE_SUPERUSER_CREDENTIALS`
+- Default Value: `False`
 
 
 Example Playbook
 ----------------
 
 ```yaml
-TODO: Add example
+- hosts: localhost
+  any_errors_fatal: true
+  vars:
+    mas_instance_id: masinst1
+    mas_hide_superuser_credentials: True
+  roles:
+    - ibm.mas_devops.suite_verify
+
 ```
+
 
 License
 -------

--- a/ibm/mas_devops/roles/suite_verify/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_verify/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
+mas_hide_superuser_credentials: "{{ lookup('env', 'MAS_HIDE_SUPERUSER_CREDENTIALS') | default('False', True) }}"

--- a/ibm/mas_devops/roles/suite_verify/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_verify/tasks/main.yml
@@ -4,9 +4,11 @@
 # 1. Check for undefined properties that do not have a default
 # -----------------------------------------------------------------------------
 - name: "Fail if mas_instance_id is not provided"
-  when: mas_instance_id is not defined or mas_instance_id == ""
-  fail:
-    msg: "mas_instance_id property is required"
+  assert:
+    that:
+      - mas_instance_id is defined
+      - mas_instance_id != ""
+    fail_msg: "mas_instance_id property is required"
 
 
 # 2. Configure target namespace
@@ -26,12 +28,15 @@
     kind: Suite
   register: suite_cr_result
   until:
-    - suite_cr_result.resources[0].status is defined
-    - suite_cr_result.resources[0].status.conditions | length == 5
-    - suite_cr_result.resources[0].status.conditions[0].status == 'True'
-    - suite_cr_result.resources[0].status.conditions[1].status == 'True'
-    - suite_cr_result.resources[0].status.conditions[2].status == 'True'
-    - suite_cr_result.resources[0].status.conditions[3].status == 'True'
+    - suite_cr_result.resources[0].status.conditions is defined
+    - suite_cr_result.resources[0].status.conditions | selectattr('type', 'equalto', 'SystemDatabaseReady') | map(attribute='status') | list | length > 0
+    - suite_cr_result.resources[0].status.conditions | selectattr('type', 'equalto', 'SystemDatabaseReady') | map(attribute='status') | list | first == "True"
+    - suite_cr_result.resources[0].status.conditions | selectattr('type', 'equalto', 'BASIntegrationReady') | map(attribute='status') | list | length > 0
+    - suite_cr_result.resources[0].status.conditions | selectattr('type', 'equalto', 'BASIntegrationReady') | map(attribute='status') | list | first == "True"
+    - suite_cr_result.resources[0].status.conditions | selectattr('type', 'equalto', 'SLSIntegrationReady') | map(attribute='status') | list | length > 0
+    - suite_cr_result.resources[0].status.conditions | selectattr('type', 'equalto', 'SLSIntegrationReady') | map(attribute='status') | list | first == "True"
+    - suite_cr_result.resources[0].status.conditions | selectattr('type', 'equalto', 'Ready') | map(attribute='status') | list | length > 0
+    - suite_cr_result.resources[0].status.conditions | selectattr('type', 'equalto', 'Ready') | map(attribute='status') | list | first == "True"
   retries: 30 # approx 30 minutes before we give up
   delay: 60 # 1 minute
 
@@ -39,6 +44,7 @@
 # 4. Lookup for superuser credentials
 # -----------------------------------------------------------------------------
 - name: "Lookup MAS superuser credentials"
+  when: not mas_hide_superuser_credentials
   community.kubernetes.k8s_info:
     api_version: v1
     kind: Secret
@@ -46,6 +52,17 @@
     namespace: "{{mas_namespace}}"
   register: superuser_credentials
 
+- name: "Show the username/password"
+  when: not mas_hide_superuser_credentials
+  set_fact:
+    superuser_username: "{{ superuser_credentials.resources[0].data.username | b64decode }}"
+    superuser_password: "{{ superuser_credentials.resources[0].data.password | b64decode }}"
+
+- name: "Hide acutal username/password"
+  when: mas_hide_superuser_credentials
+  set_fact:
+    superuser_username: "Available in Secret/{{ mas_instance_id }}-credentials-superuser"
+    superuser_password: "Available in Secret/{{ mas_instance_id }}-credentials-superuser"
 
 # 5. Print MAS login information
 # -----------------------------------------------------------------------------
@@ -67,7 +84,6 @@
 - debug:
     msg:
       - "Maximo Application is Ready, use the superuser credentials to authenticate"
-      - "Superuser Credentials:"
-      - "Username: .... {{ superuser_credentials.resources[0].data.username | b64decode }}"
-      - "Password: .... {{ superuser_credentials.resources[0].data.password | b64decode }}"
-      - "Admin Url: ... {{ admin_route.resources[0].spec.host}}"
+      - "Admin Dashboard ... https://{{ admin_route.resources[0].spec.host }}/"
+      - "Username .......... {{ superuser_username }}"
+      - "Password .......... {{ superuser_password }}"

--- a/pipelines/CONTRIBUTING.md
+++ b/pipelines/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Each time you want to modify and test a pipeline run, use the following:
 
 ```bash
 export DEV_MODE=true
-export VERSION=5.1.5
+export VERSION=6.0.0
 
 # Update the settings secret (if you changed any global settings)
 oc apply -f pipelines/samples/sample-pipelinesettings-roks-donotcommit.yaml

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -48,7 +48,7 @@ pipelines/bin/install-pipelines.sh
 # 2. Build and Install the MAS Pipeline Task Definitions
 ```
 export DEV_MODE=true
-export VERSION=5.1.5
+export VERSION=6.0.0
 
 pipelines/bin/build-pipelines.sh
 oc apply -f pipelines/ibm-mas_devops-clustertasks-$VERSION.yaml


### PR DESCRIPTION
- Suite verify doesn't work with MAS 8.7 pre-release builds (due to the new OSDK introducing a `Failure` status condition)
- Update docs for suite_verify role #3 