### PR TITLE
[patch] Install container-service plugin

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,6 +1,9 @@
 ## Changes
 Note that links to pull requests prior to public release of the code (4.0) direct to IBM GitHub Enterprise, and will only be accessible to IBM employees.
-- `10.1` Update suite application roles to support Optimizer application ([309](https://github.com/ibm-mas/ansible-devops/pull/309))
+
+- `10.1` Multiple Updates:
+    - Update suite application roles to support Optimizer application ([309](https://github.com/ibm-mas/ansible-devops/pull/309))
+    - Support AIO configuration in Manage ([316](https://github.com/ibm-mas/ansible-devops/pull/316))
 - `10.0` One-click installer support ([#285](https://github.com/ibm-mas/ansible-devops/pull/285), [#296](https://github.com/ibm-mas/ansible-devops/pull/296), [#299](https://github.com/ibm-mas/ansible-devops/pull/299))
 - `9.0` Multiple Updates:
     - Added ability to set annotations onto suite CR ([#269](https://github.com/ibm-mas/ansible-devops/pull/269))

--- a/ibm/mas_devops/README.md
+++ b/ibm/mas_devops/README.md
@@ -6,7 +6,9 @@
 ## Change Log
 Note that links to pull requests prior to public release of the code (4.0) direct to IBM GitHub Enterprise, and will only be accessible to IBM employees.
 
-- `10.1` Update suite application roles to support Optimizer application ([309](https://github.com/ibm-mas/ansible-devops/pull/309))
+- `10.1` Multiple Updates:
+    - Update suite application roles to support Optimizer application ([309](https://github.com/ibm-mas/ansible-devops/pull/309))
+    - Support AIO configuration in Manage ([316](https://github.com/ibm-mas/ansible-devops/pull/316))
 - `10.0` One-click installer support ([#285](https://github.com/ibm-mas/ansible-devops/pull/285), [#296](https://github.com/ibm-mas/ansible-devops/pull/296), [#299](https://github.com/ibm-mas/ansible-devops/pull/299))
 - `9.0` Multiple Updates:
     - Added ability to set annotations onto suite CR  ([#269](https://github.com/ibm-mas/ansible-devops/pull/269)

--- a/image/ansible-devops/Dockerfile
+++ b/image/ansible-devops/Dockerfile
@@ -24,8 +24,8 @@ RUN python3 -m pip install --upgrade pip && python3 -m pip install -r requiremen
 
 # Install Ansible Collections
 COPY ibm-mas_devops.tar.gz ${HOME}/ibm-mas_devops.tar.gz
-RUN ansible-galaxy collection install ${HOME}/ibm-mas_devops.tar.gz -p /opt/app-root/lib64/python3.8/site-packages/ansible_collections --force && \
-    ansible-galaxy collection install -r ${HOME}/requirements.yml -p /opt/app-root/lib64/python3.8/site-packages/ansible_collections
+RUN ansible-galaxy collection install ${HOME}/ibm-mas_devops.tar.gz -p /opt/app-root/lib64/python3.9/site-packages/ansible_collections --force && \
+    ansible-galaxy collection install -r ${HOME}/requirements.yml -p /opt/app-root/lib64/python3.9/site-packages/ansible_collections
 
 RUN chmod -R ug+rwx ${HOME}/env.sh && \
     chmod -R ug+rwx ${HOME}/.ansible && \

--- a/image/ansible-devops/Dockerfile
+++ b/image/ansible-devops/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/python-38
+FROM registry.access.redhat.com/ubi8/python-39
 
 # Running as userId = default
 # HOME=/opt/app-root

--- a/image/ansible-devops/Dockerfile
+++ b/image/ansible-devops/Dockerfile
@@ -26,6 +26,7 @@ RUN python3 -m pip install --upgrade pip && python3 -m pip install -r requiremen
 COPY ibm-mas_devops.tar.gz ${HOME}/ibm-mas_devops.tar.gz
 RUN ansible-galaxy collection install ${HOME}/ibm-mas_devops.tar.gz -p /opt/app-root/lib64/python3.8/site-packages/ansible_collections --force && \
     ansible-galaxy collection install -r ${HOME}/requirements.yml -p /opt/app-root/lib64/python3.8/site-packages/ansible_collections
+
 RUN chmod -R ug+rwx ${HOME}/env.sh && \
     chmod -R ug+rwx ${HOME}/.ansible && \
     chmod a+x ${HOME}/run-playbook.sh && \
@@ -39,11 +40,13 @@ RUN wget -q https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.8
     mv kubectl /usr/local/bin/ && \
     rm -rf openshift-client-linux.tar.gz
 
-# Install IBM CLoud CLI
+# Install IBM CLoud CLI with container-service plugin
 RUN wget -q https://download.clis.cloud.ibm.com/ibm-cloud-cli/2.3.0/IBM_Cloud_CLI_2.3.0_amd64.tar.gz &&\
     tar -xvzf IBM_Cloud_CLI_2.3.0_amd64.tar.gz && \
     mv Bluemix_CLI/bin/ibmcloud /usr/local/bin/  && \
-    rm -rf Bluemix_CLI IBM_Cloud_CLI_2.3.0_amd64.tar.gz
+    rm -rf Bluemix_CLI IBM_Cloud_CLI_2.3.0_amd64.tar.gz && \
+    ibmcloud plugin repo-plugins -r 'IBM Cloud' && \
+    ibmcloud plugin install container-service
 
 ENV ANSIBLE_CONFIG=/opt/app-root/src/ansible.cfg
 


### PR DESCRIPTION
- The docker image already installs the IBM Cloud CLI, but needs the IBM `container-service` plugin enabled as well to be able to do anything useful in the context of this collection.
- Also upgrades the Python runtime in the Docker image from 3.8 to 3.9