### PR TITLE
[patch] Miscellanous task and documentation updates

### DIFF
--- a/ibm/mas_devops/roles/cert_manager/README.md
+++ b/ibm/mas_devops/roles/cert_manager/README.md
@@ -9,7 +9,7 @@ Role Variables
 ### mas_channel
 Used to determine whether to install SBO stable channel and the IBM badged cert-manager.
 
-- Optional, if not provided then the IBM Certificate Manager will be installed.
+- Optional, if not provided then the IBM certificate manager will be preferred to the JetStack certificate manager.
 - Environment Variable: `MAS_CHANNEL`
 - Default Value: None
 
@@ -19,8 +19,34 @@ Example Playbook
 
 ```yaml
 - hosts: localhost
+  vars:
+    mas_channel: 8.8.x
   roles:
     - ibm.mas_devops.cert_manager
+```
+
+
+Tekton Task
+-----------
+Start a run of the **mas-devops-cert-manager** Task as below, you must have already prepared the namespace:
+
+```
+cat <<EOF | oc create -f -
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: mas-devops-cert-manager-
+spec:
+  taskRef:
+    kind: Task
+    name: mas-devops-cert-manager
+  params:
+  - name: mas_channel
+    value: 8.8.x
+  resources: {}
+  serviceAccountName: pipeline
+  timeout: 24h0m0s
+EOF
 ```
 
 

--- a/ibm/mas_devops/roles/cluster_monitoring/README.md
+++ b/ibm/mas_devops/roles/cluster_monitoring/README.md
@@ -75,6 +75,34 @@ Example Playbook
 ```
 
 
+Tekton Task
+-----------
+Start a run of the **mas-devops-cluster-monitoring** Task as below, you must have already prepared the namespace:
+
+```
+cat <<EOF | oc create -f -
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: mas-devops-cluster-monitoring-
+spec:
+  taskRef:
+    kind: Task
+    name: mas-devops-cluster-monitoring
+  params:
+  - name: prometheus_storage_class
+    value: "ibmc-block-gold"
+  - name: prometheus_alertmgr_storage_class
+    value: "ibmc-file-gold-gid"
+  - name: prometheus_userworkload_storage_class
+    value: "ibmc-block-gold"
+  resources: {}
+  serviceAccountName: pipeline
+  timeout: 24h0m0s
+EOF
+```
+
+
 License
 -------
 

--- a/ibm/mas_devops/roles/common_services/README.md
+++ b/ibm/mas_devops/roles/common_services/README.md
@@ -20,6 +20,27 @@ Example Playbook
 ```
 
 
+Tekton Task
+-----------
+Start a run of the **mas-devops-common-services** Task as below, you must have already prepared the namespace:
+
+```
+cat <<EOF | oc create -f -
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: mas-devops-common-services-
+spec:
+  taskRef:
+    kind: Task
+    name: mas-devops-common-services
+  resources: {}
+  serviceAccountName: pipeline
+  timeout: 24h0m0s
+EOF
+```
+
+
 License
 -------
 

--- a/image/ansible-devops/save-junit-to-mongo.py
+++ b/image/ansible-devops/save-junit-to-mongo.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
     # Initialize the properties we need
     instanceId = os.getenv("MAS_INSTANCE_ID")
     productId = "ibm-mas-devops"
-    build = os.getenv("TRAVIS_BUILD_NUMBER")
+    build = os.getenv("DEVOPS_BUILD_NUMBER")
     suite = os.getenv("JUNIT_SUITE_NAME", "")
     junitOutputDir = os.getenv("JUNIT_OUTPUT_DIR", "/tmp")
 
@@ -30,7 +30,7 @@ if __name__ == "__main__":
         print("Results not recorded because MAS_INSTANCE_ID env var is not set")
         exit(0)
     if build is None:
-        print("Results not recorded because TRAVIS_BUILD_NUMBER env var is not set")
+        print("Results not recorded because DEVOPS_BUILD_NUMBER env var is not set")
         exit(0)
 
     runId = f"{instanceId}:{build}"
@@ -54,7 +54,7 @@ if __name__ == "__main__":
             for testcase in resultDoc["testsuites"]["testsuite"]["testcase"]:
                 testcase["name"] = testcase["name"].replace("[localhost] localhost: ", "")
                 # Playbooks don't have ibm/mas_devops in the classnmae but do have /opt/app-root.
