### PR TITLE
[patch] db2u fix for NFS storage + remove cp4d settings

### DIFF
--- a/ibm/mas_devops/roles/db2/README.md
+++ b/ibm/mas_devops/roles/db2/README.md
@@ -1,7 +1,7 @@
 db2u
 ==========
 
-This role creates a Db2 Warehouse instance using the Db2u Operator. A namespace called `db2u` will be created and the db2u operator will be installed into the `ibm-common-services` namespace to service the `db2ucluster` requests in `db2u` namespace. A private root CA certificate is created and is used to secure the TLS connections to the database. A Db2 Warehouse cluster will be created along with a public TLS encrypted route to allow external access to the cluster (access is via port 443 on the route). Both the external route and the internal service use the same server certificate.
+This role creates a Db2 Warehouse instance using the Db2u Operator. A namespace called `db2u` will be created and the db2u operator will be installed into the `ibm-common-services` namespace to service the `db2ucluster` requests in `db2u` namespace. A private root CA certificate is created and is used to secure the TLS connections to the database. A Db2 Warehouse cluster will be created along with a public TLS encrypted route to allow external access to the cluster (access is via the ssl-server nodeport port on the *-db2u-engn-svc service). Internal access is via the *-db2u-engn-svc service and port 50001. Both the external route and the internal service use the same server certificate.
 
 The private root CA certificate and the server certificate are available from the `db2u-ca` and `db2u-certificate` secrets in the `db2u` namespace.  The default user is `db2inst1` and the password is available in the `instancepassword` secret in the same namespace.  You can examine the deployed resources in the `db2u` namespace:
 

--- a/ibm/mas_devops/roles/db2/tasks/main.yml
+++ b/ibm/mas_devops/roles/db2/tasks/main.yml
@@ -230,9 +230,8 @@
     definition: "{{ lookup('template', 'templates/tlsroute.yml.j2') }}"
 
 
-# 14. Delete db2 pod on intial setup only, to workaround db2 issue 
-# that was causing TLS connection issues when the pod was first 
-# started
+# 14. Delete db2 pod on intial setup only, to workaround db2 issue
+# that was causing TLS connection issues when the pod was first started
 # -----------------------------------------------------------------------------
 - name: Delete db2u pod on intial setup
   kubernetes.core.k8s:

--- a/ibm/mas_devops/roles/db2/tasks/main.yml
+++ b/ibm/mas_devops/roles/db2/tasks/main.yml
@@ -6,6 +6,10 @@
     that: db2_instance_name is defined and db2_instance_name != ""
     fail_msg: "db2_instance_name property has not been set"
 
+- name: "Fail if ENTITLEMENT_KEY has not been provided"
+  assert:
+    that: entitlement_key is defined and entitlement_key != ""
+    fail_msg: "ENTITLEMENT_KEY property has not been set"
 
 # 2. Load default storage classes (if not provided by the user)
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/db2/tasks/main.yml
+++ b/ibm/mas_devops/roles/db2/tasks/main.yml
@@ -12,7 +12,12 @@
 - include_tasks: tasks/determine-storage-classes.yml
 
 
-# 3. Provide debug information to the user
+# 3. Setup the norootsquash daemonsets for db2u pods to work with NFS backed storage
+# -----------------------------------------------------------------------------
+- include_tasks: tasks/setup_norootsquash.yml
+
+
+# 4. Provide debug information to the user
 # -----------------------------------------------------------------------------
 - name: "Debug information"
   debug:
@@ -30,7 +35,7 @@
       - "MAS Config directory ......... {{ mas_config_dir }}"
 
 
-# 4. Install a Db2u Operator
+# 5. Install a Db2u Operator
 # -----------------------------------------------------------------------------
 - name: "Create db2u Namespace"
   kubernetes.core.k8s:
@@ -69,7 +74,7 @@
     wait_timeout: 120
 
 
-# 5. Get the cluster subdomain to be used for the certificate and route creation
+# 6. Get the cluster subdomain to be used for the certificate and route creation
 # -----------------------------------------------------------------------------
 - name: "Get cluster subdomain"
   kubernetes.core.k8s_info:
@@ -79,7 +84,7 @@
   register: _cluster_subdomain
 
 
-# 6. Create self-signed certificate for Db2u SSL
+# 7. Create self-signed certificate for Db2u SSL
 # -----------------------------------------------------------------------------
 - name: "Create internal CA certificate issuer"
   kubernetes.core.k8s:
