### PR TITLE
[patch] Remove double pip install & lock versions

### DIFF
--- a/image/ansible-devops/Dockerfile
+++ b/image/ansible-devops/Dockerfile
@@ -1,9 +1,10 @@
 FROM registry.access.redhat.com/ubi8/python-38
 
-RUN pip install ansible openshift jmespath
+# Running as userId = default
 RUN echo ${HOME}
 
 COPY requirements.yml ${HOME}/requirements.yml
+COPY requirements.txt ${HOME}/requirements.txt
 COPY env.sh ${HOME}/env.sh
 COPY run-playbook.sh ${HOME}/run-playbook.sh
 COPY save-junit-to-mongo.py ${HOME}/save-junit-to-mongo.py
@@ -13,10 +14,12 @@ COPY ibmcloud-oc.sh ${HOME}/ibmcloud-oc.sh
 # TODO: Caio, why do we switch to the root user for the rest of this Dockerfile, and why leave it as root user active at the end?
 USER root
 
-# Install Python modules
-RUN python3 -m pip install junit_xml pymongo xmljson kubernetes==12.0.1 openshift==0.12.1
+# Upgrade pip and install Python modules
+RUN python3 -m pip install --upgrade pip && python3 -m pip install -r requirements.txt
 
 # Install Ansible Collections
+ENV ANSIBLE_CONFIG=/opt/app-root/src/ansible.cfg
+
 COPY ibm-mas_devops.tar.gz ${HOME}/ibm-mas_devops.tar.gz
 RUN ansible-galaxy collection install ${HOME}/ibm-mas_devops.tar.gz -p /opt/app-root/lib64/python3.8/site-packages/ansible_collections --force && \
     ansible-galaxy collection install -r ${HOME}/requirements.yml -p /opt/app-root/lib64/python3.8/site-packages/ansible_collections
@@ -36,5 +39,3 @@ RUN wget -q https://download.clis.cloud.ibm.com/ibm-cloud-cli/2.3.0/IBM_Cloud_CL
     tar -xvzf IBM_Cloud_CLI_2.3.0_amd64.tar.gz && \
     mv Bluemix_CLI/bin/ibmcloud /usr/local/bin/  && \
     rm -rf Bluemix_CLI IBM_Cloud_CLI_2.3.0_amd64.tar.gz
-
-ENV ANSIBLE_CONFIG=/opt/app-root/src/ansible.cfg

--- a/image/ansible-devops/ansible.cfg
+++ b/image/ansible-devops/ansible.cfg
@@ -4,7 +4,12 @@ roles_path = /opt/ansible/roles
 library = /opt/ansible/library
 
 # Record timings per task, and enable junit result file generation
-callback_whitelist = profile_tasks,junit
+# [DEPRECATION WARNING]: [defaults]callback_whitelist option, normalizing names
+# to new standard, use callbacks_enabled instead. This feature will be removed
+# from ansible-core in version 2.15. Deprecation warnings can be disabled by
+# setting deprecation_warnings=False in ansible.cfg.
+# callback_whitelist = profile_tasks,junit
+callbacks_enabled = profile_tasks,junit
 
 # Verbosity: 0 (low) - 7 (high)
 verbosity = 1

--- a/image/ansible-devops/requirements.txt
+++ b/image/ansible-devops/requirements.txt
@@ -1,0 +1,7 @@
+junit_xml==1.9
+pymongo==4.0.2
+xmljson==0.2.1
+ansible==5.5.0
+kubernetes==12.0.1
+openshift==0.12.1
+jmespath==1.0.0


### PR DESCRIPTION
- We have two seperate pip installs for some reason (installing two different versions of openshift python package)
- Also locked all python packages to a set version, so we are not vulnerable to supply chain attacks (all the rage these days)