### PR TITLE
[patch] Make common-services catalog source configurable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,37 @@ Note that during a build the version of the ansible collection is automatically 
 
 
 ## Building the collection locally
-```bash
-cd ibm/mas_devops
 
-ansible-galaxy collection build --force && ansible-galaxy collection install ibm-mas_devops-11.0.0.tar.gz --force
+```bash
+# Build
+ansible-galaxy collection build --output-path image/ansible-devops/ ibm/mas_devops --force && mv image/ansible-devops/ibm-mas_devops-11.0.0.tar.gz image/ansible-devops/ibm-mas_devops.tar.gz
+
+# Install
+ansible-galaxy collection install image/ansible-devops/ibm-mas_devops.tar.gz --force
+
+# Run Ansible Playbook
+export REGISTRY_PUBLIC_HOST=xxx
+export IBM_ENTITLEMENT_KEY=xxx
+ansible-playbook ibm.mas_devops.mirror_sls
+
+# Build docker image
+docker build -t ansible-devops:local image/ansible-devops
+
+# Run Ansible Container
+docker run -ti ansible-devops:local bash
+```
+
+
+## Ultimate one-liner
+Build the collection, build the docker container, run the docker container ...
+```bash
+ansible-galaxy collection build --output-path image/ansible-devops/ ibm/mas_devops --force && mv image/ansible-devops/ibm-mas_devops-11.0.0.tar.gz image/ansible-devops/ibm-mas_devops.tar.gz && ansible-galaxy collection install image/ansible-devops/ibm-mas_devops.tar.gz --force && docker build -t ansible-devops image/ansible-devops && docker run -ti ansible-devops:local bash
+```
+
+
+## Building the collection locally
+```bash
+ansible-galaxy collection build ibm/mas_devops --force && ansible-galaxy collection install ibm-mas_devops-11.0.0.tar.gz --force
 ansible-playbook ibm.mas_devops.playbook
 ```
 

--- a/build/bin/initbuild.sh
+++ b/build/bin/initbuild.sh
@@ -76,7 +76,7 @@ else
 
   # See: https://github.com/fsaintjacques/semver-tool/blob/master/src/semver
   if [ "${SEMVER_RELEASE_LEVEL}" == "initial" ]; then
-    echo $SEMVER_LAST_TAG > $VERSION_FILE
+    echo "1.0.0" > $VERSION_FILE
     echo "Configuring semver for initial release of $(cat $VERSION_FILE)"
   elif [[ "${SEMVER_RELEASE_LEVEL}" =~ ^(major|minor|patch)$ ]]; then
     semver bump ${SEMVER_RELEASE_LEVEL} ${SEMVER_LAST_TAG} > $VERSION_FILE

--- a/ibm/mas_devops/galaxy.yml
+++ b/ibm/mas_devops/galaxy.yml
@@ -4,7 +4,7 @@ version: 11.0.0
 readme: README.md
 authors:
   - David Parker <parkerda@uk.ibm.com>
-  - Paul Stone
+  - Paul Stone <stonepd@uk.ibm.com>
   - Tom Klapiscak
   - Andrew Whitfield
   - Caio Pereira <caiofcp@br.ibm.com>

--- a/ibm/mas_devops/roles/common_services/README.md
+++ b/ibm/mas_devops/roles/common_services/README.md
@@ -10,6 +10,16 @@ This will result in the following operators being installed in the `ibm-common-s
 Also, an operator group will be created in the namespace if one does not already exist.
 
 
+Role Variables
+--------------
+### common_services_catalog_source
+Used to override the operator catalog source used when creating the `ibm-common-service-operator` subscription.
+
+- Optional
+- Environment Variable: `COMMON_SERVICES_CATALOG_SOURCE`
+- Default Value: `ibm-operator-catalog`
+
+
 Example Playbook
 ----------------
 

--- a/ibm/mas_devops/roles/common_services/defaults/main.yml
+++ b/ibm/mas_devops/roles/common_services/defaults/main.yml
@@ -1,0 +1,1 @@
+common_services_catalog_source: "{{ lookup('env', 'COMMON_SERVICES_CATALOG_SOURCE') | default('ibm-operator-catalog', true) }}"

--- a/ibm/mas_devops/roles/common_services/defaults/main.yml
+++ b/ibm/mas_devops/roles/common_services/defaults/main.yml
@@ -1,1 +1,2 @@
+---
 common_services_catalog_source: "{{ lookup('env', 'COMMON_SERVICES_CATALOG_SOURCE') | default('ibm-operator-catalog', true) }}"

--- a/ibm/mas_devops/roles/common_services/templates/subscription.yml.j2
+++ b/ibm/mas_devops/roles/common_services/templates/subscription.yml.j2
@@ -24,5 +24,5 @@ spec:
   channel: v3
   installPlanApproval: Automatic
   name: ibm-common-service-operator
-  source: ibm-operator-catalog
+  source: {{ common_services_catalog_source }}
   sourceNamespace: openshift-marketplace

--- a/pipelines/tasks/common-services.yaml
+++ b/pipelines/tasks/common-services.yaml
@@ -5,6 +5,10 @@ metadata:
   name: mas-devops-common-services
 spec:
   params:
+    - name: common_services_catalog_source
+      type: string
+      default: ""
+
     # Optional support built into the ansible-devops image
     # for saving task execution results to a MongoDb instance
     - name: mas_instance_id
@@ -26,6 +30,8 @@ spec:
 
   stepTemplate:
     env:
+      - name: COMMON_SERVICES_CATALOG_SOURCE
+        value: $(params.common_services_catalog_source)
       # Optional support built into the ansible-devops image
       # for saving task execution results to a MongoDb instance
       - name: MAS_INSTANCE_ID


### PR DESCRIPTION
Exposes new **optional** parameter `common_services_catalog_source` and associated environment variable `COMMON_SERVICES_CATALOG_SOURCE`.  The primary use of these is when performing an air gap install.