### PR TITLE
[patch] Remove ibmcloud-oc login hack

### DIFF
--- a/image/ansible-devops/Dockerfile
+++ b/image/ansible-devops/Dockerfile
@@ -9,7 +9,6 @@ COPY env.sh ${HOME}/env.sh
 COPY run-playbook.sh ${HOME}/run-playbook.sh
 COPY save-junit-to-mongo.py ${HOME}/save-junit-to-mongo.py
 COPY ansible.cfg ${HOME}/ansible.cfg
-COPY ibmcloud-oc.sh ${HOME}/ibmcloud-oc.sh
 COPY clear-mustgather-workspace.sh ${HOME}/clear-mustgather-workspace.sh
 
 # ----- Switch to root user ---------------------------------------------------
@@ -29,7 +28,6 @@ RUN ansible-galaxy collection install ${HOME}/ibm-mas_devops.tar.gz -p /opt/app-
 RUN chmod -R ug+rwx ${HOME}/env.sh && \
     chmod -R ug+rwx ${HOME}/.ansible && \
     chmod a+x ${HOME}/run-playbook.sh && \
-    chmod a+x ${HOME}/ibmcloud-oc.sh && \
     chmod a+x ${HOME}/clear-mustgather-workspace.sh
 
 # Install OpenShift CLI 4.8.35

--- a/image/ansible-devops/ibmcloud-oc.sh
+++ b/image/ansible-devops/ibmcloud-oc.sh
@@ -1,8 +1,0 @@
-# Install Plugin
-echo "Install IBM Cloud plugin"
-ibmcloud plugin install container-service
-ibmcloud plugin list
-
-# Authenticate
-echo "Authenticate in IBM Cloud"
-ibmcloud login --apikey ${IBMCLOUD_APIKEY} --no-region --quiet

--- a/image/ansible-devops/run-playbook.sh
+++ b/image/ansible-devops/run-playbook.sh
@@ -9,7 +9,6 @@ if [ -e "/workspace/entitlement/entitlement.lic" ]; then
 fi
 
 source /opt/app-root/src/env.sh
-/opt/app-root/src/ibmcloud-oc.sh
 ansible-playbook "$@"
 rc=$?
 python3 /opt/app-root/src/save-junit-to-mongo.py


### PR DESCRIPTION
Thought this was sorted a long time ago, clearly not.  The image as-is (and thus the pipeline which uses the image), will only be usable in a IBMCloud ROKS cluster.  Far from desirable.

The ansible-devops container currently runs a script (`ibmcloud-oc.sh`) as part of the `run-playbook.sh` script.  This is entirely redundant:

- When running in cluster (e.g. as part of a pipeline) the pod will already have access to the local OCP without a login
- When using the container as a route to manually execute commands, the end-user will be able to `oc login` to any cluster they want

I don't remember the details of why this existed in the first place, but it's definitely not required, and it limits the new one-click in-cluster install to only IBM Cloud ROKS clusters so must be removed.