### PR TITLE
[patch] Fix breaking change in #187

### DIFF
--- a/bin/mas-ansible.sh
+++ b/bin/mas-ansible.sh
@@ -172,6 +172,7 @@ fi
 PLAYBOOK=$1
 if [[ -z "$PLAYBOOK" ]]; then
   echo "Enter the name of a playbook to run:"
+  echo " - ocp/provision"
   echo " - fullstack-roks"
   echo " - lite-core-roks"
   echo " - lite-iot-roks"

--- a/ibm/mas_devops/playbooks/cp4d/hack-worker-nodes.yml
+++ b/ibm/mas_devops/playbooks/cp4d/hack-worker-nodes.yml
@@ -1,6 +1,10 @@
 ---
 - hosts: localhost
   any_errors_fatal: true
+  vars:
+    # This playbook is only valid for ROKS clusters, it's a quirk of ROKS
+    # and CP4D v4 that we need to do this :(
+    cluster_type: roks
   roles:
     - ibm.mas_devops.ocp_login
     - ibm.mas_devops.cp4d_hack_worker_nodes

--- a/ibm/mas_devops/roles/ocp_setup_mas_deps/README.md
+++ b/ibm/mas_devops/roles/ocp_setup_mas_deps/README.md
@@ -15,6 +15,12 @@ For MAS 8.6 or earlier (or when running MAS 8.7 on OCP 4.6) Service Binding Oper
 
 Role Variables
 --------------
+### ocp_disable_upgrade
+Set this to `true` to instruct the role to disable automatic OCP upgrades in the cluster.
+
+- Environment Variable: None
+- Default Value: `false`
+
 ### artifactory_username
 Use to enable the install of development catalog sources for pre-release installation.
 

--- a/ibm/mas_devops/roles/ocp_setup_mas_deps/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_setup_mas_deps/defaults/main.yml
@@ -1,7 +1,11 @@
 ---
 airgap_install: false
 
+# --- OCP settings ----------------------------------------------------------------------------------------------------
 cluster_type: "{{ lookup('env', 'CLUSTER_TYPE') }}"
+
+# Set this to true to disable upgrade in the cluster (role will overwrite the ClusterVersion resource)
+ocp_disable_upgrade: false
 
 # --- Dev catalog settings --------------------------------------------------------------------------------------------
 # Only required when using the development catalog sources for pre-release installation

--- a/ibm/mas_devops/roles/ocp_setup_mas_deps/tasks/certmanager/foundation-services.yml
+++ b/ibm/mas_devops/roles/ocp_setup_mas_deps/tasks/certmanager/foundation-services.yml
@@ -3,32 +3,6 @@
 
 # This will result in the following operators being installed in the ibm-common-services namespace
 # - IBM Cert Manager
-# - IBM Cloud Pak Foundational Services
-# - IBM NamespaceScope Operator
-# - Operand Deployment Lifecycle Manager
-
-- name: Check if operator group is present
-  k8s_info:
-    namespace: ibm-common-services
-    kind: OperatorGroup
-  register: og_info
-
-- name: Install Cert Manager (Foundation Services version)
-  kubernetes.core.k8s:
-    definition: "{{ lookup('template', 'templates/foundation-services/subscription.j2') }}"
-    wait: yes
-    wait_timeout: 120
-
-- name: "Wait for Foundation Services resources to be ready (60s delay)"
-  kubernetes.core.k8s_info:
-    api_version: apps/v1
-    name: operand-deployment-lifecycle-manager
-    namespace: ibm-common-services
-    kind: Deployment
-  register: _operand_deployment
-  until: _operand_deployment.resources[0].status.availableReplicas is defined
-  retries: 90 # Approximately 10 minutes before we give up
-  delay: 60 # 1 minute
 
 - name: Install Foundation Services ibm-cert-manager operand request
   kubernetes.core.k8s:
@@ -46,6 +20,7 @@
   until: _certmanager_deployment.resources[0].status.availableReplicas is defined
   retries: 90 # Approximately 10 minutes before we give up
   delay: 60 # 1 minute
+
 
 - name: "Wait for ibm-cert-manager operator webhook deployment to be ready (60s delay)"
   kubernetes.core.k8s_info:

--- a/ibm/mas_devops/roles/ocp_setup_mas_deps/tasks/disable-ocp-upgrade.yml
+++ b/ibm/mas_devops/roles/ocp_setup_mas_deps/tasks/disable-ocp-upgrade.yml
@@ -1,0 +1,24 @@
+---
+
+# 1. Getting cluster version details
+# -----------------------------------------------------------------------------
+- name: "Get ocp cluster version details "
+  k8s_info:
+    kind: ClusterVersion
+    name: version
+  register: cluster_details
+
+- name: Print cluster id
+  debug:
+    msg: "clusterID : {{ cluster_details.resources[0].spec.clusterID }}"
+
+# 2. Apply (with force) the ClusterVersion resource
+# -----------------------------------------------------------------------------
+- name: Set Cluster Version Definition
+  vars:
+    cluster_id: "{{ cluster_details.resources[0].spec.clusterID }}"
+  kubernetes.core.k8s:
+    apply: yes
+    force: yes
+    state: present
+    definition: "{{ lookup('template', 'templates/cluster-version.yml') }}"

