### PR TITLE
[patch] Pipeline requires empty pipeline-additional-configs

### DIFF
--- a/bin/mas
+++ b/bin/mas
@@ -275,6 +275,10 @@ function run_pipeline() {
   oc delete secret pipeline-sls-entitlement --ignore-not-found=true
 
   # Create new secrets
+  # pipeline-additional-configs must exist (otherwise the suite-install step will hang),
+  # but can be empty if no additional configs are required
+  # TODO: Support passing in files to this secret (--from-file=$MAS_CONFIG_DIR/filename.yaml)
+  oc create secret generic pipeline-additional-configs
   oc create secret generic pipeline-sls-entitlement --from-file=$MAS_CONFIG_DIR/entitlement.lic
 
   # Start pipeline execution


### PR DESCRIPTION
It is not a requirement to provide additional configuration files, however the secret must exist for the pipeline to execute (it can be an empty secret with no data)