### PR TITLE
[patch] Fix Deamonset / Daemonset typos

### DIFF
--- a/ibm/mas_devops/roles/cp4d_db2wh/tasks/setup_norootsquash.yml
+++ b/ibm/mas_devops/roles/cp4d_db2wh/tasks/setup_norootsquash.yml
@@ -32,11 +32,11 @@
   register: secretUpdateResult
 
 
-# 3. Create DeamonSet
+# 3. Create DaemonSet
 # -----------------------------------------------------------------------------
-- name: Create 'norootsquash' DeamonSet
+- name: Create 'norootsquash' DaemonSet
   community.kubernetes.k8s:
-    definition: "{{ lookup('template', 'templates/norootsquash_deamonset.yml') }}"
+    definition: "{{ lookup('template', 'templates/norootsquash_daemonset.yml') }}"
     wait: yes
     wait_timeout: 120
 


### PR DESCRIPTION
Fix for the following failure in cp4d_db2wh role: the template file templates/norootsquash_deamonset.yml could not be found for the lookup