### PR TITLE
[minor] Allow ocp_server and ocp_token to be used for ocp_login

### DIFF
--- a/ibm/mas_devops/playbooks/ocp/login.yml
+++ b/ibm/mas_devops/playbooks/ocp/login.yml
@@ -1,7 +1,0 @@
----
-- hosts: localhost
-  vars:
-    cluster_name: "{{ lookup('env', 'CLUSTER_NAME')}}"
-    cluster_type: roks
-  roles:
-    - ibm.mas_devops.ocp_login

--- a/ibm/mas_devops/playbooks/ocp/login.yml
+++ b/ibm/mas_devops/playbooks/ocp/login.yml
@@ -1,0 +1,7 @@
+---
+- hosts: localhost
+  vars:
+    cluster_name: "{{ lookup('env', 'CLUSTER_NAME')}}"
+    cluster_type: roks
+  roles:
+    - ibm.mas_devops.ocp_login

--- a/ibm/mas_devops/roles/ocp_login/README.md
+++ b/ibm/mas_devops/roles/ocp_login/README.md
@@ -1,7 +1,7 @@
 ocp_login
 =========
 
-This role provides support to login to a cluster using the `oc cli`
+This role provides support to login to a cluster using the `oc cli`. If you set `ocp_server` and `ocp_token` then a non cluster type specific login is attempted rather than using the cluster_type specific facts (apikey or username/password).
 
 
 Role Variables
@@ -16,6 +16,10 @@ Role Variables
 #### Fyre specific facts
 - `username` Required when cluster type is quickburn
 - `password` Required when cluster type is quickburn
+
+#### Non cluster_type specific facts
+- `ocp_server` The OCP server address to perform oc login against
+- `ocp_token` The login token to use for oc login
 
 
 Example Playbook

--- a/ibm/mas_devops/roles/ocp_login/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_login/defaults/main.yml
@@ -3,6 +3,10 @@
 cluster_name: "{{ lookup('env', 'CLUSTER_NAME')}}"
 cluster_type: "{{ lookup('env', 'CLUSTER_TYPE')}}"
 
+# For already provisioned clusters set token and server to log directly into rather than cluster type (ROKS/Fyre) specific login
+ocp_token: "{{ lookup('env', 'OCP_TOKEN') }}"
+ocp_server: "{{ lookup('env', 'OCP_SERVER') }}"
+
 # IBM Cloud ROKS API Key - used when cluster_type == "roks"
 ibmcloud_apikey: "{{ lookup('env', 'IBMCLOUD_APIKEY') }}"
 

--- a/ibm/mas_devops/roles/ocp_login/tasks/login-quickburn.yml
+++ b/ibm/mas_devops/roles/ocp_login/tasks/login-quickburn.yml
@@ -2,14 +2,14 @@
 # 1. Fyre Login
 # -----------------------------------------------------------------------------
 - name: "login-quickburn : Fail if username is not provided"
-  when: username is not defined or username == ""
-  fail:
-    msg: "username property is required"
+  assert:
+    that: username is defined and username != ""
+    fail_msg: "username property is required"
 
 - name: "login-quickburn : Fail if password is not provided"
-  when: password is not defined or password == ""
-  fail:
-    msg: "password property is required"
+  assert:
+    that: password is defined and password != ""
+    fail_msg: "password property is required"
 
 - name: "login-quickburn : Get Cluster Details"
   uri:

--- a/ibm/mas_devops/roles/ocp_login/tasks/login-roks.yml
+++ b/ibm/mas_devops/roles/ocp_login/tasks/login-roks.yml
@@ -6,9 +6,9 @@
 # 1. Check that we have an IBM Cloud API key defined
 # -----------------------------------------------------------------------------
 - name: "login-roks : Fail if ibmcloud_apikey is not provided"
-  when: ibmcloud_apikey is not defined or ibmcloud_apikey == ""
-  fail:
-    msg: "ibmcloud_apikey property is required"
+  assert:
+    that: ibmcloud_apikey is defined and ibmcloud_apikey != ""
+    fail_msg: "ibmcloud_apikey property is required"
 
 
 # 2. Login to IBM Cloud

