### PR TITLE
[patch] Fix for undefined Kafka resource

### DIFF
--- a/ibm/mas_devops/roles/amqstreams/tasks/main.yaml
+++ b/ibm/mas_devops/roles/amqstreams/tasks/main.yaml
@@ -85,6 +85,7 @@
   retries: 120 # Once the cluster is ready we will wait for up to 20 minutes for the listener information to be added to the status sub-resource
   delay: 10 # seconds
   until:
+    - kafka_cluster_lookup.resources is defined
     - kafka_cluster_lookup.resources | length > 0
     - kafka_cluster_lookup.resources[0].status is defined
     - kafka_cluster_lookup.resources[0].status.listeners is defined


### PR DESCRIPTION
Got an issue with current master version of role `masdevops.amqstreams` while installing amq streams:
```
TASK [ibm.mas_devops.amqstreams : Lookup Kafka Resource] ***************************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'kafka_cluster_lookup.resources | length > 0' failed. The error was: error while evaluating conditional (kafka_cluster_lookup.resources | length > 0): 'dict object' has no attribute 'resources'"}
```
https://github.com/ibm-mas/ansible-devops/blob/master/ibm/mas_devops/roles/amqstreams/tasks/main.yaml#L88

It seems it's just missing to include `kafka_cluster_lookup.resources is defined` as part of the `until` condition.