### PR TITLE
[patch] - fix cpd storage class

### DIFF
--- a/ibm/mas_devops/roles/cp4d_install/README.md
+++ b/ibm/mas_devops/roles/cp4d_install/README.md
@@ -25,12 +25,17 @@ Required only if `cpd_version = cpd35`, otherwise unused because in CP4D v4 we h
 
 ### cpd_storage_class
 Required only if `cpd_version = cpd40`, otherwise unused.
+Default storage class in CPD v4.0, for IBM Cloud `ibmc-file-gold-gid` can be used.
 
 - Environment Variable: `CPD_STORAGE_CLASS`
 - Default Value: None
 
-Note: As per CloudPak For Data support team's recommendation, the value set for `cpd_storage_class` will also be used for file and metastore storages while installing CPD v4.0 Control Plane.
-Source: https://www.ibm.com/docs/en/cloud-paks/cp-data/4.0?topic=requirements-storage
+### cpd_metadb_block_storage_class
+Required only if `cpd_version = cpd40`, otherwise unused.
+Default block storage class for `zenCoreMetaDbStorageClass` in CPD v4.0, for IBM Cloud `ibmc-block-gold` can be used.
+
+- Environment Variable: `CPD_METADB_BLOCK_STORAGE_CLASS`
+- Default Value: None
 
 ### cpd_services_namespace
 Only supported if `cpd_version = cpd40`, otherwise unused. For v3.5 support this value is always set to `cpd-meta-ops`.

--- a/ibm/mas_devops/roles/cp4d_install/defaults/main.yml
+++ b/ibm/mas_devops/roles/cp4d_install/defaults/main.yml
@@ -10,12 +10,9 @@ cpd_registry_user: cp
 # This is only used for cpd35, we have to use cp4d_hack_worker_nodes to set up the global image pull secret needed by cpd40
 cpd_entitlement_key: "{{ lookup('env', 'CPD_ENTITLEMENT_KEY') }}"
 
-# Both CP4D storage classes have the same storage requirements as per recommendation from cpd support team
-# so we set storageClass and zenCoreMetadbStorageClass to "{{ cpd_storage_class }}"
-# https://www.ibm.com/docs/en/cloud-paks/cp-data/4.0?topic=requirements-storage
-#
 # If this changes in the future we will expose a seperate variable for each.
 cpd_storage_class: "{{ lookup('env', 'CPD_STORAGE_CLASS') }}"
+cpd_metadb_block_storage_class: "{{ lookup('env', 'CPD_METADB_BLOCK_STORAGE_CLASS') }}"
 
 # --- MAS channel control ---------------------------------------------------------------------------------------------
 # Temporary solution: this will be used to determine whether to install CPD v4 or v3.5, if MAS channels from the below

--- a/ibm/mas_devops/roles/cp4d_install/tasks/install/cpd40.yml
+++ b/ibm/mas_devops/roles/cp4d_install/tasks/install/cpd40.yml
@@ -9,14 +9,20 @@
     that: cpd_storage_class is defined and cpd_storage_class != ""
     fail_msg: "cpd_storage_class property has not been set"
 
+- name: "Assert that cpd_metadb_block_storage_class has been provided"
+  assert:
+    that: cpd_metadb_block_storage_class is defined and cpd_metadb_block_storage_class != ""
+    fail_msg: "cpd_metadb_block_storage_class property has not been set"
+
 - name: "Debug information"
   debug:
     msg:
-      - "CPD meta namespace ........... {{ cpd_meta_namespace }}"
-      - "CPD services namespace ....... {{ cpd_services_namespace }}"
-      - "CPD registry ................. {{ cpd_registry }}"
-      - "CPD username ................. {{ cpd_registry_user }}"
-      - "CPD storage class ............ {{ cpd_storage_class }}"
+      - "CPD meta namespace ..................... {{ cpd_meta_namespace }}"
+      - "CPD services namespace ................. {{ cpd_services_namespace }}"
+      - "CPD registry ........................... {{ cpd_registry }}"
+      - "CPD username ........................... {{ cpd_registry_user }}"
+      - "CPD storage class ...................... {{ cpd_storage_class }}"
+      - "CPD metadb block storage class ......... {{ cpd_metadb_block_storage_class }}"
 
 # 2. Setup namespace for CP4D
 # -----------------------------------------------------------------------------
@@ -98,6 +104,35 @@
   until: _zen_deployment.resources[0].status.availableReplicas is defined
   retries: 90 # Approximately 90 minutes before we give up
   delay: 60 # 1 minute