-                # Roles have both ibm/mas_devops and /opt/app-root. 
+                # Roles have both ibm/mas_devops and /opt/app-root.
                 # Guard against both and remove when required.
                 if "/opt/app-root/" in testcase["classname"]:
                     testcase["classname"] = testcase["classname"].split("/opt/app-root/")[1]

--- a/image/ansible-devops/save-junit-to-mongo.py
+++ b/image/ansible-devops/save-junit-to-mongo.py
@@ -16,14 +16,14 @@ if __name__ == "__main__":
     instanceId = os.getenv("MAS_INSTANCE_ID")
     productId = "ibm-mas-devops"
     build = os.getenv("DEVOPS_BUILD_NUMBER")
-    suite = os.getenv("JUNIT_SUITE_NAME", "")
+    suite = os.getenv("DEVOPS_SUITE_NAME", "")
     junitOutputDir = os.getenv("JUNIT_OUTPUT_DIR", "/tmp")
 
     channelId = "n/a"
     version = "unknown"
 
     if suite == "":
-        print ("Results not recorded because JUNIT_SUITE_NAME is not defined")
+        print ("Results not recorded because DEVOPS_SUITE_NAME is not defined")
         exit(0)
 
     if instanceId is None:

--- a/pipelines/tasks/appconnect.yaml
+++ b/pipelines/tasks/appconnect.yaml
@@ -5,19 +5,37 @@ metadata:
   name: mas-devops-appconnect
 spec:
   params:
-    - name: junit_suite_name
-      type: string
-      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
-      default: ""
     - name: mas_instance_id
       type: string
 
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
   stepTemplate:
     env:
-      - name: JUNIT_SUITE_NAME
-        value: $(params.junit_suite_name)
       - name: MAS_INSTANCE_ID
         value: $(params.mas_instance_id)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
 
   steps:
     - name: appconnect

--- a/pipelines/tasks/cert-manager.yaml
+++ b/pipelines/tasks/cert-manager.yaml
@@ -5,20 +5,38 @@ metadata:
   name: mas-devops-cert-manager
 spec:
   params:
-    - name: junit_suite_name
-      type: string
-      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
-      default: ""
     - name: mas_channel
       type: string
       default: ""
 
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
   stepTemplate:
     env:
-      - name: JUNIT_SUITE_NAME
-        value: $(params.junit_suite_name)
       - name: MAS_CHANNEL
         value: $(params.mas_channel)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
 
   steps:
     - name: cert-manager

--- a/pipelines/tasks/cert-manager.yaml
+++ b/pipelines/tasks/cert-manager.yaml
@@ -11,6 +11,10 @@ spec:
 
     # Optional support built into the ansible-devops image
     # for saving task execution results to a MongoDb instance
+    - name: mas_instance_id
+      type: string
+      description: Optional MAS instance Id, used to enable save-junit-to-mongo.py
+      default: ""
     - name: devops_mongo_uri
       type: string
       description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
@@ -31,6 +35,8 @@ spec:
 
       # Optional support built into the ansible-devops image
       # for saving task execution results to a MongoDb instance
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
       - name: DEVOPS_MONGO_URI
         value: $(params.devops_mongo_uri)
       - name: DEVOPS_SUITE_NAME

--- a/pipelines/tasks/cert-manager.yaml
+++ b/pipelines/tasks/cert-manager.yaml
@@ -11,9 +11,7 @@ spec:
       default: ""
     - name: mas_channel
       type: string
-
-    - name: mas_channel
-      type: string
+      default: ""
 
   stepTemplate:
     env:

--- a/pipelines/tasks/cluster-monitoring.yaml
+++ b/pipelines/tasks/cluster-monitoring.yaml
@@ -10,10 +10,51 @@ spec:
       description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
       default: ""
 
+    - name: prometheus_retention_period
+      type: string
+      default: ""
+    - name: prometheus_storage_class
+      type: string
+      default: ""
+    - name: prometheus_storage_size
+      type: string
+      default: ""
+    - name: prometheus_alertmgr_storage_class
+      type: string
+      default: ""
+    - name: prometheus_alertmgr_storage_size
+      type: string
+      default: ""
+    - name: prometheus_userworkload_retention_period
+      type: string
+      default: ""
+    - name: prometheus_userworkload_storage_class
+      type: string
+      default: ""
+    - name: prometheus_userworkload_storage_size
+      type: string
+      default: ""
+
   stepTemplate:
     env:
       - name: JUNIT_SUITE_NAME
         value: $(params.junit_suite_name)
