### PR TITLE
[patch] Fix handling of required properties in db2_setup role

### DIFF
--- a/ibm/mas_devops/playbooks/oneclick_add_manage.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_manage.yml
@@ -6,6 +6,10 @@
   vars:
     db2_instance_name: db2w-shared
 
+    # db2u role doesn't need this set, but suite_db2_setup_for_manage does, otherwise it will not
+    # know what namespace to look for the db2 isntance
+    db2_namespace: db2u
+
     mas_workspace_id: masdev
     mas_app_id: manage
 

--- a/ibm/mas_devops/roles/suite_db2_setup_for_manage/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_manage/tasks/main.yml
@@ -4,6 +4,13 @@
 
 # 1. Provide debug information to the user
 # -----------------------------------------------------------------------------
+- name: "Check required properties are set"
+  assert:
+    that:
+      - db2_namespace is defined and db2_namespace != ""
+      - db2_instance_name is defined and db2_instance_name != ""
+    fail_msg: "db2_namespace and db2_instance_name are both required properties"
+
 - name: "Debug information - part 1"
   debug:
     msg:


### PR DESCRIPTION
- The manage playbook doesn't define the required `db2_namespace` property
- The suite_db2_setup_for_manage role doesn't check for required properties being set

This results in confusing failure message when the role tries to copy files into the pod, especially if the user's active namespace if the `db2u` one as it will find the pod, but fail to copy to it.