+
+# Wait ZenService lite-cr to be deployed
+# ----------------------------------------------------------------------------------------------
+- name: "Wait ZenService lite-cr to be deployed"
+  community.kubernetes.k8s_info:
+    api_version: zen.cpd.ibm.com/v1
+    name: lite-cr
+    namespace: "{{ cpd_services_namespace }}"
+    kind: ZenService
+  register: zenlitecr_output
+  until:
+    - zenlitecr_output.resources is defined
+    - zenlitecr_output.resources | length > 0
+  retries: 60 # approx 60 minutes before we give up
+  delay: 60 # 1 minute
+
+# Patch ZenService lite-cr to scaleConfig: medium - this is a recommendation from cpd team
+# ----------------------------------------------------------------------------------------------
+- name: "Patch ZenService lite-cr to scaleConfig: medium"
+  community.kubernetes.k8s:
+    api_version: zen.cpd.ibm.com/v1
+    name: lite-cr
+    namespace: "{{ cpd_services_namespace }}"
+    kind: ZenService
+    definition:
+      spec:
+        scaleConfig: medium
+    apply: true
+  register: zenlitecr_update
 
 - name: "Wait for ibmcpd CPD 4.0 to be Completed"
   kubernetes.core.k8s_info:

--- a/ibm/mas_devops/roles/cp4d_install/templates/cpd40/ibmcpd.yaml
+++ b/ibm/mas_devops/roles/cp4d_install/templates/cpd40/ibmcpd.yaml
@@ -9,3 +9,4 @@ spec:
     license: Standard
   storageClass: "{{ cpd_storage_class }}"
   zenCoreMetadbStorageClass: "{{ cpd_storage_class }}"
+  scaleConfig: medium

--- a/ibm/mas_devops/roles/cp4d_install/templates/cpd40/ibmcpd.yaml
+++ b/ibm/mas_devops/roles/cp4d_install/templates/cpd40/ibmcpd.yaml
@@ -8,5 +8,4 @@ spec:
     accept: true
     license: Standard
   storageClass: "{{ cpd_storage_class }}"
-  zenCoreMetadbStorageClass: "{{ cpd_storage_class }}"
-  scaleConfig: medium
+  zenCoreMetadbStorageClass: "{{ cpd_metadb_block_storage_class }}"

--- a/ibm/mas_devops/roles/cp4d_install_services/templates/cpd40/aiopenscale/service.yml
+++ b/ibm/mas_devops/roles/cp4d_install_services/templates/cpd40/aiopenscale/service.yml
@@ -9,6 +9,6 @@ spec:
   license:
     accept: true
     license: Standard    # Specify the license you purchased
-  version: 4.0.2
+  version: 4.0.7
   type: service
   storageClass: "{{ cpd_storage_class }}"

--- a/ibm/mas_devops/roles/cp4d_install_services/templates/cpd40/spark/service.yml
+++ b/ibm/mas_devops/roles/cp4d_install_services/templates/cpd40/spark/service.yml
@@ -8,5 +8,5 @@ spec:
   license:
     accept: true
     license: Standard     # Specify the license you purchased
-  version: 4.0.3
+  version: 4.0.7
   storageClass: "{{ cpd_storage_class }}"

--- a/ibm/mas_devops/roles/cp4d_install_services/templates/cpd40/wd/service.yml
+++ b/ibm/mas_devops/roles/cp4d_install_services/templates/cpd40/wd/service.yml
@@ -20,7 +20,7 @@ metadata:
 spec:
   license:
     accept: true
-  version: 4.0.6
+  version: 4.0.7
   shared:
     storageClassName: "{{ cpd_wd_storage_class }}"     # See the guidance in "Information you need to complete this task"
   watsonGateway:

--- a/ibm/mas_devops/roles/cp4d_install_services/templates/cpd40/wml/service.yml
+++ b/ibm/mas_devops/roles/cp4d_install_services/templates/cpd40/wml/service.yml
@@ -10,5 +10,5 @@ spec:
     accept: true
     license: Standard
   storageClass: "{{ cpd_storage_class }}"
-  version: 4.0.3
+  version: 4.0.7
   scaleConfig: small

--- a/ibm/mas_devops/roles/cp4d_install_services/templates/cpd40/wsl/service.yml
+++ b/ibm/mas_devops/roles/cp4d_install_services/templates/cpd40/wsl/service.yml
@@ -10,4 +10,4 @@ spec:
     license: Standard
   scaleConfig: small
   storageClass: "{{ cpd_storage_class }}"
-  version: 4.0.3
+  version: 4.0.7


### PR DESCRIPTION
This PR rollbacks the change to use `ibmc-file-gold-gid` in both storage classes that cpd uses. Instead, now we'll again use `ibmc-file-gold-gid` for the primary storage class and `ibmc-block-gold` for zen metadb. This was discussed and agreed after the recent cpd outage we had in march on ivt11, the recommendation came from cpd support team:

https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/2326

In addition, this PR also updates Watson services to latest patch available.