+      - name: PROMETHEUS_RETENTION_PERIOD
+        value: $(params.prometheus_retention_period)
+      - name: PROMETHEUS_STORAGE_CLASS
+        value: $(params.prometheus_storage_class)
+      - name: PROMETHEUS_STORAGE_SIZE
+        value: $(params.prometheus_storage_size)
+      - name: PROMETHEUS_ALERTMGR_STORAGE_CLASS
+        value: $(params.prometheus_alertmgr_storage_class)
+      - name: PROMETHEUS_ALERTMGR_STORAGE_SIZE
+        value: $(params.prometheus_alertmgr_storage_size)
+      - name: PROMETHEUS_USERWORKLOAD_RETENTION_PERIOD
+        value: $(params.prometheus_userworkload_retention_period)
+      - name: PROMETHEUS_USERWORKLOAD_STORAGE_CLASS
+        value: $(params.prometheus_userworkload_storage_class)
+      - name: PROMETHEUS_USERWORKLOAD_STORAGE_SIZE
+        value: $(params.prometheus_userworkload_storage_size)
 
   steps:
     - name: cluster-monitoring

--- a/pipelines/tasks/cluster-monitoring.yaml
+++ b/pipelines/tasks/cluster-monitoring.yaml
@@ -32,6 +32,10 @@ spec:
 
     # Optional support built into the ansible-devops image
     # for saving task execution results to a MongoDb instance
+    - name: mas_instance_id
+      type: string
+      description: Optional MAS instance Id, used to enable save-junit-to-mongo.py
+      default: ""
     - name: devops_mongo_uri
       type: string
       description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
@@ -66,6 +70,8 @@ spec:
 
       # Optional support built into the ansible-devops image
       # for saving task execution results to a MongoDb instance
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
       - name: DEVOPS_MONGO_URI
         value: $(params.devops_mongo_uri)
       - name: DEVOPS_SUITE_NAME

--- a/pipelines/tasks/cluster-monitoring.yaml
+++ b/pipelines/tasks/cluster-monitoring.yaml
@@ -5,11 +5,6 @@ metadata:
   name: mas-devops-cluster-monitoring
 spec:
   params:
-    - name: junit_suite_name
-      type: string
-      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
-      default: ""
-
     - name: prometheus_retention_period
       type: string
       default: ""
@@ -35,10 +30,23 @@ spec:
       type: string
       default: ""
 
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
   stepTemplate:
     env:
-      - name: JUNIT_SUITE_NAME
-        value: $(params.junit_suite_name)
       - name: PROMETHEUS_RETENTION_PERIOD
         value: $(params.prometheus_retention_period)
       - name: PROMETHEUS_STORAGE_CLASS
@@ -55,6 +63,15 @@ spec:
         value: $(params.prometheus_userworkload_storage_class)
       - name: PROMETHEUS_USERWORKLOAD_STORAGE_SIZE
         value: $(params.prometheus_userworkload_storage_size)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
 
   steps:
     - name: cluster-monitoring

--- a/pipelines/tasks/common-services.yaml
+++ b/pipelines/tasks/common-services.yaml
@@ -5,15 +5,31 @@ metadata:
   name: mas-devops-common-services
 spec:
   params:
-    - name: junit_suite_name
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
       type: string
       description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
       default: ""
 
   stepTemplate:
     env:
-      - name: JUNIT_SUITE_NAME
-        value: $(params.junit_suite_name)
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
 
   steps:
     - name: common-services

--- a/pipelines/tasks/common-services.yaml
+++ b/pipelines/tasks/common-services.yaml
@@ -7,6 +7,10 @@ spec:
   params:
     # Optional support built into the ansible-devops image
     # for saving task execution results to a MongoDb instance
+    - name: mas_instance_id
+      type: string
+      description: Optional MAS instance Id, used to enable save-junit-to-mongo.py
+      default: ""
     - name: devops_mongo_uri
       type: string
       description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
