### PR TITLE
[patch] BasCfg CR name has to be {inst}-bas-system

### DIFF
--- a/ibm/mas_devops/roles/gencfg_uds/templates/bascfg.yml.j2
+++ b/ibm/mas_devops/roles/gencfg_uds/templates/bascfg.yml.j2
@@ -12,7 +12,7 @@ stringData:
 apiVersion: config.mas.ibm.com/v1
 kind: BasCfg
 metadata:
-  name: "{{ mas_instance_id }}-uds-system"
+  name: "{{ mas_instance_id }}-bas-system"
   namespace: "mas-{{ mas_instance_id }}-core"
   labels:
     mas.ibm.com/configScope: system


### PR DESCRIPTION
The gencfg_uds role was incorrectly creating a CR that had the name {{ instance }}-uds-system but the monagent-mas within MAS is explicitly looking for {inst}-bas-system. As it doesn't find it then the suite CR is updated to say it has failed to integrate with BAS.