### PR TITLE
[patch] Fixes indexerror in save-to-junit script + change to use kubernetes.core

### DIFF
--- a/ibm/mas_devops/roles/cp4d_install_services/tasks/main.yml
+++ b/ibm/mas_devops/roles/cp4d_install_services/tasks/main.yml
@@ -42,7 +42,7 @@
 # 3. Provide CP4D dashboard URL
 # -----------------------------------------------------------------------------
 - name: "Obtain CP4D dashboard URL"
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     kind: Route
     label_selectors: component=ibm-nginx

--- a/ibm/mas_devops/roles/cp4d_install_services/tasks/watsonstudiocfg.yml
+++ b/ibm/mas_devops/roles/cp4d_install_services/tasks/watsonstudiocfg.yml
@@ -6,7 +6,7 @@
 # 1. Provide CP4D credentials
 # -----------------------------------------------------------------------------
 - name: Retrieve CPD admin credentials
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     name: admin-user-details
     namespace: "{{ cpd_services_namespace }}"

--- a/ibm/mas_devops/roles/db2u/tasks/main.yml
+++ b/ibm/mas_devops/roles/db2u/tasks/main.yml
@@ -76,7 +76,7 @@
 # 3. Get the cluster subdomain to be used for the certificate and route creation
 # -----------------------------------------------------------------------------
 - name: "Get cluster subdomain"
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: config.openshift.io/v1
     kind: Ingress
     name: cluster
@@ -86,13 +86,13 @@
 # 4. Create self-signed certificate for Db2u SSL
 # -----------------------------------------------------------------------------
 - name: "Create internal CA certificate issuer"
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     apply: yes
     definition: "{{ lookup('template', 'templates/certs/ca_issuer.yml.j2') }}"
   register: createCaIssuer
 
 - name: "Create and wait for CA certificate"
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     apply: yes
     definition: "{{ lookup('template', 'templates/certs/ca_certificate.yml.j2') }}"
     wait: yes
@@ -103,13 +103,13 @@
   register: createCaCert
 
 - name: "Create certificate issuer"
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     apply: yes
     definition: "{{ lookup('template', 'templates/certs/issuer.yml.j2') }}"
   register: createIssuer
 
 - name: "Create db2u certificate"
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     apply: yes
     definition: "{{ lookup('template', 'templates/certs/certificate.yml.j2') }}"
   register: createCertificate
@@ -129,13 +129,13 @@
 # 6. Create a Db2 instance
 # -----------------------------------------------------------------------------
 - name: "Create db2 instance"
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     apply: yes
     definition: "{{ lookup('template', 'templates/db2ucluster.yml.j2') }}"
 
 # Wait for the cluster to be ready
 - name: "Wait for db2u instance to be ready (5m delay)"
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: db2u.databases.ibm.com/v1
     name: "{{ db2u_instance_name | lower }}"
     namespace: "{{db2u_namespace}}"
@@ -153,7 +153,7 @@
 # 7. Configure a public route for Db2
 # -----------------------------------------------------------------------------
 - name: Lookup db2u Engn Service
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     kind: Service
     name: "c-{{db2u_instance_name | lower}}-db2u-engn-svc"
@@ -165,7 +165,7 @@
   delay: 20
 
 - name: Lookup db2u TLS certificates
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     kind: Secret
     name: "db2u-certificate"
@@ -189,7 +189,7 @@
     "{{_db2u_instance_engn_svc.resources[0].spec.ports}}"
 
 - name: "Create Db2u route"
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     apply: yes
     definition: "{{ lookup('template', 'templates/tlsroute.yml.j2') }}"
 

--- a/ibm/mas_devops/roles/db2u/tasks/suite_jdbccfg.yml
+++ b/ibm/mas_devops/roles/db2u/tasks/suite_jdbccfg.yml
@@ -8,7 +8,7 @@
   include_vars: "vars/jdbccfg/{{ mas_config_scope }}.yml"
 
 - name: Lookup db2u instance password
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     kind: Secret
     name: "c-{{db2u_instance_name | lower }}-instancepassword"

--- a/ibm/mas_devops/roles/suite_app_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/main.yml
@@ -62,7 +62,7 @@
 - name: Lookup and Approve MAS Subscription
   block:
     - name: Lookup and Approve Operator install plan