@@ -24,6 +28,8 @@ spec:
     env:
       # Optional support built into the ansible-devops image
       # for saving task execution results to a MongoDb instance
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
       - name: DEVOPS_MONGO_URI
         value: $(params.devops_mongo_uri)
       - name: DEVOPS_SUITE_NAME

--- a/pipelines/tasks/cos.yaml
+++ b/pipelines/tasks/cos.yaml
@@ -5,19 +5,37 @@ metadata:
   name: mas-devops-cos
 spec:
   params:
-    - name: junit_suite_name
-      type: string
-      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
-      default: ""
     - name: mas_instance_id
       type: string
 
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
   stepTemplate:
     env:
-      - name: JUNIT_SUITE_NAME
-        value: $(params.junit_suite_name)
       - name: MAS_INSTANCE_ID
         value: $(params.mas_instance_id)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
 
   steps:
     - name: cos

--- a/pipelines/tasks/cp4d.yaml
+++ b/pipelines/tasks/cp4d.yaml
@@ -23,6 +23,10 @@ spec:
 
     # Optional support built into the ansible-devops image
     # for saving task execution results to a MongoDb instance
+    - name: mas_instance_id
+      type: string
+      description: Optional MAS instance Id, used to enable save-junit-to-mongo.py
+      default: ""
     - name: devops_mongo_uri
       type: string
       description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
@@ -50,6 +54,8 @@ spec:
 
       # Optional support built into the ansible-devops image
       # for saving task execution results to a MongoDb instance
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
       - name: DEVOPS_MONGO_URI
         value: $(params.devops_mongo_uri)
       - name: DEVOPS_SUITE_NAME

--- a/pipelines/tasks/cp4d.yaml
+++ b/pipelines/tasks/cp4d.yaml
@@ -5,11 +5,6 @@ metadata:
   name: mas-devops-cp4d
 spec:
   params:
-    - name: junit_suite_name
-      type: string
-      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
-      default: ""
-
     # Namespace configuration (Optional, defaults built into Ansible role)
     - name: cpd_operator_namespace
       type: string
@@ -26,11 +21,23 @@ spec:
       type: string
       default: ""
 
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
   stepTemplate:
     env:
-      - name: JUNIT_SUITE_NAME
-        value: $(params.junit_suite_name)
-
       - name: CPD_OPERATOR_NAMESPACE
         value: $(params.cpd_operator_namespace)
       - name: CPD_INSTANCE_NAMESPACE
@@ -40,6 +47,15 @@ spec:
         value: $(params.cpd_primary_storage_class)
       - name: CPD_METADATA_STORAGE_CLASS
         value: $(params.cpd_metadata_storage_class)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
 
   steps:
     - name: cp4d

--- a/pipelines/tasks/cp4d_service.yaml
+++ b/pipelines/tasks/cp4d_service.yaml
@@ -5,11 +5,6 @@ metadata:
   name: mas-devops-cp4d-service
 spec:
   params:
-    - name: junit_suite_name
-      type: string
-      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
-      default: ""
-
     # Namespace configuration (Optional, defaults built into Ansible role)
     - name: cpd_operator_namespace
       type: string
@@ -36,11 +31,23 @@ spec:
       description: Workspace ID
       default: ""
 
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
   stepTemplate:
     env:
-      - name: JUNIT_SUITE_NAME
-        value: $(params.junit_suite_name)
-
       - name: MAS_CONFIG_DIR
         value: /workspace/configs
       - name: MAS_INSTANCE_ID
@@ -57,6 +64,15 @@ spec:
         value: $(params.cpd_service_name)
       - name: CPD_SERVICE_STORAGE_CLASS
         value: $(params.cpd_service_storage_class)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
 
   steps:
     - name: cp4d-service

--- a/pipelines/tasks/db2.yaml
+++ b/pipelines/tasks/db2.yaml
@@ -5,11 +5,6 @@ metadata:
   name: mas-devops-db2
 spec:
   params:
-    - name: junit_suite_name
-      type: string
-      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
-      default: ""
-
     # Configure DB2W
     - name: db2_instance_name
       type: string
@@ -53,11 +48,23 @@ spec:
       type: string
       default: ""
 
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
   stepTemplate:
     env:
-      - name: JUNIT_SUITE_NAME
-        value: $(params.junit_suite_name)
-
       # Configure JdbcCfg
       - name: MAS_CONFIG_DIR
         value: /workspace/configs