@@ -110,7 +115,7 @@
     definition: "{{ lookup('template', 'templates/certs/certificate.yml.j2') }}"
   register: createCertificate
 
-# 7. Taint and label dedicated node if specified
+# 8. Taint and label dedicated node if specified
 # -----------------------------------------------------------------------------
 - name: Taint and label dedicated worker node
   when:
@@ -123,7 +128,7 @@
     oc adm uncordon {{ db2_dedicated_node }}
 
 
-# 8. Wait until the Db2uCluster CRD is available
+# 9. Wait until the Db2uCluster CRD is available
 # -----------------------------------------------------------------------------
 - name: "Wait until the Db2uCluster CRD is available"
   kubernetes.core.k8s_info:
@@ -144,7 +149,18 @@
     - db2_crd_info.resources | length > 0
 
 
-# 9. Create a Db2 instance
+# 10. Lookup db2 instance to see if it exists already
+# -----------------------------------------------------------------------------
+- name: "See if db2u instance already exists"
+  kubernetes.core.k8s_info:
+    api_version: db2u.databases.ibm.com/v1
+    name: "{{ db2_instance_name | lower }}"
+    namespace: "{{db2_namespace}}"
+    kind: Db2uCluster
+  register: initial_db2_cluster_lookup
+
+
+# 11. Create a Db2 instance
 # -----------------------------------------------------------------------------
 - name: "Create db2 instance"
   kubernetes.core.k8s:
@@ -152,7 +168,7 @@
     definition: "{{ lookup('template', 'templates/db2ucluster.yml.j2') }}"
 
 
-# 10. Wait for the cluster to be ready
+# 12. Wait for the cluster to be ready
 # -----------------------------------------------------------------------------
 - name: "Wait for db2u instance to be ready (5m delay)"
   kubernetes.core.k8s_info:
@@ -170,7 +186,7 @@
   delay: 300 # 5 minutes
 
 
-# 11. Configure a public route for Db2
+# 13. Configure a public route for Db2
 # -----------------------------------------------------------------------------
 - name: Lookup db2u Engn Service
   kubernetes.core.k8s_info:
@@ -214,7 +230,21 @@
     definition: "{{ lookup('template', 'templates/tlsroute.yml.j2') }}"
 
 
-# 12. Generate a JdbcCfg for MAS configuration
+# 14. Delete db2 pod on intial setup only, to workaround db2 issue 
+# that was causing TLS connection issues when the pod was first 
+# started
+# -----------------------------------------------------------------------------
+- name: Delete db2u pod on intial setup
+  kubernetes.core.k8s:
+    api_version: v1
+    kind: Pod
+    name: "c-{{db2_instance_name | lower}}-db2u-0"
+    namespace: "{{db2_namespace}}"
+    state: absent
+  when: initial_db2_cluster_lookup.resources | length == 0
+
+
+# 15. Generate a JdbcCfg for MAS configuration
 # -----------------------------------------------------------------------------
 - include_tasks: tasks/suite_jdbccfg.yml
   when:

