### PR TITLE
[minor] Set AIO install to True on the ManageWorkspace

### DIFF
--- a/ibm/mas_devops/roles/suite_app_configure/vars/defaultspecs/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_configure/vars/defaultspecs/manage.yml
@@ -5,6 +5,8 @@ mas_app_ws_spec:
     jdbc: "{{ mas_appws_jdbc_binding | default( 'system' , true) }}"
   components: "{{ mas_appws_components | default(omit, true) }}"
   settings:
+    aio:
+      install: true
     db:
       dbSchema: "{{ db2_schema }}"
       maxinst:


### PR DESCRIPTION
Sets AIO to true in the Manage CR so that it can be configured if Health and MSO and installed. https://github.com/ibm-mas/ansible-devops/issues/264