@@ -78,7 +85,6 @@ spec:
       - name: DB2_TABLE_ORG
         value: $(params.db2_table_org)
 
-
       # Configure storage sizes (storage classes are set globally in the secret)
       - name: DB2_META_STORAGE_SIZE
         value: $(params.db2_meta_storage_size)
@@ -90,6 +96,15 @@ spec:
         value: $(params.db2_logs_storage_size)
       - name: DB2_TEMP_STORAGE_SIZE
         value: $(params.db2_temp_storage_size)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
 
   steps:
     - name: db2

--- a/pipelines/tasks/gencfg-workspace.yaml
+++ b/pipelines/tasks/gencfg-workspace.yaml
@@ -5,10 +5,6 @@ metadata:
   name: mas-devops-gencfg-workspace
 spec:
   params:
-    - name: junit_suite_name
-      type: string
-      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
-      default: ""
     - name: mas_instance_id
       type: string
       description: Instance ID
@@ -19,10 +15,23 @@ spec:
       type: string
       description: Workspace Name
 
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
   stepTemplate:
     env:
-      - name: JUNIT_SUITE_NAME
-        value: $(params.junit_suite_name)
       - name: MAS_CONFIG_DIR
         value: /workspace/configs
       - name: MAS_INSTANCE_ID
@@ -31,6 +40,15 @@ spec:
         value: $(params.mas_workspace_id)
       - name: MAS_WORKSPACE_NAME
         value: $(params.mas_workspace_name)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
 
   steps:
     - name: gencfg-workspace

--- a/pipelines/tasks/ibm-catalogs.yaml
+++ b/pipelines/tasks/ibm-catalogs.yaml
@@ -5,11 +5,6 @@ metadata:
   name: mas-devops-ibm-catalogs
 spec:
   params:
-    - name: junit_suite_name
-      type: string
-      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
-      default: ""
-
     - name: artifactory_username
       default: ''
       type: string
@@ -19,15 +14,36 @@ spec:
       type: string
       description: Required to install development MAS catalogs
 
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
   stepTemplate:
     env:
-      - name: JUNIT_SUITE_NAME
-        value: $(params.junit_suite_name)
-
       - name: ARTIFACTORY_USERNAME
         value: $(params.artifactory_username)
       - name: ARTIFACTORY_APIKEY
         value: $(params.artifactory_apikey)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
 
   steps:
     - name: ibm-catalogs

--- a/pipelines/tasks/ibm-catalogs.yaml
+++ b/pipelines/tasks/ibm-catalogs.yaml
@@ -16,6 +16,10 @@ spec:
 
     # Optional support built into the ansible-devops image
     # for saving task execution results to a MongoDb instance
+    - name: mas_instance_id
+      type: string
+      description: Optional MAS instance Id, used to enable save-junit-to-mongo.py
+      default: ""
     - name: devops_mongo_uri
       type: string
       description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
@@ -38,6 +42,8 @@ spec:
 
       # Optional support built into the ansible-devops image
       # for saving task execution results to a MongoDb instance
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
       - name: DEVOPS_MONGO_URI
         value: $(params.devops_mongo_uri)
       - name: DEVOPS_SUITE_NAME

--- a/pipelines/tasks/kafka.yaml
+++ b/pipelines/tasks/kafka.yaml
@@ -5,11 +5,6 @@ metadata:
   name: mas-devops-kafka
 spec:
   params:
-    - name: junit_suite_name
-      type: string
-      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
-      default: ""
-
     - name: mas_instance_id
       type: string
       description: Instance ID
@@ -28,11 +23,23 @@ spec:
       type: string
       default: "masuser"
 
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
   stepTemplate:
     env:
-      - name: JUNIT_SUITE_NAME
-        value: $(params.junit_suite_name)
-
       - name: MAS_CONFIG_DIR
         value: /workspace/configs
       - name: MAS_INSTANCE_ID
@@ -46,6 +53,15 @@ spec:
         value: $(params.kafka_cluster_size)
       - name: KAFKA_USER_NAME
         value: $(params.kafka_user_name)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
 
   steps:
     - name: kafka

--- a/pipelines/tasks/mongodb.yaml
+++ b/pipelines/tasks/mongodb.yaml
@@ -5,24 +5,41 @@ metadata:
   name: mas-devops-mongodb
 spec:
   params:
