### PR TITLE
[patch] - update cpd service version

### DIFF
--- a/ibm/mas_devops/roles/cp4d_install_services/templates/cpd40/aiopenscale/service.yml
+++ b/ibm/mas_devops/roles/cp4d_install_services/templates/cpd40/aiopenscale/service.yml
@@ -11,4 +11,4 @@ spec:
     license: Standard    # Specify the license you purchased
   type: service
   storageClass: "{{ cpd_storage_class }}"
-  version: 4.0.7 # openscale does not support 'version':'latest' and if we remove 'version', their operator will consider it 'latest', looks like a bug in openscale
+  version: 4.0.8 # openscale does not support 'version':'latest' and if we remove 'version', their operator will consider it 'latest', looks like a bug in openscale

--- a/ibm/mas_devops/roles/cp4d_install_services/templates/cpd40/aiopenscale/subscription.yml
+++ b/ibm/mas_devops/roles/cp4d_install_services/templates/cpd40/aiopenscale/subscription.yml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: ibm-watson-openscale-operator-subscription
   namespace: "{{ cpd_meta_namespace }}"    # Pick the project that contains the Cloud Pak for Data operator
 spec:
-  channel: v1
+  channel: v1.5
   installPlanApproval: Automatic
   name: ibm-cpd-wos
   source: ibm-operator-catalog

--- a/ibm/mas_devops/roles/cp4d_install_services/templates/cpd40/spark/service.yml
+++ b/ibm/mas_devops/roles/cp4d_install_services/templates/cpd40/spark/service.yml
@@ -8,5 +8,4 @@ spec:
   license:
     accept: true
     license: Standard     # Specify the license you purchased
-  version: 4.0.7
   storageClass: "{{ cpd_storage_class }}"

--- a/ibm/mas_devops/roles/cp4d_install_services/templates/cpd40/wd/service.yml
+++ b/ibm/mas_devops/roles/cp4d_install_services/templates/cpd40/wd/service.yml
@@ -1,15 +1,4 @@
 ---
-apiVersion: edb.cpd.ibm.com/v1
-kind: CPDEdbService
-metadata:
-  name: cpd-edb-service     # This is the recommended name, but you can change it
-  namespace: "{{ cpd_services_namespace }}" # Replace with the project where you will install EDB Postgres Standard
-spec:
-  license:
-    accept: true
-    license: Standard     # Specify the license you purchased
-  storageClass: "{{ cpd_wd_storage_class }}"    # See the guidance in "Information you need to complete this task"
----
 apiVersion: discovery.watson.ibm.com/v1
 kind: WatsonDiscovery
 metadata:
@@ -20,7 +9,6 @@ metadata:
 spec:
   license:
     accept: true
-  version: 4.0.7
   shared:
     storageClassName: "{{ cpd_wd_storage_class }}"     # See the guidance in "Information you need to complete this task"
   watsonGateway:

--- a/ibm/mas_devops/roles/cp4d_install_services/templates/cpd40/wd/subscription.yml
+++ b/ibm/mas_devops/roles/cp4d_install_services/templates/cpd40/wd/subscription.yml
@@ -14,18 +14,6 @@ spec:
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: ibm-cpd-edb-operator-catalog-subscription
-  namespace: "{{ cpd_meta_namespace }}"    # Pick the project that contains the Cloud Pak for Data
-spec:
-  installPlanApproval: Automatic
-  channel: v4.0
-  name: ibm-cpd-edb
-  source: ibm-operator-catalog
-  sourceNamespace: openshift-marketplace
----
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
   labels:
     app.kubernetes.io/instance: ibm-watson-discovery-operator-subscription
     app.kubernetes.io/managed-by: ibm-watson-discovery-operator

--- a/ibm/mas_devops/roles/cp4d_install_services/templates/cpd40/wml/service.yml
+++ b/ibm/mas_devops/roles/cp4d_install_services/templates/cpd40/wml/service.yml
@@ -10,5 +10,4 @@ spec:
     accept: true
     license: Standard
   storageClass: "{{ cpd_storage_class }}"
-  version: 4.0.7
   scaleConfig: small

--- a/ibm/mas_devops/roles/cp4d_install_services/templates/cpd40/wsl/service.yml
+++ b/ibm/mas_devops/roles/cp4d_install_services/templates/cpd40/wsl/service.yml
@@ -10,4 +10,3 @@ spec:
     license: Standard
   scaleConfig: small
   storageClass: "{{ cpd_storage_class }}"
-  version: 4.0.7


### PR DESCRIPTION
This fixes mismatches among supported cpd service versions:
- unpinned the version of all watson services because we found deployment issues when service operator is at latest version but not the service CR, so removed the versions to ensure both operator's vs cr's are matching (except openscale, they don't allow `latest` or removing the `version` prop)
- changed the openscale channel to unlock the service latest version.
- removed edb operator from watson discovery dependencies, in latest wd versions it is not needed anymore.