### PR TITLE
[patch] Loop until we find the registry PVC

### DIFF
--- a/ibm/mas_devops/roles/ocp_roks_upgrade_registry_storage/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_roks_upgrade_registry_storage/tasks/main.yml
@@ -16,13 +16,12 @@
     name: image-registry-storage
     namespace: openshift-image-registry
   register: lookup_registry_pvc
-
-- name: "Check that we could find the PVC"
-  assert:
-    that:
-      - lookup_registry_pvc.resources is defined
-      - lookup_registry_pvc.resources | length == 1
-      - lookup_registry_pvc.resources[0].spec.volumeName is defined
+  retries: 20 # 10 minutes
+  delay: 30
+  until:
+    - lookup_registry_pvc.resources is defined
+    - lookup_registry_pvc.resources | length == 1
+    - lookup_registry_pvc.resources[0].spec.volumeName is defined
 
 - name: "Set PVC ID"
   set_fact:


### PR DESCRIPTION
There's a timing window where the PVC doesn't yet exist.  Addition of a simple retry loop should close this window.