-    - name: junit_suite_name
-      type: string
-      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
-      default: ""
-
     - name: mas_instance_id
       type: string
       description: Instance ID
       default: "" # By default, no config will be generated
 
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
   stepTemplate:
     env:
-      - name: JUNIT_SUITE_NAME
-        value: $(params.junit_suite_name)
       - name: MAS_CONFIG_DIR
         value: /workspace/configs
       - name: MAS_INSTANCE_ID
         value: $(params.mas_instance_id)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
 
   steps:
     - name: mongodb

--- a/pipelines/tasks/nvidia-gpu.yaml
+++ b/pipelines/tasks/nvidia-gpu.yaml
@@ -5,15 +5,31 @@ metadata:
   name: mas-devops-nvidia-gpu
 spec:
   params:
-    - name: junit_suite_name
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
       type: string
       description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
       default: ""
 
   stepTemplate:
     env:
-      - name: JUNIT_SUITE_NAME
-        value: $(params.junit_suite_name)
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
 
   steps:
     - name: nvidi-gpu

--- a/pipelines/tasks/nvidia-gpu.yaml
+++ b/pipelines/tasks/nvidia-gpu.yaml
@@ -7,6 +7,10 @@ spec:
   params:
     # Optional support built into the ansible-devops image
     # for saving task execution results to a MongoDb instance
+    - name: mas_instance_id
+      type: string
+      description: Optional MAS instance Id, used to enable save-junit-to-mongo.py
+      default: ""
     - name: devops_mongo_uri
       type: string
       description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
@@ -24,6 +28,8 @@ spec:
     env:
       # Optional support built into the ansible-devops image
       # for saving task execution results to a MongoDb instance
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
       - name: DEVOPS_MONGO_URI
         value: $(params.devops_mongo_uri)
       - name: DEVOPS_SUITE_NAME

--- a/pipelines/tasks/sbo.yaml
+++ b/pipelines/tasks/sbo.yaml
@@ -10,6 +10,10 @@ spec:
 
     # Optional support built into the ansible-devops image
     # for saving task execution results to a MongoDb instance
+    - name: mas_instance_id
+      type: string
+      description: Optional MAS instance Id, used to enable save-junit-to-mongo.py
+      default: ""
     - name: devops_mongo_uri
       type: string
       description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
@@ -30,6 +34,8 @@ spec:
 
       # Optional support built into the ansible-devops image
       # for saving task execution results to a MongoDb instance
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
       - name: DEVOPS_MONGO_URI
         value: $(params.devops_mongo_uri)
       - name: DEVOPS_SUITE_NAME

--- a/pipelines/tasks/sbo.yaml
+++ b/pipelines/tasks/sbo.yaml
@@ -5,20 +5,37 @@ metadata:
   name: mas-devops-sbo
 spec:
   params:
-    - name: junit_suite_name
-      type: string
-      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
-      default: ""
-
     - name: mas_channel
       type: string
 
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
   stepTemplate:
     env:
-      - name: JUNIT_SUITE_NAME
-        value: $(params.junit_suite_name)
       - name: MAS_CHANNEL
         value: $(params.mas_channel)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
 
   steps:
     - name: sbo

--- a/pipelines/tasks/sls.yaml
+++ b/pipelines/tasks/sls.yaml
@@ -5,11 +5,6 @@ metadata:
   name: mas-devops-sls
 spec:
   params:
-    - name: junit_suite_name
-      type: string
-      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
-      default: ""
-
     - name: mas_instance_id
       type: string
       description: Instance ID
@@ -51,11 +46,23 @@ spec:
       type: string
       description: Required to use development MAS builds
 
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
   stepTemplate:
     env:
-      - name: JUNIT_SUITE_NAME
-        value: $(params.junit_suite_name)
-
       - name: MAS_CONFIG_DIR
         value: /workspace/configs
       - name: MAS_INSTANCE_ID
@@ -80,6 +87,15 @@ spec:
         value: $(params.artifactory_username)
       - name: ARTIFACTORY_APIKEY
         value: $(params.artifactory_apikey)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
 
   steps:
     - name: sls

--- a/pipelines/tasks/suite-app-config.yaml
+++ b/pipelines/tasks/suite-app-config.yaml
@@ -5,10 +5,6 @@ metadata:
   name: mas-devops-suite-app-config
 spec:
   params:
