### PR TITLE
[patch] Change default ROKS worker flavour

### DIFF
--- a/ibm/mas_devops/roles/ocp_provision/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/defaults/main.yml
@@ -29,8 +29,8 @@ ibmcloud_apikey: "{{ lookup('env', 'IBMCLOUD_APIKEY') }}"
 ibmcloud_resourcegroup: "{{ lookup('env', 'IBMCLOUD_RESOURCEGROUP') | default('Default', true) }}"
 
 roks_zone: "{{ lookup('env', 'ROKS_ZONE') | default('lon02', true) }}"
-roks_flavor: "{{ lookup('env', 'ROKS_FLAVOR') | default('b3c.8x32', true) }}"
-roks_workers: "{{ lookup('env', 'ROKS_WORKERS') | default('6', true) }}"
+roks_flavor: "{{ lookup('env', 'ROKS_FLAVOR') | default('b3c.16x64.300gb', true) }}"
+roks_workers: "{{ lookup('env', 'ROKS_WORKERS') | default('3', true) }}"
 roks_flags: "{{ lookup('env', 'ROKS_FLAGS') | default('', true) }}"
 
 # Quickburn defaults


### PR DESCRIPTION
Convert from six 8x32 worker nodes to three 16x64.300gb worker nodes.  This gives us a significant increase in local disk capacity on each worker (and a 50% increase in total disk capacity across the cluster) ... and it actually works out 10 cents/hour cheaper for customers for the same CPU and memory.