### PR TITLE
[patch] Change variables for wait on application code

### DIFF
--- a/ibm/mas_devops/roles/suite_app_configure/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_configure/tasks/main.yml
@@ -61,7 +61,7 @@
     kind: "{{ mas_app_ws_kind }}"
     name: "{{ mas_instance_id }}-{{ mas_workspace_id }}"
     namespace: "{{ mas_app_namespace }}"
-    wait: true
+    wait: yes
     wait_condition:
       status: "True"
       type: Ready
@@ -69,7 +69,7 @@
     wait_timeout: "{{ mas_app_cfg_timeout }}" # before we give up and fall back into the retry loop
   register: app_ws_cr_result
   retries: "{{ mas_app_cfg_retries }}"
-  delay: 0
+  delay: 5 # seconds
   until:
     - app_ws_cr_result.resources is defined
     - app_ws_cr_result.resources | length > 0

--- a/ibm/mas_devops/roles/suite_app_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/main.yml
@@ -111,7 +111,7 @@
     name: "{{ mas_instance_id }}"
     namespace: "{{ mas_app_namespace }}"
     kind: "{{ mas_app_kind }}"
-    wait: true
+    wait: yes
     wait_condition:
       status: "True"
       type: Ready
@@ -119,7 +119,7 @@
     wait_timeout: "{{ mas_app_install_timeout }}" # before we give up and fall back into the retry loop
   register: app_cr_result
   retries: "{{ mas_app_install_retries }}"
-  delay: 0
+  delay: 5 # seconds
   until:
     - app_cr_result.resources is defined
     - app_cr_result.resources | length > 0

--- a/ibm/mas_devops/roles/suite_app_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/main.yml
@@ -111,7 +111,7 @@
     name: "{{ mas_instance_id }}"
     namespace: "{{ mas_app_namespace }}"
     kind: "{{ mas_app_kind }}"
-    wait: yes
+    wait: yes # changed true to yes
     wait_condition:
       status: "True"
       type: Ready


### PR DESCRIPTION
The latest fvt pipelines are failing in the install application (specifically install-iot and install-manage).   The Created CRDs are showing the wait condition is true but it doesn't appear to be actually waiting and checking the conditions every minute as  expected.  The timestamps indicates that it ran in 45 seconds when it should have been waiting 10 mins for manage and 30 mins for IoT.   

The version of ansible was updated for the current build, and it may have resulted in the values of the variables to be modified.   

The changes that were made are:

- wait:  true     ===>   wait: yes
- delay: 0        ===>   delay: 5