-    - name: junit_suite_name
-      type: string
-      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
-      default: ""
     - name: mas_app_id
       type: string
       description: Maximo Application Suite Application ID
@@ -22,10 +18,24 @@ spec:
     - name: mas_workspace_id
       type: string
       description: Maximo Application Suite Workspace ID
+
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
   stepTemplate:
     env:
-      - name: JUNIT_SUITE_NAME
-        value: $(params.junit_suite_name)
       - name: MAS_INSTANCE_ID
         value: $(params.mas_instance_id)
       - name: MAS_WORKSPACE_ID
@@ -34,6 +44,16 @@ spec:
         value: $(params.mas_app_id)
       - name: MAS_APPWS_COMPONENTS
         value: $(params.mas_appws_components)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
+
   steps:
     - name: suite-app-config
       command:

--- a/pipelines/tasks/suite-app-install.yaml
+++ b/pipelines/tasks/suite-app-install.yaml
@@ -5,11 +5,6 @@ metadata:
   name: mas-devops-suite-app-install
 spec:
   params:
-    - name: junit_suite_name
-      type: string
-      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
-      default: ""
-
     - name: artifactory_username
       default: ''
       type: string
@@ -49,11 +44,23 @@ spec:
       type: string
       description: Application specifications such as binding, settings, etc
 
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
   stepTemplate:
     env:
-      - name: JUNIT_SUITE_NAME
-        value: $(params.junit_suite_name)
-
       - name: MAS_INSTANCE_ID
         value: $(params.mas_instance_id)
 
@@ -78,6 +85,15 @@ spec:
         value: $(params.mas_app_catalog_source)
       - name: MAS_APP_SPEC
         value: $(params.mas_app_spec)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
 
   steps:
     - name: suite-app-install

--- a/pipelines/tasks/suite-config.yaml
+++ b/pipelines/tasks/suite-config.yaml
@@ -5,22 +5,40 @@ metadata:
   name: mas-devops-suite-config
 spec:
   params:
-    - name: junit_suite_name
-      type: string
-      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
-      default: ""
     - name: mas_instance_id
       type: string
       description: Instance ID
 
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
   stepTemplate:
     env:
-      - name: JUNIT_SUITE_NAME
-        value: $(params.junit_suite_name)
       - name: MAS_CONFIG_DIR
         value: /workspace/configs
       - name: MAS_INSTANCE_ID
         value: $(params.mas_instance_id)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
 
   steps:
     - name: suite-config

--- a/pipelines/tasks/suite-db2-setup-for-manage.yaml
+++ b/pipelines/tasks/suite-db2-setup-for-manage.yaml
@@ -15,6 +15,10 @@ spec:
 
     # Optional support built into the ansible-devops image
     # for saving task execution results to a MongoDb instance
+    - name: mas_instance_id
+      type: string
+      description: Optional MAS instance Id, used to enable save-junit-to-mongo.py
+      default: ""
     - name: devops_mongo_uri
       type: string
       description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
@@ -37,6 +41,8 @@ spec:
 
       # Optional support built into the ansible-devops image
       # for saving task execution results to a MongoDb instance
+      - name: MAS_INSTANCE_ID
+        value: $(params.mas_instance_id)
       - name: DEVOPS_MONGO_URI
         value: $(params.devops_mongo_uri)
       - name: DEVOPS_SUITE_NAME

--- a/pipelines/tasks/suite-db2-setup-for-manage.yaml
+++ b/pipelines/tasks/suite-db2-setup-for-manage.yaml
@@ -5,10 +5,6 @@ metadata:
   name: mas-devops-suite-db2-setup-for-manage
 spec:
   params:
-    - name: junit_suite_name
-      type: string
-      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
-      default: ""
     - name: db2_instance_name
       type: string
       description: Name (specifically, not the ID) of the DB2 Warehouse instance to execute the hack
@@ -16,14 +12,37 @@ spec:
       type: string
       description: Namespace where the DB2 Warehouse instance to execute the hack resides
       default: "db2u"
+
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
   stepTemplate:
     env:
-      - name: JUNIT_SUITE_NAME
-        value: $(params.junit_suite_name)
       - name: DB2_INSTANCE_NAME
         value: $(params.db2_instance_name)
       - name: DB2_NAMESPACE
         value: $(params.db2_namespace)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
 
   steps:
     - name: suite-db2-setup-for-manage

