### PR TITLE
[patch] Create symlink to playbooks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @durera
+* @durera @whitfiea

--- a/bin/mas
+++ b/bin/mas
@@ -56,7 +56,6 @@ function install_pipeline() {
 }
 
 
-
 # Prepare the pipeline
 # -----------------------------------------------------------------------------
 function config_pipeline() {

--- a/image/ansible-devops/Dockerfile
+++ b/image/ansible-devops/Dockerfile
@@ -39,3 +39,5 @@ RUN wget -q https://download.clis.cloud.ibm.com/ibm-cloud-cli/2.3.0/IBM_Cloud_CL
     tar -xvzf IBM_Cloud_CLI_2.3.0_amd64.tar.gz && \
     mv Bluemix_CLI/bin/ibmcloud /usr/local/bin/  && \
     rm -rf Bluemix_CLI IBM_Cloud_CLI_2.3.0_amd64.tar.gz
+
+RUN ln -s /opt/app-root/lib64/python3.8/site-packages/ansible_collections/ibm/mas_devops/playbooks /opt/app-root/playbooks

--- a/image/ansible-devops/Dockerfile
+++ b/image/ansible-devops/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8/python-38
 
 # Running as userId = default
-RUN echo ${HOME}
+# HOME=/opt/app-root
 
 COPY requirements.yml ${HOME}/requirements.yml
 COPY requirements.txt ${HOME}/requirements.txt
@@ -11,15 +11,13 @@ COPY save-junit-to-mongo.py ${HOME}/save-junit-to-mongo.py
 COPY ansible.cfg ${HOME}/ansible.cfg
 COPY ibmcloud-oc.sh ${HOME}/ibmcloud-oc.sh
 
-# TODO: Caio, why do we switch to the root user for the rest of this Dockerfile, and why leave it as root user active at the end?
+# ----- Switch to root user ---------------------------------------------------
 USER root
 
 # Upgrade pip and install Python modules
 RUN python3 -m pip install --upgrade pip && python3 -m pip install -r requirements.txt
 
 # Install Ansible Collections
-ENV ANSIBLE_CONFIG=/opt/app-root/src/ansible.cfg
-
 COPY ibm-mas_devops.tar.gz ${HOME}/ibm-mas_devops.tar.gz
 RUN ansible-galaxy collection install ${HOME}/ibm-mas_devops.tar.gz -p /opt/app-root/lib64/python3.8/site-packages/ansible_collections --force && \
     ansible-galaxy collection install -r ${HOME}/requirements.yml -p /opt/app-root/lib64/python3.8/site-packages/ansible_collections
@@ -39,5 +37,9 @@ RUN wget -q https://download.clis.cloud.ibm.com/ibm-cloud-cli/2.3.0/IBM_Cloud_CL
     tar -xvzf IBM_Cloud_CLI_2.3.0_amd64.tar.gz && \
     mv Bluemix_CLI/bin/ibmcloud /usr/local/bin/  && \
     rm -rf Bluemix_CLI IBM_Cloud_CLI_2.3.0_amd64.tar.gz
+
+# ----- Switch back to default user ---------------------------------------------------
+USER default
+ENV ANSIBLE_CONFIG=/opt/app-root/src/ansible.cfg
 
 RUN ln -s /opt/app-root/lib64/python3.8/site-packages/ansible_collections/ibm/mas_devops/playbooks /opt/app-root/playbooks

--- a/image/ansible-devops/Dockerfile
+++ b/image/ansible-devops/Dockerfile
@@ -41,8 +41,7 @@ RUN wget -q https://download.clis.cloud.ibm.com/ibm-cloud-cli/2.3.0/IBM_Cloud_CL
     mv Bluemix_CLI/bin/ibmcloud /usr/local/bin/  && \
     rm -rf Bluemix_CLI IBM_Cloud_CLI_2.3.0_amd64.tar.gz
 
-# ----- Switch back to default user ---------------------------------------------------
-USER default
 ENV ANSIBLE_CONFIG=/opt/app-root/src/ansible.cfg
 
 RUN ln -s /opt/app-root/lib64/python3.8/site-packages/ansible_collections/ibm/mas_devops/playbooks /opt/app-root/playbooks
+RUN ln -s /opt/app-root/lib64/python3.8/site-packages/ansible_collections/ibm/mas_devops/roles /opt/app-root/roles

--- a/image/ansible-devops/Dockerfile
+++ b/image/ansible-devops/Dockerfile
@@ -13,6 +13,10 @@ COPY ibmcloud-oc.sh ${HOME}/ibmcloud-oc.sh
 COPY clear-mustgather-workspace.sh ${HOME}/clear-mustgather-workspace.sh
 
 # ----- Switch to root user ---------------------------------------------------
+# If we switch back to the "default" user then mounts in /workspace/xxx are
+# not writeable, there may be a way to fix this so that we don't have to leave
+# the active user as root, haven't looked into this yet.
+
 USER root
 
 # Upgrade pip and install Python modules

--- a/pipelines/tasks/cp4d/create-db2-instance.yaml
+++ b/pipelines/tasks/cp4d/create-db2-instance.yaml
@@ -83,7 +83,7 @@ spec:
     - name: cp4d-create-db2-instance
       command:
         - /opt/app-root/src/run-playbook.sh
-        - /opt/app-root/lib/python3.8/site-packages/ansible_collections/ibm/mas_devops/playbooks/cp4d/create-db2-instance.yml
+        - /opt/app-root/playbooks/cp4d/create-db2-instance.yml
       image: quay.io/ibmmas/ansible-devops:latest
       imagePullPolicy: Always
       workingDir: /workspace/configs

--- a/pipelines/tasks/cp4d/install-services-db2.yaml
+++ b/pipelines/tasks/cp4d/install-services-db2.yaml
@@ -21,7 +21,7 @@ spec:
     - name: cp4d-install-services-db2
       command:
         - /opt/app-root/src/run-playbook.sh
-        - /opt/app-root/lib/python3.8/site-packages/ansible_collections/ibm/mas_devops/playbooks/cp4d/install-services-db2.yml
+        - /opt/app-root/playbooks/cp4d/install-services-db2.yml
       image: quay.io/ibmmas/ansible-devops:latest
       imagePullPolicy: Always
       workingDir: /workspace/configs

--- a/pipelines/tasks/cp4d/install-services-fullstack.yaml
+++ b/pipelines/tasks/cp4d/install-services-fullstack.yaml
@@ -21,7 +21,7 @@ spec:
     - name: cp4d-install-services-fullstack
       command:
         - /opt/app-root/src/run-playbook.sh
-        - /opt/app-root/lib/python3.8/site-packages/ansible_collections/ibm/mas_devops/playbooks/cp4d/install-services-fullstack.yml
+        - /opt/app-root/playbooks/cp4d/install-services-fullstack.yml
       image: quay.io/ibmmas/ansible-devops:latest
       imagePullPolicy: Always
       workingDir: /workspace/configs

--- a/pipelines/tasks/cp4d/install-services-watsonstudio.yaml
+++ b/pipelines/tasks/cp4d/install-services-watsonstudio.yaml
@@ -21,7 +21,7 @@ spec:
     - name: cp4d-install-services-watsonstudio
       command:
         - /opt/app-root/src/run-playbook.sh
-        - /opt/app-root/lib/python3.8/site-packages/ansible_collections/ibm/mas_devops/playbooks/cp4d/install-services-watsonstudio.yml
+        - /opt/app-root/playbooks/cp4d/install-services-watsonstudio.yml
       image: quay.io/ibmmas/ansible-devops:latest
       imagePullPolicy: Always
       workingDir: /workspace/configs

--- a/pipelines/tasks/dependencies/install-amqstreams.yaml
+++ b/pipelines/tasks/dependencies/install-amqstreams.yaml
@@ -21,7 +21,7 @@ spec:
     - name: install-amqstreams
       command:
         - /opt/app-root/src/run-playbook.sh
-        - /opt/app-root/lib/python3.8/site-packages/ansible_collections/ibm/mas_devops/playbooks/dependencies/install-amqstreams.yml
+        - /opt/app-root/playbooks/dependencies/install-amqstreams.yml
       image: quay.io/ibmmas/ansible-devops:latest
       imagePullPolicy: Always
       workingDir: /workspace/configs

--- a/pipelines/tasks/dependencies/install-mongodb-ce.yaml
+++ b/pipelines/tasks/dependencies/install-mongodb-ce.yaml
@@ -21,7 +21,7 @@ spec:
     - name: install-mongodb-ce
       command:
         - /opt/app-root/src/run-playbook.sh
-        - /opt/app-root/lib/python3.8/site-packages/ansible_collections/ibm/mas_devops/playbooks/dependencies/install-mongodb-ce.yml
+        - /opt/app-root/playbooks/dependencies/install-mongodb-ce.yml
       image: quay.io/ibmmas/ansible-devops:latest
       imagePullPolicy: Always
       workingDir: /workspace/configs

--- a/pipelines/tasks/dependencies/install-sls.yaml
+++ b/pipelines/tasks/dependencies/install-sls.yaml
@@ -21,7 +21,7 @@ spec:
     - name: install-sls
       command:
         - /opt/app-root/src/run-playbook.sh
-        - /opt/app-root/lib/python3.8/site-packages/ansible_collections/ibm/mas_devops/playbooks/dependencies/install-sls.yml
+        - /opt/app-root/playbooks/dependencies/install-sls.yml
       image: quay.io/ibmmas/ansible-devops:latest
       imagePullPolicy: Always
       workingDir: /workspace/configs

--- a/pipelines/tasks/dependencies/install-uds.yaml
+++ b/pipelines/tasks/dependencies/install-uds.yaml
@@ -21,7 +21,7 @@ spec:
     - name: install-uds
       command:
         - /opt/app-root/src/run-playbook.sh
-        - /opt/app-root/lib/python3.8/site-packages/ansible_collections/ibm/mas_devops/playbooks/dependencies/install-uds.yml
+        - /opt/app-root/playbooks/dependencies/install-uds.yml
       image: quay.io/ibmmas/ansible-devops:latest
       imagePullPolicy: Always
       workingDir: /workspace/configs

--- a/pipelines/tasks/mas/configure-app.yaml
+++ b/pipelines/tasks/mas/configure-app.yaml
@@ -36,7 +36,7 @@ spec:
     - name: configure-app
       command:
         - /opt/app-root/src/run-playbook.sh
-        - /opt/app-root/lib/python3.8/site-packages/ansible_collections/ibm/mas_devops/playbooks/mas/configure-app.yml
+        - /opt/app-root/playbooks/mas/configure-app.yml
       image: quay.io/ibmmas/ansible-devops:latest
       imagePullPolicy: Always
       workingDir: /workspace/configs

--- a/pipelines/tasks/mas/configure-suite.yaml
+++ b/pipelines/tasks/mas/configure-suite.yaml
@@ -21,7 +21,7 @@ spec:
     - name: configure-suite
       command:
         - /opt/app-root/src/run-playbook.sh
-        - /opt/app-root/lib/python3.8/site-packages/ansible_collections/ibm/mas_devops/playbooks/mas/configure-suite.yml
+        - /opt/app-root/playbooks/mas/configure-suite.yml
       image: quay.io/ibmmas/ansible-devops:latest
       imagePullPolicy: Always
       workingDir: /workspace/configs

--- a/pipelines/tasks/mas/gencfg-workspace.yaml
+++ b/pipelines/tasks/mas/gencfg-workspace.yaml
@@ -31,7 +31,7 @@ spec:
     - name: gencfg-workspace
       command:
         - /opt/app-root/src/run-playbook.sh
-        - /opt/app-root/lib/python3.8/site-packages/ansible_collections/ibm/mas_devops/playbooks/mas/gencfg-workspace.yml
+        - /opt/app-root/playbooks/mas/gencfg-workspace.yml
       image: quay.io/ibmmas/ansible-devops:latest
       imagePullPolicy: Always
       workingDir: /workspace/configs

--- a/pipelines/tasks/mas/hack-manage-db2.yaml
+++ b/pipelines/tasks/mas/hack-manage-db2.yaml
@@ -25,7 +25,7 @@ spec:
     - name: hack-manage-db2
       command:
         - /opt/app-root/src/run-playbook.sh
-        - /opt/app-root/lib/python3.8/site-packages/ansible_collections/ibm/mas_devops/playbooks/mas/hack-manage-db2.yml
+        - /opt/app-root/playbooks/mas/hack-manage-db2.yml
       image: quay.io/ibmmas/ansible-devops:latest
       imagePullPolicy: Always
       workingDir: /workspace/configs

--- a/pipelines/tasks/mas/install-app.yaml
+++ b/pipelines/tasks/mas/install-app.yaml
@@ -38,7 +38,7 @@ spec:
     - name: install-app
       command:
         - /opt/app-root/src/run-playbook.sh
-        - /opt/app-root/lib/python3.8/site-packages/ansible_collections/ibm/mas_devops/playbooks/mas/install-app.yml
+        - /opt/app-root/playbooks/mas/install-app.yml
       image: quay.io/ibmmas/ansible-devops:latest
       imagePullPolicy: Always
       workingDir: /workspace/configs

--- a/pipelines/tasks/mas/install-suite.yaml
+++ b/pipelines/tasks/mas/install-suite.yaml
@@ -21,7 +21,7 @@ spec:
     - name: install-suite
       command:
         - /opt/app-root/src/run-playbook.sh
-        - /opt/app-root/lib/python3.8/site-packages/ansible_collections/ibm/mas_devops/playbooks/mas/install-suite.yml
+        - /opt/app-root/playbooks/mas/install-suite.yml
       image: quay.io/ibmmas/ansible-devops:latest
       imagePullPolicy: Always
       workingDir: /workspace/configs

--- a/pipelines/tasks/mas/mustgather.yaml
+++ b/pipelines/tasks/mas/mustgather.yaml
@@ -25,7 +25,7 @@ spec:
     - name: mustgather
       command:
         - /opt/app-root/src/run-playbook.sh
-        - /opt/app-root/lib/python3.8/site-packages/ansible_collections/ibm/mas_devops/playbooks/mas/mustgather.yml
+        - /opt/app-root/playbooks/mas/mustgather.yml
       image: quay.io/ibmmas/ansible-devops:latest
       imagePullPolicy: Always
       workingDir: /workspace/mustgather

--- a/pipelines/tasks/ocp/configure-ocp.yaml
+++ b/pipelines/tasks/ocp/configure-ocp.yaml
@@ -21,7 +21,7 @@ spec:
     - name: configure-ocp
       command:
         - /opt/app-root/src/run-playbook.sh
-        - /opt/app-root/lib/python3.8/site-packages/ansible_collections/ibm/mas_devops/playbooks/ocp/configure-ocp.yml
+        - /opt/app-root/playbooks/ocp/configure-ocp.yml
       image: quay.io/ibmmas/ansible-devops:latest
       imagePullPolicy: Always
       workingDir: /workspace/configs


### PR DESCRIPTION
The playbooks are buried in Python's site-packages, create a symlink in the default directory.

- Update ClusterTasks to use the new simpler path /opt/apt-root/playbooks
- Add @whitfiea as codeowner for signoff to master branch privileges