### PR TITLE
[patch] Fix app upgrade strategy defaulting to Manual

### DIFF
--- a/ibm/mas_devops/playbooks/mas/install-app.yml
+++ b/ibm/mas_devops/playbooks/mas/install-app.yml
@@ -28,8 +28,5 @@
     # MAS application configuration
     mas_app_id: "{{ lookup('env', 'MAS_APP_ID') }}"
 
-    # Determine MAS Operator Upgrade Strategy Manual | Automatic
-    mas_app_upgrade_strategy: "{{ lookup('env', 'MAS_APP_UPGRADE_STRATEGY') | default('Manual', true) }}"
-
   roles:
     - ibm.mas_devops.suite_app_install

--- a/ibm/mas_devops/roles/suite_app_install/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_app_install/defaults/main.yml
@@ -5,3 +5,5 @@ mas_app_channel: 8.x
 
 mas_icr_cp: cp.icr.io/cp
 mas_entitlement_username: cp
+
+mas_app_upgrade_strategy: "{{ lookup('env', 'MAS_APP_UPGRADE_STRATEGY') | default('Automatic', true) }}"


### PR DESCRIPTION
MAS Application upgrade strategy was still set to Manual by default following:
- #205