### PR TITLE
[minor] adding support for install mas with manual upgrade

### DIFF
--- a/ibm/mas_devops/playbooks/mas/install-app.yml
+++ b/ibm/mas_devops/playbooks/mas/install-app.yml
@@ -28,5 +28,8 @@
     # MAS application configuration
     mas_app_id: "{{ lookup('env', 'MAS_APP_ID') }}"
 
+    # Determine MAS Operator Upgrade Strategy Manual | Automatic
+    mas_app_upgrade_strategy: "{{ lookup('env', 'MAS_APP_UPGRADE_STRATEGY') | default('Manual', true) }}"
+
   roles:
     - ibm.mas_devops.suite_app_install

--- a/ibm/mas_devops/playbooks/mas/install-suite.yml
+++ b/ibm/mas_devops/playbooks/mas/install-suite.yml
@@ -66,6 +66,9 @@
 
     mas_config_dir: "{{ lookup('env', 'MAS_CONFIG_DIR') }}"
 
+    # Determine MAS Operator Upgrade Strategy Manual | Automatic
+    mas_upgrade_strategy: "{{ lookup('env', 'MAS_UPGRADE_STRATEGY') | default('Manual', true) }}"
+
   roles:
     - ibm.mas_devops.suite_dns
     - ibm.mas_devops.suite_install

--- a/ibm/mas_devops/roles/suite_app_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/main.yml
@@ -32,12 +32,12 @@
 - name: "Debug information"
   debug:
     msg:
-      - "Instance ID ............... {{ mas_instance_id }}"
-      - "Application ID ............ {{ mas_app_id }}"
-      - "MAS app namespace ......... {{ mas_app_namespace }}"
-      - "App catalog source ........ {{ mas_app_catalog_source }}"
-      - "App channel ............... {{ mas_app_channel }}"
-
+      - "Instance ID ................ {{ mas_instance_id }}"
+      - "Application ID ............. {{ mas_app_id }}"
+      - "MAS app namespace .......... {{ mas_app_namespace }}"
+      - "App catalog source ......... {{ mas_app_catalog_source }}"
+      - "App channel ................ {{ mas_app_channel }}"
+      - "App Subscription Upgrade ... {{ mas_app_upgrade_strategy }}"
 
 # 4. Install the operator
 # -----------------------------------------------------------------------------
@@ -49,6 +49,34 @@
     catalog_source: "{{ mas_app_catalog_source }}"
     operator_group: "{{ lookup('template', 'templates/operator-group.yml.j2') }}"
     subscription: "{{ lookup('template', 'templates/subscription.yml.j2') }}"
+
+- name: Lookup and Approve MAS Subscription
+  block:
+    - name: Lookup and Approve Operator install plan
+      community.kubernetes.k8s_info:
+        api_version: operators.coreos.com/v1alpha1
+        kind: InstallPlan
+        namespace: "{{ mas_app_namespace }}"
+        label_selectors:
+          - operators.coreos.com/ibm-mas-{{mas_app_id}}.{{mas_app_namespace}}
+      register: mas_app_installplan_info
+      retries: 20
+      delay: 60 # Retry for approx 20 minutes (60s * 20 attempts) before giving up
+      until: mas_app_installplan_info.resources | length > 0
+
+    - name: Approve the install plan for MAS
+      when:
+        - (mas_app_installplan_info.resources[0].status.phase != "Complete" or first_install)
+      community.kubernetes.k8s:
+        definition:
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: InstallPlan
+          metadata:
+            name: "{{ mas_app_installplan_info.resources[0].metadata.name }}"
+            namespace: "{{ mas_app_namespace }}"
+          spec:
+            approved: true
+  when: mas_app_upgrade_strategy == 'Manual'
 
 # 5. Wait until the Application's CRD is available
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/suite_app_install/templates/subscription.yml.j2
+++ b/ibm/mas_devops/roles/suite_app_install/templates/subscription.yml.j2
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ mas_app_namespace }}
 spec:
   channel: {{ mas_app_channel }}
-  installPlanApproval: Automatic
+  installPlanApproval: {{ mas_app_upgrade_strategy }}
   name: ibm-mas-{{ 'manage' if (mas_app_id == 'health') else mas_app_id }}
   source: {{ mas_app_catalog_source }}
   sourceNamespace: openshift-marketplace

--- a/ibm/mas_devops/roles/suite_install/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_install/defaults/main.yml
@@ -7,3 +7,10 @@ mas_icr_cp: cp.icr.io/cp
 mas_entitlement_username: cp
 
 mas_icr_cpopen: icr.io/cpopen
+
+ibm_common_services_namespace: ibm-common-services
+ibm_common_services_subscription_labels:
+  - ibm-common-service-operator.ibm-common-services
+  - ibm-namespace-scope-operator.ibm-common-services
+  - ibm-odlm.ibm-common-services
+  - ibm-licensing-operator-app.ibm-common-services

