### PR TITLE
[patch] Fix build system semver regex

### DIFF
--- a/build/bin/initbuild.sh
+++ b/build/bin/initbuild.sh
@@ -14,8 +14,8 @@ if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
   echo "Note: non-branch build for a tag named '${GITHUB_REF_NAME}'"
   TAG_BASED_RELEASE=true
 
-  SEMVER_XYZ="(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
-  SEMVER_PRE="(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?"
+  SEMVER_XYZ="(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
+  SEMVER_PRE="(-(0|[1-9][0-9]*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*)?"
   SEMVER_BUILD="(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?"
   SEMVER_REGEXP="^${SEMVER_XYZ}${SEMVER_PRE}${SEMVER_BUILD}$"
 


### PR DESCRIPTION
The current regex doesn't work for double digit version numbers (e.g. `10.0.0`).  Replacing `\d` with `[0-9]` seems to work.  The regex could be improved further to be honest, but that's out of the scope of this work.