-      community.kubernetes.k8s_info:
+      kubernetes.core.k8s_info:
         api_version: operators.coreos.com/v1alpha1
         kind: InstallPlan
         namespace: "{{ mas_app_namespace }}"
@@ -76,7 +76,7 @@
     - name: Approve the install plan for MAS Application
       when:
         - mas_app_installplan_info.resources[0].status.phase != "Complete"
-      community.kubernetes.k8s:
+      kubernetes.core.k8s:
         definition:
           apiVersion: operators.coreos.com/v1alpha1
           kind: InstallPlan

--- a/ibm/mas_devops/roles/suite_install/tasks/ibm-common-services.yml
+++ b/ibm/mas_devops/roles/suite_install/tasks/ibm-common-services.yml
@@ -5,7 +5,7 @@
     msg: "{{item}}"
 
 - name: "Verify if ibm operator is already installed"
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
     kind: Subscription
     namespace: "{{ ibm_common_services_namespace }}"
@@ -16,7 +16,7 @@
 - name: Lookup and Approve IBM Common Services operators
   block:
     - name: "Lookup and wait for Operator subscription to exist"
-      community.kubernetes.k8s_info:
+      kubernetes.core.k8s_info:
         api_version: operators.coreos.com/v1alpha1
         kind: Subscription
         namespace: "{{ ibm_common_services_namespace }}"
@@ -28,7 +28,7 @@
       until: _item_subscription_result.resources | length > 0
 
     - name: Lookup Operator install plan
-      community.kubernetes.k8s_info:
+      kubernetes.core.k8s_info:
         api_version: operators.coreos.com/v1alpha1
         kind: InstallPlan
         namespace: "{{ ibm_common_services_namespace }}"
@@ -50,7 +50,7 @@
         - item_install_plan.resources | length > 0
         - item_install_plan.resources[0].status is defined
         - item_install_plan.resources[0].status.phase != "Complete"
-      community.kubernetes.k8s:
+      kubernetes.core.k8s:
         definition:
           apiVersion: operators.coreos.com/v1alpha1
           kind: InstallPlan

--- a/ibm/mas_devops/roles/suite_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_install/tasks/main.yml
@@ -55,7 +55,7 @@
 - name: Lookup and Approve MAS Subscription
   block:
     - name: Lookup Operator install plan
-      community.kubernetes.k8s_info:
+      kubernetes.core.k8s_info:
         api_version: operators.coreos.com/v1alpha1
         kind: InstallPlan
         namespace: "{{ mas_namespace }}"
@@ -70,7 +70,7 @@
       when:
         - mas_install_plan.resources | length > 0
         - mas_install_plan.resources[0].status.phase != "Complete"
-      community.kubernetes.k8s:
+      kubernetes.core.k8s:
         definition:
           apiVersion: operators.coreos.com/v1alpha1
           kind: InstallPlan

--- a/image/ansible-devops/save-junit-to-mongo.py
+++ b/image/ansible-devops/save-junit-to-mongo.py
@@ -46,17 +46,6 @@ if __name__ == "__main__":
 
         root = tree.getroot()
 
-#####
-        bf = Yahoo(dict_type=dict)
-        resultDoc = bf.data(root)
-
-        for testcase in resultDoc["testsuites"]["testsuite"]["testcase"]:
-            print(testcase)
-            print(testcase["name"])
-            print(testcase["classname"])
-            testcase["name"] = testcase["name"].replace("[localhost] localhost: ", "")
-            testcase["classname"] = testcase["classname"].split("ibm/mas_devops/")[1]
-#####
         if "DEVOPS_MONGO_URI" in os.environ and os.environ['DEVOPS_MONGO_URI'] != "":
             # Convert junit xml to json
             bf = Yahoo(dict_type=dict)
@@ -64,7 +53,8 @@ if __name__ == "__main__":
 
             for testcase in resultDoc["testsuites"]["testsuite"]["testcase"]:
                 testcase["name"] = testcase["name"].replace("[localhost] localhost: ", "")
