### PR TITLE
[patch] Fix name of ocs role in fyre playbook

### DIFF
--- a/ibm/mas_devops/playbooks/ocp_fyre_provision.yml
+++ b/ibm/mas_devops/playbooks/ocp_fyre_provision.yml
@@ -25,4 +25,4 @@
     - ibm.mas_devops.ocp_verify
 
     # 3. Install OpenShift Container Storage
-    - ibm.mas_devops.ocp_setup_ocs
+    - ibm.mas_devops.ocs


### PR DESCRIPTION
We renamed the `ocp_setup_ocs` role to simply `ocs`, the Fyre provision playbook wasn't updated to match this.