--- a/ibm/mas_devops/roles/db2/tasks/setup_norootsquash.yml
+++ b/ibm/mas_devops/roles/db2/tasks/setup_norootsquash.yml
@@ -1,0 +1,58 @@
+---
+# If you are using IBM® Cloud File Storage (ibmc-file-gold-gid storage class) for Red Hat® OpenShift® Kubernetes Service with Db2®,
+# you must use the cp.icr.io/cp/cpd/norootsquash:3.0-amd64 image to set no_root_squash.
+
+# 1. Set 'cpregistrysecret' secret content
+# -----------------------------------------------------------------------------
+- name: Set 'ibm-registry' secret content
+  vars:
+    entitledAuthStr: "{{ registry_user }}:{{ entitlement_key }}"
+    entitledAuth: "{{ entitledAuthStr | b64encode }}"
+    content:
+      - "{\"auths\":{\"{{ registry }}/cp/cpd\":{\"username\":\"{{ registry_user }}\",\"password\":\"{{ entitlement_key }}\",\"email\":\"{{ registry_user }}\",\"auth\":\"{{ entitledAuth }}\"}"
+      - "}"
+      - "}"
+  set_fact:
+    new_secret: "{{ content | join('') }}"
+
+
+# 2. Generate 'ibm-registry' secret
+# -----------------------------------------------------------------------------
+- name: "Generate 'ibm-registry' secret"
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: v1
+      kind: Secret
+      type: kubernetes.io/dockerconfigjson
+      metadata:
+        name: ibm-registry
+        namespace: kube-system
+      data:
+        .dockerconfigjson: "{{ new_secret | to_json | b64encode }}"
+  register: secretUpdateResult
+
+
+# 3. Create DaemonSet
+# -----------------------------------------------------------------------------
+- name: Create 'norootsquash' DaemonSet
+  kubernetes.core.k8s:
+    definition: "{{ lookup('template', 'templates/norootsquash_daemonset.yml.j2') }}"
+    wait: yes
+    wait_timeout: 120
+
+
+# 4. Wait for 'norootsquash' DaemonSet to be running
+# -----------------------------------------------------------------------------
+- name: "Wait for 'norootsquash' DaemonSet to be running"
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    name: norootsquash
+    namespace: kube-system
+    kind: DaemonSet
+  register: daemonset_output
+  until:
+    - daemonset_output.resources is defined
+    - daemonset_output.resources | length > 0
+    - daemonset_output.resources[0].status.numberReady > 0
+  retries: 60 # approx 60 minutes before we give up
+  delay: 60 # 1 minute

--- a/ibm/mas_devops/roles/db2/templates/db2ucluster.yml.j2
+++ b/ibm/mas_devops/roles/db2/templates/db2ucluster.yml.j2
@@ -15,9 +15,6 @@ spec:
     rest:
       enabled: false
 
-  advOpts:
-    db2SecurityPlugin: cloud_gss_plugin
-
   version: "{{ db2_version }}"
   size: {{ db2_num_pods }}
 
@@ -53,11 +50,7 @@ spec:
         DB2AUTH: 'OSAUTHDB,ALLOW_LOCAL_FALLBACK,PLUGIN_AUTO_RELOAD'
         DB2_FMP_RUN_AS_CONNECTED_USER: 'NO'
         DB2_WORKLOAD: {{ db2_workload }}
-      dbmConfig:
-        SRVCON_PW_PLUGIN: IBMIAMauthpwfile
-        group_plugin: IBMIAMauthgroup
-        srvcon_auth: GSS_SERVER_ENCRYPT
-        srvcon_gssplugin_list: IBMIAMauth
+
     mln:
       total: {{ db2_mln_count }}
 

--- a/ibm/mas_devops/roles/db2/templates/norootsquash_daemonset.yml.j2
+++ b/ibm/mas_devops/roles/db2/templates/norootsquash_daemonset.yml.j2
@@ -1,0 +1,56 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: norootsquash
+  namespace: kube-system
+  labels:
+    tier: management
+    app: norootsquash
+spec:
+  selector:
+    matchLabels:
+      name: norootsquash
+  template:
+    metadata:
+      labels:
+        name: norootsquash
+    spec:
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      containers:
+        - resources:
+            requests:
+              cpu: 0.01
+          name: systemdutil01
+          image: cp.icr.io/cp/cpd/norootsquash:3.0-amd64
+          imagePullPolicy: Always
+          args: ["-option", "restart", "-service", "nfs-idmapd.service"]
+          volumeMounts:
+            - mountPath: /host/etc
+              name: host-etc
+            - mountPath: /host/var/log
+              name: host-log
+              readOnly: true
+            - mountPath: /run/systemd
+              name: host-systemd
+            - mountPath: /host/sys
+              name: host-sys
+      imagePullSecrets:
+        - name: ibm-registry
+      tolerations:
+        - operator: Exists
+      volumes:
+        - name: host-etc
+          hostPath:
+            path: /etc
+        - name: host-log
+          hostPath:
+            path: /var/log
+        - name: host-systemd
+          hostPath:
+            path: /run/systemd
+        - name: host-sys
+          hostPath:
+            path: /sys


### PR DESCRIPTION
Updates the db2 role so that the noroot_squash daemonset is created which is needed for file storage backed by NFS.

Also removes settings from the db2ucluster that linked the user registry for db2ucluster to an instance of cp4d. As there is no cp4d then this won't work and will also stop ldap user registry configuration.

Also deletes the db2 pod if the db2ucluster is newly created to workaround the issue with db2u not allowing TLS connects when it first started.