-                testcase["classname"] = testcase["classname"].split("ibm/mas_devops/")[1]
+                if "/opt/app-root/" in testcase["classname"]:
+                    testcase["classname"] = testcase["classname"].split("/opt/app-root/")[1]
             # Enrich document
             resultDoc["_id"] = resultId
             resultDoc["build"] = build

--- a/image/ansible-devops/save-junit-to-mongo.py
+++ b/image/ansible-devops/save-junit-to-mongo.py
@@ -53,8 +53,13 @@ if __name__ == "__main__":
 
             for testcase in resultDoc["testsuites"]["testsuite"]["testcase"]:
                 testcase["name"] = testcase["name"].replace("[localhost] localhost: ", "")
+                # Playbooks don't have ibm/mas_devops in the classnmae but do have /opt/app-root.
+                # Roles have both ibm/mas_devops and /opt/app-root. 
+                # Guard against both and remove when required.
                 if "/opt/app-root/" in testcase["classname"]:
                     testcase["classname"] = testcase["classname"].split("/opt/app-root/")[1]
+                if "ibm/mas_devops/" in testcase["classname"]:
+                    testcase["classname"] = testcase["classname"].split("ibm/mas_devops/")[1]
             # Enrich document
             resultDoc["_id"] = resultId
             resultDoc["build"] = build

--- a/image/ansible-devops/save-junit-to-mongo.py
+++ b/image/ansible-devops/save-junit-to-mongo.py
@@ -46,6 +46,17 @@ if __name__ == "__main__":
 
         root = tree.getroot()
 
+#####
+        bf = Yahoo(dict_type=dict)
+        resultDoc = bf.data(root)
+
+        for testcase in resultDoc["testsuites"]["testsuite"]["testcase"]:
+            print(testcase)
+            print(testcase["name"])
+            print(testcase["classname"])
+            testcase["name"] = testcase["name"].replace("[localhost] localhost: ", "")
+            testcase["classname"] = testcase["classname"].split("ibm/mas_devops/")[1]
+#####
         if "DEVOPS_MONGO_URI" in os.environ and os.environ['DEVOPS_MONGO_URI'] != "":
             # Convert junit xml to json
             bf = Yahoo(dict_type=dict)

--- a/pipelines/samples/sample-pipelinesettings-roks.yaml
+++ b/pipelines/samples/sample-pipelinesettings-roks.yaml
@@ -67,6 +67,7 @@ stringData:
   SLS_ICR_CPOPEN: "$SLS_ICR_CPOPEN"
   SLS_ENTITLEMENT_USERNAME: "$SLS_ENTITLEMENT_USERNAME"
   SLS_ENTITLEMENT_KEY: "$SLS_ENTITLEMENT_KEY"
+  SLS_LICENSE_FILE: "/workspace/entitlement/entitlement.lic"
 
   # -------------------------
   # dependencies/install-uds.yml

--- a/pipelines/samples/sample-pipelinesettings.yaml
+++ b/pipelines/samples/sample-pipelinesettings.yaml
@@ -77,6 +77,7 @@ stringData:
   SLS_MONGODB_CFG_FILE: "/workspace/configs/mongo-mongoce.yml"
   SLS_COMPLIANCE_ENFORCE: ""
   SLS_LICENSE_ID: ""
+  SLS_LICENSE_FILE: ""
   SLS_STORAGE_CLASS: "<REQUIRED: enter a storage class>"
   SLS_CATALOG_SOURCE: ""
   SLS_CHANNEL: ""


### PR DESCRIPTION
Fixes the IndexError seen in issue #245 caused by the fact that the testcase classname doesn't have ibm_mas/devops in the name for playbooks (it does for roles). The code now checks for the existence of the strong before chopping it. It also chops the playbook name so we end up with testcase classnames like the following for playbooks and roles:

![image](https://user-images.githubusercontent.com/6817894/162921837-3a87f030-f2bc-43da-bb38-97036c980105.png)

This PR also changes the few places that still used the deprecated community.kubernetes module and changes to use kubernetes.core as per issue #250 

Final change was to add SLS_LICENSE_FILE to the sample pipeline settings as this is now required when bootstrapping.  

Tested in pipeline and manually set "TRAVIS_BUILD_NUMBER" and "DEVOPS_MONGO_URI" to push test results to mongo. Also ran pipeline against changed roles that changed to the kubernetes.core module.