--- a/ibm/mas_devops/roles/ocp_login/tasks/login.yml
+++ b/ibm/mas_devops/roles/ocp_login/tasks/login.yml
@@ -1,0 +1,26 @@
+---
+# 1. Check that we have the ocp vars defined
+# -----------------------------------------------------------------------------
+- name: "login : Fail if ocp_token is not provided"
+  when: ocp_token is not defined or ocp_token == ""
+  fail:
+    msg: "ocp_token property is required"
+
+- name: "login : Fail if ocp_server is not provided"
+  when: ocp_server is not defined or ocp_server == ""
+  fail:
+    msg: "ocp_server property is required"
+
+
+# 2. Login to OCP
+# -----------------------------------------------------------------------------
+- name: "login : Login to OCP"
+  shell: |
+    oc login --token={{ ocp_token }} --server={{ ocp_server }}
+  register: login_result
+  retries: 5
+  delay: 10
+  until: login_result.rc == 0
+
+- debug:
+    msg: "{{ login_result.stdout_lines }}"

--- a/ibm/mas_devops/roles/ocp_login/tasks/login.yml
+++ b/ibm/mas_devops/roles/ocp_login/tasks/login.yml
@@ -2,14 +2,14 @@
 # 1. Check that we have the ocp vars defined
 # -----------------------------------------------------------------------------
 - name: "login : Fail if ocp_token is not provided"
-  when: ocp_token is not defined or ocp_token == ""
-  fail:
-    msg: "ocp_token property is required"
+  assert:
+    that: ocp_token is defined and ocp_token != ""
+    fail_msg: "ocp_token property is required"
 
 - name: "login : Fail if ocp_server is not provided"
-  when: ocp_server is not defined or ocp_server == ""
-  fail:
-    msg: "ocp_server property is required"
+  assert:
+    that: ocp_server is defined and ocp_server != ""
+    fail_msg: "ocp_server property is required"
 
 
 # 2. Login to OCP

--- a/ibm/mas_devops/roles/ocp_login/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_login/tasks/main.yml
@@ -6,10 +6,14 @@
   fail:
     msg: "cluster_type property is required"
 
-- name: "Fail if cluster_type is not supported"
-  when: cluster_type is not in supported_cluster_types
+# Allow for different cluster_types if the ocp_token and ocp_server have been set
+- name: "Fail if cluster_type is not supported and no ocp_token or ocp_server has been set"
+  when: 
+    - cluster_type is not in supported_cluster_types
+    - ocp_token is not defined or ocp_token == ""
+    - ocp_server is not defined or ocp_server == ""
   fail:
-    msg: "cluster_type '{{ cluster_type }}' property is not supported by this role"
+    msg: "cluster_type '{{ cluster_type }}' property is not supported by this role if you haven't set ocp_server or ocp_token properties"
 
 
 # 2. Provide debug info
@@ -18,9 +22,21 @@
     msg:
       - "Cluster name ................. {{ cluster_name }}"
       - "Cluster type ................. {{ cluster_type }}"
+      - "OCP server ................... {{ ocp_server }}"
 
 
-# 3. Perform login
+# 3. Perform login using cluster specific login
 # -----------------------------------------------------------------------------
 - include_tasks: "tasks/login-{{ cluster_type }}.yml"
-  when: cluster_type != 'in-cluster'
+  when: 
+    - cluster_type != 'in-cluster'
+    - ocp_token is not defined or ocp_token == ""
+    - ocp_server is not defined or ocp_server == ""
+
+# 4. Perform login using generic ocp token
+# -----------------------------------------------------------------------------
+- include_tasks: "tasks/login.yml"
+  when: 
+    - cluster_type != 'in-cluster'
+    - ocp_token is defined and ocp_token != ""
+    - ocp_server is defined and ocp_server != ""