--- a/ibm/mas_devops/roles/ocp_setup_mas_deps/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_setup_mas_deps/tasks/main.yml
@@ -55,33 +55,13 @@
       - "OCP Install Version ................ {{ ocp_install_version }}"
       - "OCP Install Release ................ {{ ocp_install_release }}"
 
-#Getting cluster version details
-- name: "Get ocp cluster version details "
-  k8s_info:
-    kind: ClusterVersion
-    name: version
-  register: cluster_details
-#Print cluster id
-- name: Print cluster id
-  debug:
-    msg: "clusterID : {{ cluster_details.resources[0].spec.clusterID }}"
-
-#Task to avoid automatic upgrades of OCP cluster
-#Removed desiredUpdate, updatechannel
-- name: Set Cluster Version Definition
-  vars:
-    cluster_id: "{{ cluster_details.resources[0].spec.clusterID }}"
-  kubernetes.core.k8s:
-    apply: yes
-    force: yes
-    state: present
-    definition: "{{ lookup('template', 'templates/cluster-version.yml') }}"
 
 # 1. Install IBM catalogs
 # -----------------------------------------------------------------------------
 - name: "Create IBM catalogs"
   kubernetes.core.k8s:
     definition: "{{ lookup('template', 'templates/ibm-catalogs.yml') }}"
+
 
 # 2. Install development (pre-release) catalogs
 # -----------------------------------------------------------------------------
@@ -93,6 +73,7 @@
     - artifactory_apikey != ""
     - not airgap_install
   include_tasks: "tasks/development-catalogs.yml"
+
 
 # 3. Install Foundation Services
 # -----------------------------------------------------------------------------
@@ -118,6 +99,7 @@
   retries: 90 # Approximately 10 minutes before we give up
   delay: 60 # 1 minute
 
+
 # 4. Install cert-manager
 # -----------------------------------------------------------------------------
 - name: Check if Cert Manager is already installed
@@ -142,6 +124,7 @@
     - (_cert_manager_deployed.resources | length) == 0
     - not airgap_install
 
+
 # 5. Install Service Binding Operator
 # -----------------------------------------------------------------------------
 # Install stable channel with automatic updates if MAS 8.7+, otherwise, install preview channel locked to v0.8
@@ -155,6 +138,7 @@
 - include_tasks: "tasks/sbo/{{ sbo_channel }}.yml"
   when:
     - not airgap_install
+
 
 # 6. Update openshift monitoring to define a specific storage class for Prometheus logs
 # -------------------------------------------------------------------------------------
@@ -171,6 +155,7 @@
     wait: yes
     wait_timeout: 120
 
+
 # 7. Increase cluster image registry from defautl 100Gi to 400Gi (cp4d images consume lot of space)
 # -------------------------------------------------------------------------------------
 - name: "Increase cluster image registry"
@@ -180,3 +165,9 @@
 
 - name: Debug Image Registry Volume order request
   debug: msg="{{ result }}"
+
+# 8. Disable OCP Upgrade
+# -----------------------------------------------------------------------------
+- name: "Disable OCP Upgrade"
+  include_tasks: "tasks/disable-ocp-upgrade.yml"
+  when: ocp_disable_upgrade == true

--- a/ibm/mas_devops/roles/ocp_setup_mas_deps/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_setup_mas_deps/tasks/main.yml
@@ -81,6 +81,14 @@
 # - IBM Cloud Pak Foundational Services
 # - IBM NamespaceScope Operator
 # - Operand Deployment Lifecycle Manager
+#
+# Also, an operator group will be created in the namespace if one does not already exist
+
+- name: Check if operator group is present in ibm-common-services already
+  k8s_info:
+    namespace: ibm-common-services
+    kind: OperatorGroup
+  register: og_info
 
 - name: "Install Foundation Services"
   kubernetes.core.k8s:

--- a/pipelines/samples/sample-pipeline.yaml
+++ b/pipelines/samples/sample-pipeline.yaml
@@ -626,6 +626,7 @@ spec:
           values: [""]
       runAfter:
         - cfg-manage
+        - cfg-monitor
       workspaces:
         - name: settings
           workspace: shared-settings

--- a/pipelines/samples/sample-pipeline.yaml
+++ b/pipelines/samples/sample-pipeline.yaml
@@ -176,6 +176,8 @@ spec:
       taskRef:
         kind: ClusterTask
         name: mas-devops-install-mongodb-ce
+      runAfter:
+        - cfg-ocp
       workspaces:
         - name: configs
           workspace: shared-configs


### PR DESCRIPTION
- Looks like a really bad merge in #187.  Foundation services install was moved into main, but has been restored to the cert-manager sub-task in that PR.
- Also, makes the modification to `ClusterVersion` controllable via a new parameter `ocp_disable_upgrade`, which defaults to false.
- Also, moves predict into a layer 3 in the pipeline so that it installs after both Monitor and Manage have installed.