### PR TITLE
[patch] Db2 norootsquash support uses undefined variables

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - '**'
-    tags:
+    tags-ignore:
       - '**'
 jobs:
   build-ansible:

--- a/ibm/mas_devops/roles/cp4d_db2wh/README.md
+++ b/ibm/mas_devops/roles/cp4d_db2wh/README.md
@@ -142,6 +142,12 @@ Define the Kubernetes memory limit for the Db2 pod.  Only supported with CloudPa
 - Environment Variable: `DB2WH_MEMORY_LIMITS`
 - Default: `12Gi`
 
+### cpd_entitlement_key
+Required.  This is the entitlement key used to install the norootsquash Daemonset in the `kube-system` namespace. Holds your IBM Entitlement key.
+
+- Environment Variable: `CPD_ENTITLEMENT_KEY`
+- Default: None
+
 ### cpd_api_username
 Required for CP4D v3.5 only.  These credentials are used to call the REST API to create the database because CP4D v3.5 Kubernetes API is broken.  Yes, the default admin account for CP4D v3.5 really is set up as admin/password.
 
@@ -209,10 +215,7 @@ The number of logical nodes (i.e. database partitions to create).
 - Default: 1
 
 ### db2wh_num_pods
-The number of db2 pods to create in the instance. Note that db2wh_num_pods must be less than or equal to db2wh_mln_count.
-A single db2u pod can contain multiple logical nodes. So be sure to avoid specifying a large number for db2wh_mln_count while 
-specifying a small number for db2wh_num_pods. If in doubt, make db2wh_mln_count = db2wh_num_pods. A slightly out of date reference
-but still decent: https://www.ibm.com/docs/en/db2-warehouse?topic=SSCJDQ/com.ibm.swg.im.dashdb.ucontainer.doc/doc/db2w-mempernode-new.html
+The number of Db2 pods to create in the instance. Note that `db2wh_num_pods` must be less than or equal to `db2wh_mln_count`.  A single db2u pod can contain multiple logical nodes. So be sure to avoid specifying a large number for `db2wh_mln_count` while specifying a small number for `db2wh_num_pods`. If in doubt, make `db2wh_mln_count = db2wh_num_pods`. For more information refer to the [Db2 documentation](https://www.ibm.com/docs/en/db2-warehouse?topic=SSCJDQ/com.ibm.swg.im.dashdb.ucontainer.doc/doc/db2w-mempernode-new.html).
 
 - Environment Variable: `'DB2WH_NUM_PODS`
 - Default: 1

--- a/ibm/mas_devops/roles/cp4d_db2wh/defaults/main.yml
+++ b/ibm/mas_devops/roles/cp4d_db2wh/defaults/main.yml
@@ -69,3 +69,10 @@ db2wh_cpu_requests: "{{ lookup('env', 'DB2WH_CPU_REQUESTS')  | default('2000m', 
 db2wh_cpu_limits: "{{ lookup('env', 'DB2WH_CPU_LIMITS')  | default('4000m', true) }}"
 db2wh_memory_requests: "{{ lookup('env', 'DB2WH_MEMORY_REQUESTS')  | default('6Gi', true) }}"
 db2wh_memory_limits: "{{ lookup('env', 'DB2WH_MEMORY_LIMITS')  | default('12Gi', true) }}"
+
+
+# Required to install the norootsquash daemonset
+# -----------------------------------------------------------------------------------------------------------------
+cpd_registry: cp.icr.io
+cpd_registry_user: cp
+cpd_entitlement_key: "{{ lookup('env', 'CPD_ENTITLEMENT_KEY') }}"

--- a/ibm/mas_devops/roles/cp4d_db2wh/tasks/setup_norootsquash.yml
+++ b/ibm/mas_devops/roles/cp4d_db2wh/tasks/setup_norootsquash.yml
@@ -1,7 +1,9 @@
+---
 # If you are using IBM® Cloud File Storage (ibmc-file-gold-gid storage class) for Red Hat® OpenShift® Kubernetes Service with Db2®,
 # you must use the cp.icr.io/cp/cpd/norootsquash:3.0-amd64 image to set no_root_squash.
 
 # 1. Set 'cpregistrysecret' secret content
+# -----------------------------------------------------------------------------
 - name: Set 'cpregistrysecret' secret content
   vars:
     entitledAuthStr: "{{ cpd_registry_user }}:{{ cpd_entitlement_key }}"
@@ -13,7 +15,9 @@
   set_fact:
     new_secret: "{{ content | join('') }}"
 
+
 # 2. Generate 'cpregistrysecret' secret
+# -----------------------------------------------------------------------------
 - name: "Generate 'cpregistrysecret' secret"
   community.kubernetes.k8s:
     definition:
@@ -27,12 +31,15 @@
         .dockerconfigjson: "{{ new_secret | to_json | b64encode }}"
   register: secretUpdateResult
 
+
 # 3. Create DeamonSet
+# -----------------------------------------------------------------------------
 - name: Create 'norootsquash' DeamonSet
   community.kubernetes.k8s:
     definition: "{{ lookup('template', 'templates/norootsquash_deamonset.yml') }}"
     wait: yes
     wait_timeout: 120
+
 
 # 4. Wait for 'norootsquash' DaemonSet to be running
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
The new task uses variables that are not declared within the role.

Added the following and updated the documentation:

```
cpd_registry: cp.icr.io
cpd_registry_user: cp
cpd_entitlement_key: "{{ lookup('env', 'CPD_ENTITLEMENT_KEY') }}"
```

- Bug fix for #172
- Also fixes a bug introduced into the build system in this commit: https://github.com/ibm-mas/ansible-devops/commit/b93a89c7cac82e29883a5f9969032e9ad862aea1 .. the Ansible workflow should only run on branch builds, not tags.