### PR TITLE
[patch] Fix defaults for MAS_APPWS_COMPONENTS and update changelogs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,14 +7,14 @@ Note that during a build the version of the ansible collection is automatically 
 ```bash
 cd ibm/mas_devops
 
-ansible-galaxy collection build --force && ansible-galaxy collection install ibm-mas_devops-7.0.0.tar.gz --force
+ansible-galaxy collection build --force && ansible-galaxy collection install ibm-mas_devops-9.0.0.tar.gz --force
 
 ansible-playbook ../../playbook.yml
 ```
 
 ```bash
 ansible-galaxy collection build --force
-ansible-galaxy collection publish ibm-mas_devops-7.0.0.tar.gz --token=$ANSIBLE_GALAXY_TOKEN
+ansible-galaxy collection publish ibm-mas_devops-9.0.0.tar.gz --token=$ANSIBLE_GALAXY_TOKEN
 ```
 
 ## Style Guide

--- a/bin/mas-ansible.sh
+++ b/bin/mas-ansible.sh
@@ -159,7 +159,7 @@ function install_dependencies_ubuntu() {
 
 function build_and_install_local() {
   ansible-galaxy collection build $DIR/../ibm/mas_devops --force
-  ansible-galaxy collection install $DIR/../ibm-mas_devops-7.0.0.tar.gz --force
+  ansible-galaxy collection install $DIR/../ibm-mas_devops-9.0.0.tar.gz --force
 }
 
 set_target_roks

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,9 +51,14 @@ ansible-galaxy collection install ibm.mas_devops
 ## Change Log
 Note that links to pull requests prior to public release of the code (4.0) direct to IBM GitHub Enterprise, and will only be accessible to IBM employees.
 
-- `7.1` Multiple Updates:
+- `8.0` Multiple Updates:
     - Create secure route to CP4D web client when setting up DNS using CIS and suite_dns role ([#251](https://github.com/ibm-mas/ansible-devops/pull/251))
     - Configure azurefiles storage class for multi-cloud ([#260](https://github.com/ibm-mas/ansible-devops/pull/260))
+    - Create secure route to CP4D web client when setting up DNS using CIS and suite_dns role ([#251](https://github.com/ibm-mas/ansible-devops/pull/251))
+    - Configure azurefiles storage class for multi-cloud ([#260](https://github.com/ibm-mas/ansible-devops/pull/260))
+    - SMTP email support for Azure and other changes ([#265](https://github.com/ibm-mas/ansible-devops/pull/265))
+    - Add cp4d_wds role for discovery instance provison ([#234](https://github.com/ibm-mas/ansible-devops/pull/234))
+    - Change MAS_APPWS_COMPONENTS variable format ([#267](https://github.com/ibm-mas/ansible-devops/pull/267))
 - `7.0` Mulitple Updates:
     - Consolidate cluster specific provision/deprovision playbooks ([#236](https://github.com/ibm-mas/ansible-devops/pull/236))
     - Fix SLS bootstrap and update docs ([#242](https://github.com/ibm-mas/ansible-devops/pull/242))

--- a/docs/playbooks/fullstack-roks.md
+++ b/docs/playbooks/fullstack-roks.md
@@ -40,7 +40,7 @@ All timings are estimates, see the individual pages for each of these playbooks 
 Before you run the playbook you need to configure a few things in your `MAS_CONFIG_DIR`:
 
 ### Copy your entitlement license key file
-Copy the MAS license key file that you obtained from Rational License Key Server to `$MAS_CONFIG_DIR/entitlement.lic` (the file must have this exact name).  During the installation of SLS this license file will be automatically bootstrapped into the system.
+Copy the MAS license key file that you obtained from Rational License Key Server to a local path and set `SLS_LICENSE_FILE` to point to this file location. During the installation of SLS this license file will be automatically bootstrapped into the system.
 
 !!! important
     Make sure you set `SLS_LICENSE_ID` to the correct value.  For full details on what configuration options are available with the SLS install refer to the [Install SLS](dependencies.md#install-sls) topic.
@@ -53,7 +53,8 @@ Copy the MAS license key file that you obtained from Rational License Key Server
 - `MAS_INSTANCE_ID` Declare the instance ID for the MAS install
 - `MAS_ENTITLEMENT_KEY` Lookup your entitlement key from the [IBM Container Library](https://myibm.ibm.com/products-services/containerlibrary)
 - `MAS_CONFIG_DIR` Directory where generated config files will be saved (you may also provide pre-generated config files here)
-- `SLS_LICENSE_ID` The license ID must match the license file available in `$MAS_CONFIG_DIR/entitlement.lic`
+- `SLS_LICENSE_ID` The license ID must match the license file available in `SLS_LICENSE_FILE`
+- `SLS_LICENSE_FILE` The path to the location of the license file.
 - `SLS_ENTITLEMENT_KEY` Lookup your entitlement key from the [IBM Container Library](https://myibm.ibm.com/products-services/containerlibrary)
 - `UDS_CONTACT_EMAIL` Defines the email for person to contact for BAS
 - `UDS_CONTACT_FIRSTNAME` Defines the first name of the person to contact for BAS

--- a/docs/playbooks/lite-core-roks.md
+++ b/docs/playbooks/lite-core-roks.md
@@ -17,7 +17,7 @@ All timings are estimates, see the individual pages for each of these playbooks 
 ## Preparation
 Before you run the playbook you **must** prepare the entitlement license key file that will be used during the playbook run.
 
-Copy the MAS license key file that you obtained from Rational License Key Server to `$MAS_CONFIG_DIR/entitlement.lic` (the file must have this exact name).  During the installation of SLS this license file will be automatically bootstrapped into the system.
+Copy the MAS license key file that you obtained from Rational License Key Server to a local path and set `SLS_LICENSE_FILE` to point to this location.  During the installation of SLS this license file will be automatically bootstrapped into the system.
 
 !!! tip
     If you do not already have an entitlement file, create a random 12 character hex string and use this as the license ID when requesting your entitlement file from Rational License Key Server.
@@ -31,7 +31,8 @@ Copy the MAS license key file that you obtained from Rational License Key Server
 - `MAS_INSTANCE_ID` Declare the instance ID for the MAS install
 - `MAS_ENTITLEMENT_KEY` Lookup your entitlement key from the [IBM Container Library](https://myibm.ibm.com/products-services/containerlibrary)
 - `MAS_CONFIG_DIR` Directory where generated config files will be saved (you may also provide pre-generated config files here)
-- `SLS_LICENSE_ID` The license ID must match the license file available in `$MAS_CONFIG_DIR/entitlement.lic`
+- `SLS_LICENSE_ID` The license ID must match the license file available in `SLS_LICENSE_FILE`
+- `SLS_LICENSE_FILE` The path to the location of the license file.
 - `SLS_ENTITLEMENT_KEY` Lookup your entitlement key from the [IBM Container Library](https://myibm.ibm.com/products-services/containerlibrary)
 - `UDS_CONTACT_EMAIL` Defines the email for person to contact for UDS
 - `UDS_CONTACT_FIRSTNAME` Defines the first name of the person to contact for UDS

--- a/docs/playbooks/lite-manage-roks.md
+++ b/docs/playbooks/lite-manage-roks.md
@@ -74,7 +74,7 @@ First, set `SLS_LICENSE_ID` to the correct ID (a 12 character hex string) from y
 
    `export MAS_APPWS_COMPONENTS="base=latest,health=latest"`
 
-   To install Health as a Standalone with a specified version, set `MAS_APP_ID` to health and set `MAS_APPWS_COMPONENTS` to `health=x.x.x`.
+   To install Health as a Standalone with a specified version, set `MAS_APP_ID` to health and set `MAS_APPWS_COMPONENTS` to `health=x.x.x`. By default health standalone will be installed using `health=latest`
 
 
 ## Release build

--- a/docs/playbooks/lite-manage-roks.md
+++ b/docs/playbooks/lite-manage-roks.md
@@ -28,7 +28,7 @@ All timings are estimates, see the individual pages for each of these playbooks 
 Before you run the playbook you need to configure a few things in your `MAS_CONFIG_DIR`:
 
 ### Prepare your entitlement license key file
-First, set `SLS_LICENSE_ID` to the correct ID (a 12 character hex string) from your entitlement file, then copy the MAS license key file that you obtained from Rational License Key Server to `$MAS_CONFIG_DIR/entitlement.lic` (the file must have this exact name).  During the installation of SLS this license file will be automatically bootstrapped into the system.
+First, set `SLS_LICENSE_ID` to the correct ID (a 12 character hex string) from your entitlement file, then set `SLS_LICENSE_FILE` to the location of the MAS license key file that you obtained from Rational License Key Server (thie will typically be called `entitlement.lic`).  During the installation of SLS this license file will be automatically bootstrapped into the system.
 
 !!! tip
     If you do not already have an entitlement file, create a random 12 character hex string and use this as the license ID when requesting your entitlement file from Rational License Key Server.
@@ -41,13 +41,13 @@ First, set `SLS_LICENSE_ID` to the correct ID (a 12 character hex string) from y
 - `MAS_INSTANCE_ID` Declare the instance ID for the MAS install
 - `MAS_ENTITLEMENT_KEY` Lookup your entitlement key from the [IBM Container Library](https://myibm.ibm.com/products-services/containerlibrary)
 - `MAS_CONFIG_DIR` Directory where generated config files will be saved (you may also provide pre-generated config files here)
-- `SLS_LICENSE_ID` The license ID must match the license file available in `$MAS_CONFIG_DIR/entitlement.lic`
+- `SLS_LICENSE_ID` The license ID must match the license file available in `SLS_LICENSE_FILE`
+- `SLS_LICENSE_FILE` The path to the location of the license file.
 - `SLS_ENTITLEMENT_KEY` Lookup your entitlement key from the [IBM Container Library](https://myibm.ibm.com/products-services/containerlibrary)
 - `UDS_CONTACT_EMAIL` Defines the email for person to contact for BAS
 - `UDS_CONTACT_FIRSTNAME` Defines the first name of the person to contact for BAS
 - `UDS_CONTACT_LASTNAME` Defines the last name of the person to contact for BAS
 - `CPD_ENTITLEMENT_KEY` Lookup your entitlement key from the [IBM Container Library](https://myibm.ibm.com/
-- `MAS_APPWS_COMPONENTS` to customize the application components installed in the Manage Workspace
 
 ## Optional environment variables
 - `IBMCLOUD_RESOURCEGROUP` creates an IBM Cloud resource group to be used, if none are passed, `Default` resource group will be used.
@@ -64,6 +64,7 @@ First, set `SLS_LICENSE_ID` to the correct ID (a 12 character hex string) from y
 - `MAS_ENTITLEMENT_USERNAME` to override the username MAS uses to access content in the IBM Entitled Registry
 - `CIS_CRN` to enable integration with IBM Cloud Internet Services (CIS) for DNS & certificate management
 - `CIS_SUBDOMAIN` if you want to use a subdomain within your CIS instance
+- `MAS_APPWS_COMPONENTS` to customize the application components installed in the Manage Workspace
 
 !!! tip
     `MAS_ICR_CP`, `MAS_ICR_CPOPEN`, & `MAS_ENTITLEMENT_USERNAME` are primarily used when working with pre-release builds in conjunction with `W3_USERNAME`, `ARTIFACTORY_APIKEY` and the `MAS_CATALOG_SOURCE` environment variables.
@@ -96,6 +97,7 @@ export CPD_ENTITLEMENT_KEY=xxx
 # SLS configuration
 export SLS_ENTITLEMENT_KEY=xxx
 export SLS_LICENSE_ID=xxx
+export SLS_LICENSE_FILE=xxx
 
 # BAS configuration
 export BAS_CONTACT_MAIL=xxx@xxx.com
@@ -137,6 +139,7 @@ export CPD_ENTITLEMENT_KEY=xxx
 # SLS configuration
 export SLS_ENTITLEMENT_KEY=xxx
 export SLS_LICENSE_ID=xxx
+export SLS_LICENSE_FILE=xxx
 
 # BAS configuration
 export BAS_CONTACT_MAIL=xxx@xxx.com

--- a/ibm/mas_devops/README.md
+++ b/ibm/mas_devops/README.md
@@ -6,9 +6,12 @@
 ## Change Log
 Note that links to pull requests prior to public release of the code (4.0) direct to IBM GitHub Enterprise, and will only be accessible to IBM employees.
 
-- `7.1` Multiple Updates:
+- `8.0` Multiple Updates:
     - Create secure route to CP4D web client when setting up DNS using CIS and suite_dns role ([#251](https://github.com/ibm-mas/ansible-devops/pull/251))
     - Configure azurefiles storage class for multi-cloud ([#260](https://github.com/ibm-mas/ansible-devops/pull/260))
+    - SMTP email support for Azure and other changes ([#265](https://github.com/ibm-mas/ansible-devops/pull/265))
+    - Add cp4d_wds role for discovery instance provison ([#234](https://github.com/ibm-mas/ansible-devops/pull/234))
+    - Change MAS_APPWS_COMPONENTS variable format ([#267](https://github.com/ibm-mas/ansible-devops/pull/267))
 - `7.0` Mulitple Updates:
     - Consolidate cluster specific provision/deprovision playbooks ([#236](https://github.com/ibm-mas/ansible-devops/pull/236))
     - Fix SLS bootstrap and update docs ([#242](https://github.com/ibm-mas/ansible-devops/pull/242))

--- a/ibm/mas_devops/galaxy.yml
+++ b/ibm/mas_devops/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: ibm
 name: mas_devops
-version: 7.0.0
+version: 9.0.0
 readme: README.md
 authors:
   - David Parker <parkerda@uk.ibm.com>

--- a/ibm/mas_devops/plugins/filter/filters.py
+++ b/ibm/mas_devops/plugins/filter/filters.py
@@ -62,14 +62,17 @@ def appws_components(components):
           description: key=value pairs of components, seperated by commas, to install into an application workspace.
           required: True
   """
-  # Take base=latest,health=latest and make {'base': {'version': 'latest'},'health': {'version': 'latest'}}
-  split_components = components.strip().split(',')
-  components_yaml = {}
-  for component in split_components:
-    split_component = component.split('=')
-    components_yaml[split_component[0]] = {'version': split_component[1]}
+  if components is None or components == '' or components == '{}':
+    return None
+  else:
+    # Take base=latest,health=latest and make {'base': {'version': 'latest'},'health': {'version': 'latest'}}
+    split_components = components.strip().split(',')
+    components_yaml = {}
+    for component in split_components:
+      split_component = component.split('=')
+      components_yaml[split_component[0]] = {'version': split_component[1]}
 
-  return components_yaml
+    return components_yaml
 
 class FilterModule(object):
   def filters(self):

--- a/ibm/mas_devops/roles/suite_app_configure/README.md
+++ b/ibm/mas_devops/roles/suite_app_configure/README.md
@@ -16,10 +16,15 @@ Defines the kind of application that is intended for installation such as `assis
 MAS application workspace to use to configure app components
 
 ### mas_appws_components
-Defines the app components and versions to configure in the application workspace. Takes the form of key=value pairs seperated by a comma i.e. base=latest,health=latest 
+Defines the app components and versions to configure in the application workspace. Takes the form of key=value pairs seperated by a comma i.e. To install health within Manage set `base=latest,health=latest`
 
 - Environment Variable: `MAS_APPWS_COMPONENTS`
-- Default: None
+- Default:
+  For Manage the default is:
+    `base=latest`
+
+  For Health (standalone) the default is:
+    `health=latest`
 
 ### mas_app_ws_spec
 Optional.  The application workspace deployment spec used to configure various aspects of the application workspace configuration. Note that use of this will override anything set in `mas_appws_components`
@@ -47,9 +52,6 @@ Example Playbook
     mas_app_ws_spec:
       bindings:
         jdbc: "{{ mas_appws_jdbc_binding | default( 'system' , true) }}"
-      components:
-        base:
-          version: 'latest'
 
   roles:
     - ibm.mas_devops.suite_app_config

--- a/ibm/mas_devops/roles/suite_app_configure/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_app_configure/defaults/main.yml
@@ -2,4 +2,4 @@
 # MAS instance configuration
 db2_schema: "{{ lookup('env', 'MAS_DB2_SCHEMA') | default('maximo', true)}}"
 
-mas_appws_components: "{{ lookup('env', 'MAS_APPWS_COMPONENTS') | ibm.mas_devops.appws_components | default(omit, true) }}"
+mas_appws_components: "{{ lookup('env', 'MAS_APPWS_COMPONENTS') | ibm.mas_devops.appws_components | default('{}', true) }}"

--- a/ibm/mas_devops/roles/suite_app_configure/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_configure/tasks/main.yml
@@ -43,6 +43,7 @@
       - "Application ID ............ {{ mas_app_id }}"
       - "Workspace ID .............. {{ mas_workspace_id }}"
       - "MAS app namespace ......... {{ mas_app_namespace }}"
+      - "Templated workspace CR .... {{ lookup('template', 'templates/workspace.yml.j2') }}"
 
 # 4. Workspace configuration
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/suite_app_configure/vars/defaultspecs/health.yml
+++ b/ibm/mas_devops/roles/suite_app_configure/vars/defaultspecs/health.yml
@@ -3,7 +3,7 @@
 mas_app_ws_spec:
   bindings:
     jdbc: system
-  components: "{{ mas_appws_components | default(omit, true) }}"
+  components: "{{ mas_appws_components | default({'health':{'version':'latest'}}, true) }}"
 
   # Configure with the recommended settings as controlled by the operator, defaults should "just work"
   #settings:

--- a/ibm/mas_devops/roles/suite_app_configure/vars/defaultspecs/hputilities.yml
+++ b/ibm/mas_devops/roles/suite_app_configure/vars/defaultspecs/hputilities.yml
@@ -3,7 +3,7 @@
 mas_app_ws_spec:
   bindings:
     watsonstudio: system
-  components: {}
+  components: '{{ mas_appws_components | default({}, true) }}'
   settings:
     watsonstudio:
       projectid: "{{ cpd_wsl_project_id }}" # this will be set in mas_devops.cp4d_install_services (either via env var in defaults/main.yml or created via rest api

--- a/ibm/mas_devops/roles/suite_app_configure/vars/defaultspecs/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_configure/vars/defaultspecs/manage.yml
@@ -3,7 +3,7 @@
 mas_app_ws_spec:
   bindings:
     jdbc: "{{ mas_appws_jdbc_binding | default( 'system' , true) }}"
-  components: "{{ mas_appws_components | default(omit, true) }}"
+  components: "{{ mas_appws_components | default({'base':{'version':'latest'}}, true) }}"
   settings:
     db:
       dbSchema: "{{ db2_schema }}"

--- a/pipelines/CONTRIBUTING.md
+++ b/pipelines/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Each time you want to modify and test a pipeline run, use the following:
 
 ```bash
 export DEV_MODE=true
-export VERSION=7.0.0
+export VERSION=9.0.0
 
 # Update the settings secret (if you changed any global settings)
 oc apply -f pipelines/samples/sample-pipelinesettings-roks-donotcommit.yaml

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -51,7 +51,7 @@ pipelines/bin/install-pipelines.sh
 # 2. Build and Install the MAS Pipeline Task Definitions
 ```
 export DEV_MODE=true
-export VERSION=7.0.0
+export VERSION=9.0.0
 
 pipelines/bin/build-pipelines.sh
 oc apply -f pipelines/ibm-mas_devops-clustertasks-$VERSION.yaml


### PR DESCRIPTION
Updates the changelogs for new release.

Fix a few doc issues related to SLS_LICENSE_FILE.

Fixes an issue where if MAS_APPWS_COMPONENTS is not set then the Manage and Health Workspace CRs fail as these require (from the CRDs) that the spec.components contains "base" for ManageWorkspace and "health" for health Workspace (even though the operator will install them anyway). 