--- a/ibm/mas_devops/roles/ocp_login/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_login/tasks/main.yml
@@ -2,19 +2,18 @@
 # 1. Check for undefined properties that do not have a default
 # -----------------------------------------------------------------------------
 - name: "Fail if type is not provided"
-  when: cluster_type is not defined or cluster_type == ""
-  fail:
-    msg: "cluster_type property is required"
+  assert:
+    that: cluster_type is defined and cluster_type != ""
+    fail_msg: "cluster_type property is required"
 
 # Allow for different cluster_types if the ocp_token and ocp_server have been set
 - name: "Fail if cluster_type is not supported and no ocp_token or ocp_server has been set"
-  when:
-    - cluster_type is not in supported_cluster_types
-    - ocp_token is not defined or ocp_token == ""
-    - ocp_server is not defined or ocp_server == ""
-  fail:
-    msg: "cluster_type '{{ cluster_type }}' property is not supported by this role if you haven't set ocp_server or ocp_token properties"
-
+  assert:
+    that:
+      - ocp_token is defined and ocp_token != ""
+      - ocp_server is defined and ocp_server != ""
+    fail_msg: "cluster_type '{{ cluster_type }}' property is not supported by this role if you haven't set ocp_server or ocp_token properties"
+  when: cluster_type is not in supported_cluster_types
 
 # 2. Provide debug info
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/ocp_login/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_login/tasks/main.yml
@@ -8,7 +8,7 @@
 
 # Allow for different cluster_types if the ocp_token and ocp_server have been set
 - name: "Fail if cluster_type is not supported and no ocp_token or ocp_server has been set"
-  when: 
+  when:
     - cluster_type is not in supported_cluster_types
     - ocp_token is not defined or ocp_token == ""
     - ocp_server is not defined or ocp_server == ""
@@ -28,7 +28,7 @@
 # 3. Perform login using cluster specific login
 # -----------------------------------------------------------------------------
 - include_tasks: "tasks/login-{{ cluster_type }}.yml"
-  when: 
+  when:
     - cluster_type != 'in-cluster'
     - ocp_token is not defined or ocp_token == ""
     - ocp_server is not defined or ocp_server == ""
@@ -36,7 +36,7 @@
 # 4. Perform login using generic ocp token
 # -----------------------------------------------------------------------------
 - include_tasks: "tasks/login.yml"
-  when: 
+  when:
     - cluster_type != 'in-cluster'
     - ocp_token is defined and ocp_token != ""
     - ocp_server is defined and ocp_server != ""

--- a/ibm/mas_devops/roles/ocp_verify/README.md
+++ b/ibm/mas_devops/roles/ocp_verify/README.md
@@ -8,7 +8,7 @@ In IBMCloud ROKS we have seen delays of over an hour before the Red Hat Operator
 
 Role Variables
 --------------
-The role requires no variables itself, but depends on the `ibm.mas_devops.ocp_login` role, and as such inherits it's requirements.
+The role requires no variables itself, but depends on the `ibm.mas_devops.ocp_login` role, and as such inherits it's requirements. If you set `ocp_server` and `ocp_token` then a non cluster type specific login is attempted rather than using the cluster_type specific facts (apikey or username/password).
 
 - `cluster_name` Gives a name for the provisioning cluster
 - `cluster_type` quickburn | roks
@@ -19,6 +19,10 @@ The role requires no variables itself, but depends on the `ibm.mas_devops.ocp_lo
 #### Fyre specific facts
 - `username` Required when cluster type is quickburn
 - `password` Required when cluster type is quickburn
+
+#### Non cluster_type specific facts
+- `ocp_server` The OCP server address to perform oc login against
+- `ocp_token` The login token to use for oc login
 
 
 Example Playbook


### PR DESCRIPTION
Implements the changes for issue#111 to allow the role `ocp_login` to be called with the environment variables `OCP_SERVER` and `OCP_TOKEN` to be used for the `oc login` command rather than a cluster type specific login.

Also makes changes to the `ocp_login` role to use asserts rather than fail module as per issue#124