--- a/ibm/mas_devops/roles/suite_install/tasks/ibm-common-services.yml
+++ b/ibm/mas_devops/roles/suite_install/tasks/ibm-common-services.yml
@@ -1,0 +1,60 @@
+# 1. Lookup Common Services Operator Install Plans and approve
+# ----------------------------------------------------------------------------
+- name: Debug Operator name
+  debug:
+    msg: "{{item}}"
+
+- name: "Verify if ibm operator is already installed"
+  community.kubernetes.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    namespace: "{{ ibm_common_services_namespace }}"
+    label_selectors:
+      - "operators.coreos.com/{{item}}"
+  register: _item_subscription
+
+- name: Lookup and Approve IBM Common Services operators
+  block:
+    - name: "Lookup and wait for Operator subscription to exist"
+      community.kubernetes.k8s_info:
+        api_version: operators.coreos.com/v1alpha1
+        kind: Subscription
+        namespace: "{{ ibm_common_services_namespace }}"
+        label_selectors:
+          - "operators.coreos.com/{{item}}"
+      register: _item_subscription_result
+      retries: 20
+      delay: 60 # Retry for approx 20 minutes (60s * 20 attempts) before giving up
+      until: _item_subscription_result.resources | length > 0
+
+    - name: Lookup Operator install plan
+      community.kubernetes.k8s_info:
+        api_version: operators.coreos.com/v1alpha1
+        kind: InstallPlan
+        namespace: "{{ ibm_common_services_namespace }}"
+        label_selectors:
+          - "operators.coreos.com/{{item}}"
+      register: item_install_plan
+      retries: 20
+      delay: 60 # Retry for approx 20 minutes (60s * 20 attempts) before giving up
+      until: item_install_plan.resources | length > 0
+      when:
+        - _item_subscription_result.resources | length > 0
+        - _item_subscription_result.resources[0].status.state != "AtLatestKnown"
+
+    - name: Approve the subscription install plan
+      when:
+        - _item_subscription_result.resources[0].status.state != "AtLatestKnown"
+        - item_install_plan.resources | length > 0
+        - item_install_plan.resources[0].status.phase != "Complete"
+      community.kubernetes.k8s:
+        definition:
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: InstallPlan
+          metadata:
+            name: "{{ item_install_plan.resources[0].metadata.name }}"
+            namespace: "{{ ibm_common_services_namespace }}"
+          spec:
+            approved: true
+  when:
+    - (_item_subscription.resources | length == 0 or _item_subscription.resources[0].status.state == 'UpgradePending')

--- a/ibm/mas_devops/roles/suite_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_install/tasks/main.yml
@@ -39,6 +39,7 @@
       - "MAS ICR cp content ........... {{ mas_icr_cp }}"
       - "MAS ICR cpopen content ....... {{ mas_icr_cpopen }}"
       - "MAS Custom Cluster Issue ..... {{ custom_cluster_issuer }}"
+      - "MAS Subcription Upgrade ...... {{ mas_upgrade_strategy }}"
 
 # 4. Install the operator
 # -----------------------------------------------------------------------------
@@ -51,6 +52,35 @@
     operator_group: "{{ lookup('template', 'templates/operator-group.yml.j2') }}"
     subscription: "{{ lookup('template', 'templates/subscription.yml.j2') }}"
 
+- name: Lookup and Approve MAS Subscription
+  block:
+    - name: Lookup Operator install plan
+      community.kubernetes.k8s_info:
+        api_version: operators.coreos.com/v1alpha1
+        kind: InstallPlan
+        namespace: "{{ mas_namespace }}"
+        label_selectors:
+          - "operators.coreos.com/ibm-mas.{{ mas_namespace }}"
+      register: mas_install_plan
+      retries: 20
+      delay: 60 # Retry for approx 20 minutes (60s * 20 attempts) before giving up
+      until: mas_install_plan.resources | length > 0
+
+    - name: Approve the subscription install plan
+      when:
+        - mas_install_plan.resources | length > 0
+        - mas_install_plan.resources[0].status.phase != "Complete"
+      community.kubernetes.k8s:
+        definition:
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: InstallPlan
+          metadata:
+            name: "{{ mas_install_plan.resources[0].metadata.name }}"
+            namespace: "{{ mas_namespace }}"
+          spec:
+            approved: true
+  when:
+    - mas_upgrade_strategy == 'Manual'
 
 # 5. Wait until the Suite CRD is available
 # -----------------------------------------------------------------------------
@@ -110,3 +140,10 @@
     state: present
     namespace: "{{ mas_namespace }}"
     definition: "{{ cr_definition }}"
+
+# 9. Handle IBM Common Services Install plan approvals when upgragre strategy is set to Manual
+# -----------------------------------------------------------------------------
+- include_tasks: tasks/ibm-common-services.yml
+  loop: "{{ibm_common_services_subscription_labels}}"
+  when:
+    - mas_upgrade_strategy == 'Manual'

--- a/ibm/mas_devops/roles/suite_install/templates/subscription.yml.j2
+++ b/ibm/mas_devops/roles/suite_install/templates/subscription.yml.j2
@@ -6,7 +6,7 @@ metadata:
   namespace: "{{ mas_namespace }}"
 spec:
   channel: "{{ mas_channel }}"
-  installPlanApproval: Automatic
+  installPlanApproval: {{mas_upgrade_strategy}}
   name: ibm-mas
   source: "{{ mas_catalog_source }}"
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
This PR contains changes to install MAS and Apps using Manual upgrade strategy as default. This is a requirement for any SRE environment, considering that any potential outage should be communicated to customers, which may also be true for other customers as well.

When installing MAS using Manual Upgrade Strategy, all ibm-common-services operators are automatically set to Manual in ibm-common-services namespace. For the cases where common services were previously installed in the cluster, their operators subscriptions will shows as Automatic but functioning as Manual.



