### PR TITLE
[patch] update readmes and call ocs setup role for quickburn

### DIFF
--- a/docs/playbooks/lite-core-quickburn.md
+++ b/docs/playbooks/lite-core-quickburn.md
@@ -19,10 +19,13 @@ All timings are estimates, see the individual pages for each of these playbooks 
 - `FYRE_PRODUCT_ID`
 - `CLUSTER_NAME` The name to assign to the new Quickburn cluster
 - `CLUSTER_TYPE` The cluster type. Should be set to `quickburn`
+- `OCP_VERSION` The version of OCP to install as currently supported by fyre i.e. 4.8.35
+- `OCP_RELEASE` The release of OCP to help setup OCS i.e. 4.8
 - `MAS_INSTANCE_ID` Declare the instance ID for the MAS install
 - `MAS_ENTITLEMENT_KEY` Lookup your entitlement key from the [IBM Container Library](https://myibm.ibm.com/products-services/containerlibrary)
 - `MAS_CONFIG_DIR` Directory where generated config files will be saved (you may also provide pre-generated config files here)
-- `SLS_LICENSE_ID` The license ID must match the license file available in `$MAS_CONFIG_DIR/entitlement.lic`
+- `SLS_LICENSE_ID` The license ID must match the license file available in `SLS_LICENSE_FILE`
+- `SLS_LICENSE_FILE` The path to the location of the license file.
 - `SLS_ENTITLEMENT_KEY` Lookup your entitlement key from the [IBM Container Library](https://myibm.ibm.com/products-services/containerlibrary)
 
 ## Optional environment variables
@@ -50,7 +53,13 @@ export FYRE_PRODUCT_ID=225
 # Cluster configuration
 export CLUSTER_NAME=xxx
 export CLUSTER_TYPE=quickburn
-export OCP_VERSION=4.6.16
+export OCP_VERSION=4.8.35
+export OCP_RELEASE=4.8
+
+# SLS configuration
+export SLS_LICENSE_ID=xxx
+export SLS_ENTITLEMENT_KEY=xxx
+export SLS_ENTITLEMENT_FILE=xxx
 
 # MAS configuration
 export MAS_INSTANCE_ID=xxx
@@ -76,7 +85,13 @@ export FYRE_PRODUCT_ID=225
 # Cluster configuration
 export CLUSTER_NAME=xxx
 export CLUSTER_TYPE=quickburn
-export OCP_VERSION=4.6.16
+export OCP_VERSION=4.8.35
+export OCP_RELEASE=4.8
+
+# SLS configuration
+export SLS_LICENSE_ID=xxx
+export SLS_ENTITLEMENT_KEY=xxx
+export SLS_ENTITLEMENT_FILE=xxx
 
 # Allow development catalogs to be installed
 export W3_USERNAME=xxx

--- a/docs/playbooks/lite-core-roks.md
+++ b/docs/playbooks/lite-core-roks.md
@@ -110,6 +110,7 @@ export MAS_CONFIG_DIR=~/masconfig
 # SLS configuration
 export SLS_LICENSE_ID=xxx
 export SLS_ENTITLEMENT_KEY=xxx
+export SLS_ENTITLEMENT_FILE=xxx
 
 # UDS configuration
 export UDS_CONTACT_EMAIL=xxx@xxx.com

--- a/ibm/mas_devops/playbooks/lite-core-quickburn.yml
+++ b/ibm/mas_devops/playbooks/lite-core-quickburn.yml
@@ -32,10 +32,12 @@
           - lookup('env', 'CLUSTER_NAME') != ""
           - lookup('env', 'CLUSTER_TYPE') != ""
           - lookup('env', 'OCP_VERSION') != ""
+          - lookup('env', 'OCP_RELEASE') != ""
           - lookup('env', 'MAS_INSTANCE_ID') != ""
           - lookup('env', 'MAS_CONFIG_DIR') != ""
           - lookup('env', 'MAS_ENTITLEMENT_KEY') != ""
           - lookup('env', 'SLS_LICENSE_ID') != ""
+          - lookup('env', 'SLS_LICENSE_FILE') != ""
           - lookup('env', 'SLS_ENTITLEMENT_KEY') != ""
         fail_msg: "One or more required environment variables are not defined"
 
@@ -43,6 +45,7 @@
     # 1. Deploy & configure the cluster
     - ibm.mas_devops.ocp_provision
     - ibm.mas_devops.ocp_setup_mas_deps
+    - ibm.mas_devops.ocp_setup_ocs
 
     # 2. Install MongoDb
     - ibm.mas_devops.mongodb

--- a/ibm/mas_devops/playbooks/lite-core-roks.yml
+++ b/ibm/mas_devops/playbooks/lite-core-roks.yml
@@ -39,6 +39,7 @@
           - lookup('env', 'MAS_CONFIG_DIR') != ""
           - lookup('env', 'MAS_ENTITLEMENT_KEY') != ""
           - lookup('env', 'SLS_LICENSE_ID') != ""
+          - lookup('env', 'SLS_LICENSE_FILE') != ""
           - lookup('env', 'SLS_ENTITLEMENT_KEY') != ""
           - lookup('env', 'UDS_CONTACT_EMAIL') != ""
           - lookup('env', 'UDS_CONTACT_FIRSTNAME') != ""


### PR DESCRIPTION
Various readmes for playbooks didn't contain the requirement for the new SLS_LICENSE_FILE var that is needed.

Also the lite quickburn playbook didn't contain the role to setup ocs (storage) so no storage class was available when trying to deploy mongo to quickburn. This was raised in issue #258 