--- a/pipelines/tasks/suite-dns.yaml
+++ b/pipelines/tasks/suite-dns.yaml
@@ -5,20 +5,38 @@ metadata:
   name: mas-devops-suite-dns
 spec:
   params:
-    - name: junit_suite_name
-      type: string
-      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
-      default: ""
     - name: mas_instance_id
       type: string
       description: Instance ID
 
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
   stepTemplate:
     env:
-      - name: JUNIT_SUITE_NAME
-        value: $(params.junit_suite_name)
       - name: MAS_INSTANCE_ID
         value: $(params.mas_instance_id)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
 
   steps:
     - name: suite-dns

--- a/pipelines/tasks/suite-install.yaml
+++ b/pipelines/tasks/suite-install.yaml
@@ -5,11 +5,6 @@ metadata:
   name: mas-devops-suite-install
 spec:
   params:
-    - name: junit_suite_name
-      type: string
-      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
-      default: ""
-
     - name: mas_instance_id
       type: string
     - name: mas_channel
@@ -40,10 +35,23 @@ spec:
       type: string
       description: Required to install development MAS catalogs
 
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
   stepTemplate:
     env:
-      - name: JUNIT_SUITE_NAME
-        value: $(params.junit_suite_name)
       - name: MAS_CHANNEL
         value: $(params.mas_channel)
       - name: MAS_CATALOG_SOURCE
@@ -72,6 +80,15 @@ spec:
         value: $(params.mas_entitlement_username)
       - name: MAS_ENTITLEMENT_KEY
         value: $(params.mas_entitlement_key)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
 
   steps:
     - name: suite-install

--- a/pipelines/tasks/suite-verify.yaml
+++ b/pipelines/tasks/suite-verify.yaml
@@ -5,19 +5,37 @@ metadata:
   name: mas-devops-suite-verify
 spec:
   params:
-    - name: junit_suite_name
-      type: string
-      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
-      default: ""
     - name: mas_instance_id
       type: string
 
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
   stepTemplate:
     env:
-      - name: JUNIT_SUITE_NAME
-        value: $(params.junit_suite_name)
       - name: MAS_INSTANCE_ID
         value: $(params.mas_instance_id)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
 
   steps:
     - name: suite-verify

--- a/pipelines/tasks/uds.yaml
+++ b/pipelines/tasks/uds.yaml
@@ -5,10 +5,6 @@ metadata:
   name: mas-devops-uds
 spec:
   params:
-    - name: junit_suite_name
-      type: string
-      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
-      default: ""
     - name: mas_instance_id
       type: string
       default: ""
@@ -22,10 +18,23 @@ spec:
       type: string
       default: ""
 
+    # Optional support built into the ansible-devops image
+    # for saving task execution results to a MongoDb instance
+    - name: devops_mongo_uri
+      type: string
+      description: Optional MongoDb connection URI, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_suite_name
+      type: string
+      description: Optional name for the junit suite, used to enable save-junit-to-mongo.py
+      default: ""
+    - name: devops_build_number
+      type: string
+      description: Optional identifier for the execution run, used to enable save-junit-to-mongo.py
+      default: ""
+
   stepTemplate:
     env:
-      - name: JUNIT_SUITE_NAME
-        value: $(params.junit_suite_name)
       - name: MAS_CONFIG_DIR
         value: /workspace/configs
       - name: MAS_INSTANCE_ID
@@ -36,6 +45,15 @@ spec:
         value: $(params.uds_contact_firstname)
       - name: UDS_CONTACT_LASTNAME
         value: $(params.uds_contact_lastname)
+
+      # Optional support built into the ansible-devops image
+      # for saving task execution results to a MongoDb instance
+      - name: DEVOPS_MONGO_URI
+        value: $(params.devops_mongo_uri)
+      - name: DEVOPS_SUITE_NAME
+        value: $(params.devops_suite_name)
+      - name: DEVOPS_BUILD_NUMBER
+        value: $(params.devops_build_number)
 
   steps:
     - name: uds


### PR DESCRIPTION
- Support more optional parameters in Tekton tasks
- Doc updates
- Include support for `devops_mongo_uri`, `devops_suite_name`, and `devops_build_number` in all tasks.  These are key to internal FVT, and allow for pipeline execution results to be saved to a mongo database.