### PR TITLE
[patch] Entitlement vars not set for SLS dev catalogs

### DIFF
--- a/ibm/mas_devops/playbooks/dependencies/install-sls.yml
+++ b/ibm/mas_devops/playbooks/dependencies/install-sls.yml
@@ -6,6 +6,12 @@
     sls_catalog_source: "{{ lookup('env', 'SLS_CATALOG_SOURCE') | default('ibm-operator-catalog', true) }}"
     sls_channel: "{{ lookup('env', 'SLS_CHANNEL') | default('3.x', true) }}"
 
+    # --- Dev catalog settings ----------------------------------------------------------------------------------------
+    # Only required when using the development catalog sources for pre-release installation
+    # These are used to set up image pull secret in the openshift-marketplace namespace
+    artifactory_username: "{{ lookup('env', 'W3_USERNAME') | lower }}"
+    artifactory_apikey: "{{ lookup('env', 'ARTIFACTORY_APIKEY') }}"
+
     # Define where SLS will be installed
     sls_namespace: "{{ lookup('env', 'SLS_NAMESPACE') | default('ibm-sls', true) }}"
     sls_icr_cp: "{{ lookup('env', 'SLS_ICR_CP') | default('cp.icr.io/cp', true) }}"


### PR DESCRIPTION
When trying to use the dev catalog for SLS the entitlement is not correctly set in the instal-lsls playbook. This change simply makes sure the vars:

artifactory_username
artifactory_apikey

are set correctly before trying to install SLS using the dev catalog.