### PR TITLE
[patch] Add missing gencfg_jdbc doc

### DIFF
--- a/build/bin/copy-role-docs.sh
+++ b/build/bin/copy-role-docs.sh
@@ -24,6 +24,7 @@ copyDoc cp4d_install_services
 copyDoc db2u
 copyDoc gencfg_sls
 copyDoc gencfg_workspace
+copyDoc gencfg_jdbc
 copyDoc gpu_install
 copyDoc install_operator
 copyDoc mongodb

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
     - 'cp4d_install_services': roles/cp4d_install_services.md
     - 'db2u': roles/db2u.md
     - 'gencfg_sls': roles/gencfg_sls.md
+    - 'gencfg_sls': roles/gencfg_jdbc.md
     - 'gencfg_workspace': roles/gencfg_workspace.md
     - 'install_operator': roles/install_operator.md
     - 'mongodb': roles/mongodb.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,7 +34,7 @@ nav:
     - 'cp4d_install_services': roles/cp4d_install_services.md
     - 'db2u': roles/db2u.md
     - 'gencfg_sls': roles/gencfg_sls.md
-    - 'gencfg_sls': roles/gencfg_jdbc.md
+    - 'gencfg_jdbc': roles/gencfg_jdbc.md
     - 'gencfg_workspace': roles/gencfg_workspace.md
     - 'install_operator': roles/install_operator.md
     - 'mongodb': roles/mongodb.md


### PR DESCRIPTION
The role documentation for `gencfg_jdbc ` was missing from the original PR.