### PR TITLE
[minor] Consolidate entitlement management

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,46 +4,19 @@ Note that during a build the version of the ansible collection is automatically 
 
 
 ## Building the collection locally
+- Build and install the collection `make ansible-all` (default action)
+- Build the collection `make ansible-build`
+- Install the already built collection `make ansible-install`
 
+### Testing a role
 ```bash
-# Build
-ansible-galaxy collection build --output-path image/ansible-devops/ ibm/mas_devops --force && mv image/ansible-devops/ibm-mas_devops-11.0.0.tar.gz image/ansible-devops/ibm-mas_devops.tar.gz
-
-# Install
-ansible-galaxy collection install image/ansible-devops/ibm-mas_devops.tar.gz --force
-
-# Run Ansible Playbook
-export REGISTRY_PUBLIC_HOST=xxx
-export IBM_ENTITLEMENT_KEY=xxx
-ansible-playbook ibm.mas_devops.mirror_sls
-
-# Build docker image
-docker build -t ansible-devops:local image/ansible-devops
-
-# Run Ansible Container
-docker run -ti ansible-devops:local bash
+export ROLE_NAME=ibm_catalogs && make && ansible-playbook ibm.mas_devops.run_role
 ```
 
-
-## Ultimate one-liner
-Build the collection, build the docker container, run the docker container ...
-```bash
-ansible-galaxy collection build --output-path image/ansible-devops/ ibm/mas_devops --force && mv image/ansible-devops/ibm-mas_devops-11.0.0.tar.gz image/ansible-devops/ibm-mas_devops.tar.gz && ansible-galaxy collection install image/ansible-devops/ibm-mas_devops.tar.gz --force && docker build -t ansible-devops image/ansible-devops && docker run -ti ansible-devops:local bash
-```
-
-
-## Building the collection locally
-```bash
-ansible-galaxy collection build ibm/mas_devops --force && ansible-galaxy collection install ibm-mas_devops-11.0.0.tar.gz --force
-ansible-playbook ibm.mas_devops.playbook
-```
-
-
-## Testing a role
-```bash
-cd ~/ibm-mas/ansible-devops/ibm/mas_devops$
-export ROLE_NAME=ibm_catalogs && ansible-galaxy collection build --force && ansible-galaxy collection install ibm-mas_devops-11.0.0.tar.gz --force && ansible-playbook ibm.mas_devops.run_role
-```
+## Building the container image locally
+- Build the container image `make docker-build`
+- Run the already built container image `make docker-run`
+- Build and run the container image `make docker-all`
 
 
 ## Using the docker image

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 .PHONY: ansible-build ansible-install ansible-all docker-build docker-run docker-all clean
 
-.DEFAULT_GOAL := build-install
+.DEFAULT_GOAL := ansible-all
 
 ansible-build:
 	ansible-galaxy collection build --output-path image/ansible-devops/app-root ibm/mas_devops --force

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+.PHONY: ansible-build ansible-install ansible-all docker-build docker-run docker-all clean
+
+.DEFAULT_GOAL := build-install
+
+ansible-build:
+	ansible-galaxy collection build --output-path image/ansible-devops/app-root ibm/mas_devops --force
+	mv image/ansible-devops/app-root/ibm-mas_devops-11.0.0.tar.gz image/ansible-devops/app-root/ibm-mas_devops.tar.gz
+ansible-install:
+	ansible-galaxy collection install image/ansible-devops/app-root/ibm-mas_devops.tar.gz --force
+ansible-all: ansible-build ansible-install
+
+docker-build:
+	docker build -t ansible-devops:local image/ansible-devops
+docker-run:
+	docker run -ti ansible-devops:local
+docker-all: docker-build docker-run
+
+clean:
+	rm image/ansible-devops/ibm-mas_devops.tar.gz

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -4,6 +4,7 @@ Note that links to pull requests prior to public release of the code (4.0) direc
 - `10.1` Multiple Updates:
     - Update suite application roles to support Optimizer application ([309](https://github.com/ibm-mas/ansible-devops/pull/309))
     - Support AIO configuration in Manage ([316](https://github.com/ibm-mas/ansible-devops/pull/316))
+    - Consolidate entitlement management ([323](https://github.com/ibm-mas/ansible-devops/pull/323))
 - `10.0` One-click installer support ([#285](https://github.com/ibm-mas/ansible-devops/pull/285), [#296](https://github.com/ibm-mas/ansible-devops/pull/296), [#299](https://github.com/ibm-mas/ansible-devops/pull/299))
 - `9.0` Multiple Updates:
     - Added ability to set annotations onto suite CR ([#269](https://github.com/ibm-mas/ansible-devops/pull/269))

--- a/ibm/mas_devops/README.md
+++ b/ibm/mas_devops/README.md
@@ -9,9 +9,10 @@ Note that links to pull requests prior to public release of the code (4.0) direc
 - `10.1` Multiple Updates:
     - Update suite application roles to support Optimizer application ([309](https://github.com/ibm-mas/ansible-devops/pull/309))
     - Support AIO configuration in Manage ([316](https://github.com/ibm-mas/ansible-devops/pull/316))
+    - Consolidate entitlement management ([323](https://github.com/ibm-mas/ansible-devops/pull/323))
 - `10.0` One-click installer support ([#285](https://github.com/ibm-mas/ansible-devops/pull/285), [#296](https://github.com/ibm-mas/ansible-devops/pull/296), [#299](https://github.com/ibm-mas/ansible-devops/pull/299))
 - `9.0` Multiple Updates:
-    - Added ability to set annotations onto suite CR  ([#269](https://github.com/ibm-mas/ansible-devops/pull/269)
+    - Added ability to set annotations onto suite CR ([#269](https://github.com/ibm-mas/ansible-devops/pull/269)
     - Add Assist install playbooks ([#271](https://github.com/ibm-mas/ansible-devops/pull/271)
     - Added gencfg-sls and gencfg-uds playbooks for using existing SLS and UDS ([#275](https://github.com/ibm-mas/ansible-devops/pull/275)
     - Add new required var CPD_METADB_BLOCK_STORAGE_CLASS for CP4D 4.0 ([#273](https://github.com/ibm-mas/ansible-devops/pull/273)

--- a/ibm/mas_devops/playbooks/cp4d.yml
+++ b/ibm/mas_devops/playbooks/cp4d.yml
@@ -2,7 +2,7 @@
 - hosts: localhost
   any_errors_fatal: true
   vars:
-    install_watson_studio: true
+    install_watson_studio: false
 
   roles:
     - name: ibm.mas_devops.ibm_catalogs

--- a/ibm/mas_devops/playbooks/cp4d.yml
+++ b/ibm/mas_devops/playbooks/cp4d.yml
@@ -5,7 +5,8 @@
     install_cp4d: false
     install_watson_studio: false
     install_watson_machine_learning: false
-    install_analytics_engine: true
+    install_analytics_engine: false
+    install_watson_openscale: true
     cpd_product_version: 4.0.9
 
   roles:
@@ -28,8 +29,14 @@
       vars:
         cpd_service_name: wml
 
-    # Analytics Engine Powered by Apache Spark (? hours)
+    # Analytics Engine Powered by Apache Spark (30 minutes)
     - name: ibm.mas_devops.cp4d_service
       when: install_analytics_engine == true
       vars:
         cpd_service_name: spark
+
+    # Watson OpenScale (? hours)
+    - name: ibm.mas_devops.cp4d_service
+      when: install_watson_openscale == true
+      vars:
+        cpd_service_name: aiopenscale

--- a/ibm/mas_devops/playbooks/cp4d.yml
+++ b/ibm/mas_devops/playbooks/cp4d.yml
@@ -2,14 +2,34 @@
 - hosts: localhost
   any_errors_fatal: true
   vars:
-    install_watson_studio: true
+    install_cp4d: false
+    install_watson_studio: false
+    install_watson_machine_learning: false
+    install_analytics_engine: true
+    cpd_product_version: 4.0.9
 
   roles:
     - name: ibm.mas_devops.ibm_catalogs
+      when: install_cp4d == true
     - name: ibm.mas_devops.common_services
+      when: install_cp4d == true
     - name: ibm.mas_devops.cp4d
+      when: install_cp4d == true
+
+    # Watson Studio (~3 hours)
     - name: ibm.mas_devops.cp4d_service
       when: install_watson_studio == true
       vars:
         cpd_service_name: wsl
-        cpd_product_version: 4.0.9
+
+    # Watson Machine Learning (~2 hours)
+    - name: ibm.mas_devops.cp4d_service
+      when: install_watson_machine_learning == true
+      vars:
+        cpd_service_name: wml
+
+    # Analytics Engine Powered by Apache Spark (? hours)
+    - name: ibm.mas_devops.cp4d_service
+      when: install_analytics_engine == true
+      vars:
+        cpd_service_name: spark

--- a/ibm/mas_devops/playbooks/cp4d.yml
+++ b/ibm/mas_devops/playbooks/cp4d.yml
@@ -2,20 +2,21 @@
 - hosts: localhost
   any_errors_fatal: true
   vars:
-    install_cp4d: false
-    install_watson_studio: false
-    install_watson_machine_learning: false
-    install_analytics_engine: false
+    install_cp4d_platform: true
+    install_watson_studio: true
+    install_watson_machine_learning: true
+    install_analytics_engine: true
     install_watson_openscale: true
+    install_watson_discovery: true
     cpd_product_version: 4.0.9
 
   roles:
     - name: ibm.mas_devops.ibm_catalogs
-      when: install_cp4d == true
+      when: install_cp4d_platform == true
     - name: ibm.mas_devops.common_services
-      when: install_cp4d == true
+      when: install_cp4d_platform == true
     - name: ibm.mas_devops.cp4d
-      when: install_cp4d == true
+      when: install_cp4d_platform == true
 
     # Watson Studio (~3 hours)
     - name: ibm.mas_devops.cp4d_service
@@ -29,14 +30,20 @@
       vars:
         cpd_service_name: wml
 
-    # Analytics Engine Powered by Apache Spark (30 minutes)
+    # Analytics Engine Powered by Apache Spark (~30 minutes)
     - name: ibm.mas_devops.cp4d_service
       when: install_analytics_engine == true
       vars:
         cpd_service_name: spark
 
-    # Watson OpenScale (? hours)
+    # Watson OpenScale (~1 hour)
     - name: ibm.mas_devops.cp4d_service
       when: install_watson_openscale == true
       vars:
         cpd_service_name: aiopenscale
+
+    # Watson Discovery (~1 hour)
+    - name: ibm.mas_devops.cp4d_service
+      when: install_watson_discovery == true
+      vars:
+        cpd_service_name: wd

--- a/ibm/mas_devops/playbooks/cp4d.yml
+++ b/ibm/mas_devops/playbooks/cp4d.yml
@@ -2,15 +2,16 @@
 - hosts: localhost
   any_errors_fatal: true
   vars:
-    install_cp4d_platform: true
-    install_watson_studio: true
-    install_watson_machine_learning: true
-    install_analytics_engine: true
-    install_watson_openscale: true
+    install_cp4d_platform: false
+    install_watson_studio: false
+    install_watson_machine_learning: false
+    install_analytics_engine: false
+    install_watson_openscale: false
     install_watson_discovery: true
     cpd_product_version: "4.0.9"
 
   roles:
+    # Cloud Pak for Data Platform (~1 1/2 hours)
     - name: ibm.mas_devops.ibm_catalogs
       when: install_cp4d_platform == true
     - name: ibm.mas_devops.common_services
@@ -24,19 +25,64 @@
       vars:
         cpd_service_name: wsl
 
-    # Watson Machine Learning (~2 hours)
+    # Watson Machine Learning (~2 1/2 hours)
+    # PLAY RECAP ***********************************************************************************************************************************************
+    # localhost                  : ok=71   changed=14   unreachable=0    failed=0    skipped=16   rescued=0    ignored=0
+
+    # Sunday 05 June 2022  16:03:52 +0100 (0:00:00.038)       4:01:34.056 ***********
+    # ===============================================================================
+    # ibm.mas_devops.cp4d_service : wait-ccs : Wait for the Runtime service accounts to appear ------------------------------------------------------- 4820.74s
+    # ibm.mas_devops.cp4d : install-cp4d : Wait for controlPlaneStatus to be 'Completed' (2m delay) -------------------------------------------------- 4729.03s
+    # ibm.mas_devops.cp4d_service : wait-wml : Wait for wmlStatus 'Completed' or 'Failed' ------------------------------------------------------------ 3314.82s
+    # ibm.mas_devops.cp4d_service : wait-ccs : Wait for ccsStatus 'Completed' ------------------------------------------------------------------------- 904.85s
+    # ibm.mas_devops.common_services : Wait for Foundation Services resources to be ready (60s delay) ------------------------------------------------- 185.43s
+    # ibm.mas_devops.cp4d : install-cp4d : Wait for ibm-zen-operator to be ready (60s delay) ---------------------------------------------------------- 185.13s
+    # ibm.mas_devops.cp4d : install-cp4d : Wait for ZenService lite-cr to be created ------------------------------------------------------------------ 124.16s
+    # ibm.mas_devops.cp4d : create-subscriptions : Wait for cpd-platform-operator-manager to be ready (60s delay) -------------------------------------- 61.97s
+    # ibm.mas_devops.cp4d_service : wait-ccs : Wait for the runtimes operator deployment to be ready --------------------------------------------------- 61.56s
+    # ibm.mas_devops.cp4d_service : Wait until the wmlbases.wml.cpd.ibm.com CRD is available ----------------------------------------------------------- 21.64s
     - name: ibm.mas_devops.cp4d_service
       when: install_watson_machine_learning == true
       vars:
         cpd_service_name: wml
 
     # Analytics Engine Powered by Apache Spark (~30 minutes)
+    # PLAY RECAP ***********************************************************************************************************************************************
+    # localhost                  : ok=63   changed=12   unreachable=0    failed=0    skipped=16   rescued=0    ignored=0
+
+    # Sunday 05 June 2022  18:52:17 +0100 (0:00:00.037)       1:32:18.513 ***********
+    # ===============================================================================
+    # ibm.mas_devops.cp4d : install-cp4d : Wait for controlPlaneStatus to be 'Completed' (2m delay) -------------------------------------------------- 3510.30s
+    # ibm.mas_devops.cp4d_service : wait-spark : Wait for analyticsengineStatus 'Completed' or 'Failed' ---------------------------------------------- 1447.22s
+    # ibm.mas_devops.common_services : Wait for Foundation Services resources to be ready (60s delay) ------------------------------------------------- 245.25s
+    # ibm.mas_devops.cp4d : install-cp4d : Wait for ibm-zen-operator to be ready (60s delay) ---------------------------------------------------------- 123.12s
+    # ibm.mas_devops.cp4d : install-cp4d : Wait for ZenService lite-cr to be created ------------------------------------------------------------------- 62.38s
+    # ibm.mas_devops.cp4d : create-subscriptions : Wait for cpd-platform-operator-manager to be ready (60s delay) -------------------------------------- 62.02s
+    # ibm.mas_devops.cp4d_service : Wait until the analyticsengines.ae.cpd.ibm.com CRD is available ---------------------------------------------------- 31.72s
+    # ibm.mas_devops.common_services : Check if operator group is present in ibm-common-services already ------------------------------------------------ 9.29s
+    # ibm.mas_devops.cp4d_service : Obtain CP4D dashboard URL ------------------------------------------------------------------------------------------- 9.14s
+    # ibm.mas_devops.cp4d : Patch the zen service accounts ---------------------------------------------------------------------------------------------- 5.76s
     - name: ibm.mas_devops.cp4d_service
       when: install_analytics_engine == true
       vars:
         cpd_service_name: spark
 
     # Watson OpenScale (~1 hour)
+    # PLAY RECAP ***********************************************************************************************************************************************
+    # localhost                  : ok=63   changed=12   unreachable=0    failed=0    skipped=16   rescued=0    ignored=0
+
+    # Sunday 05 June 2022  23:12:09 +0100 (0:00:00.041)       1:58:08.774 ***********
+    # ===============================================================================
+    # ibm.mas_devops.cp4d : install-cp4d : Wait for controlPlaneStatus to be 'Completed' (2m delay) -------------------------------------------------- 3753.23s
+    # ibm.mas_devops.cp4d_service : wait-aiopenscale : Wait for wosStatus 'Completed' or 'Failed' ---------------------------------------------------- 2665.32s
+    # ibm.mas_devops.common_services : Wait for Foundation Services resources to be ready (60s delay) ------------------------------------------------- 246.82s
+    # ibm.mas_devops.cp4d : install-cp4d : Wait for ibm-zen-operator to be ready (60s delay) ---------------------------------------------------------- 185.08s
+    # ibm.mas_devops.cp4d : install-cp4d : Wait for ZenService lite-cr to be created ------------------------------------------------------------------- 62.64s
+    # ibm.mas_devops.cp4d : create-subscriptions : Wait for cpd-platform-operator-manager to be ready (60s delay) -------------------------------------- 62.11s
+    # ibm.mas_devops.cp4d_service : Wait until the woservices.wos.cpd.ibm.com CRD is available --------------------------------------------------------- 42.13s
+    # ibm.mas_devops.common_services : Check if operator group is present in ibm-common-services already ----------------------------------------------- 12.58s
+    # ibm.mas_devops.cp4d_service : Obtain CP4D dashboard URL ------------------------------------------------------------------------------------------ 10.80s
+    # ibm.mas_devops.cp4d : Patch the zen service accounts ---------------------------------------------------------------------------------------------- 6.59s
     - name: ibm.mas_devops.cp4d_service
       when: install_watson_openscale == true
       vars:

--- a/ibm/mas_devops/playbooks/cp4d.yml
+++ b/ibm/mas_devops/playbooks/cp4d.yml
@@ -8,7 +8,7 @@
     install_analytics_engine: true
     install_watson_openscale: true
     install_watson_discovery: true
-    cpd_product_version: 4.0.9
+    cpd_product_version: "4.0.9"
 
   roles:
     - name: ibm.mas_devops.ibm_catalogs

--- a/ibm/mas_devops/playbooks/cp4d.yml
+++ b/ibm/mas_devops/playbooks/cp4d.yml
@@ -2,16 +2,14 @@
 - hosts: localhost
   any_errors_fatal: true
   vars:
-    install_watson_studio: false
+    install_watson_studio: true
 
   roles:
     - name: ibm.mas_devops.ibm_catalogs
     - name: ibm.mas_devops.common_services
     - name: ibm.mas_devops.cp4d
     - name: ibm.mas_devops.cp4d_service
+      when: install_watson_studio == true
       vars:
         cpd_service_name: wsl
-        # Do not set this to anything other than 4.0.9 due to defect in CP4D
-        # https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/3438
         cpd_product_version: 4.0.9
-      when: install_watson_studio == true

--- a/ibm/mas_devops/playbooks/cp4d.yml
+++ b/ibm/mas_devops/playbooks/cp4d.yml
@@ -2,11 +2,11 @@
 - hosts: localhost
   any_errors_fatal: true
   vars:
-    install_cp4d_platform: false
-    install_watson_studio: false
-    install_watson_machine_learning: false
-    install_analytics_engine: false
-    install_watson_openscale: false
+    install_cp4d_platform: true
+    install_watson_studio: true
+    install_watson_machine_learning: true
+    install_analytics_engine: true
+    install_watson_openscale: true
     install_watson_discovery: true
     cpd_product_version: "4.0.9"
 

--- a/ibm/mas_devops/playbooks/cp4d.yml
+++ b/ibm/mas_devops/playbooks/cp4d.yml
@@ -1,0 +1,17 @@
+---
+- hosts: localhost
+  any_errors_fatal: true
+  vars:
+    install_watson_studio: true
+
+  roles:
+    - name: ibm.mas_devops.ibm_catalogs
+    - name: ibm.mas_devops.common_services
+    - name: ibm.mas_devops.cp4d
+    - name: ibm.mas_devops.cp4d_service
+      vars:
+        cpd_service_name: wsl
+        # Do not set this to anything other than 4.0.9 due to defect in CP4D
+        # https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/3438
+        cpd_product_version: 4.0.9
+      when: install_watson_studio == true

--- a/ibm/mas_devops/playbooks/oneclick_add_assist.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_assist.yml
@@ -1,5 +1,5 @@
 ---
-# Add Manage application to an existing MAS Core+IoT installation
+# Add Assist application to an existing MAS Core+IoT installation
 #
 # Dependencies:
 # - ansible-playbook ibm.mas_devops.oneclick_core
@@ -11,6 +11,7 @@
     # Application Dependencies
     cos_type: ibm
     cpd_service_name: wd
+    cpd_product_version: "4.0.9"
 
     # Application Installation
     mas_app_id: assist

--- a/ibm/mas_devops/roles/cp4d/README.md
+++ b/ibm/mas_devops/roles/cp4d/README.md
@@ -58,6 +58,21 @@ Useful debugging commands:
 
 Role Variables
 --------------
+
+### ibm_entitlement_key
+Provide your [IBM entitlement key](https://myibm.ibm.com/products-services/containerlibrary).
+
+- **Required**
+- Environment Variable: `IBM_ENTITLEMENT_KEY`
+- Default: None
+
+### cpd_entitlement_key
+An IBM entitlement key specific for Cloud Pak for Data installation, primarily used to override `ibm_entitlement_key` in development.
+
+- Optional
+- Environment Variable: `CPD_ENTITLEMENT_KEY`
+- Default: None
+
 ### cpd_primary_storage_class
 Primary storage class for Cloud Pak for Data.
 

--- a/ibm/mas_devops/roles/cp4d/README.md
+++ b/ibm/mas_devops/roles/cp4d/README.md
@@ -19,42 +19,61 @@ Cloud Pak for Data will be configured as a [specialized installation](https://ww
 
     In this way, you can specify different settings for the IBM Cloud Pak foundational services and for the Cloud Pak for Data operators.
 
-Cloud Pak for Data is made up of many moving parts across multiple namespaces:
+Cloud Pak for Data is made up of many moving parts across multiple namespaces.
 
 In the **ibm-common-services** namespace:
-
-- `deployment.apps/ibm-zen-operator`
-- `deployment.apps/meta-api-deploy`
-- `job.batch/pre-zen-operand-config-job`
-- `job.batch/setup-job`
+```bash
+oc -n ibm-common-services get deployments
+NAME                                   READY   UP-TO-DATE   AVAILABLE   AGE
+cert-manager-cainjector                1/1     1            1           85m
+cert-manager-controller                1/1     1            1           85m
+cert-manager-webhook                   1/1     1            1           85m
+configmap-watcher                      1/1     1            1           85m
+ibm-cert-manager-operator              1/1     1            1           87m
+ibm-common-service-operator            1/1     1            1           92m
+ibm-common-service-webhook             1/1     1            1           91m
+ibm-namespace-scope-operator           1/1     1            1           91m
+ibm-zen-operator                       1/1     1            1           87m
+meta-api-deploy                        1/1     1            1           86m
+operand-deployment-lifecycle-manager   1/1     1            1           90m
+secretshare                            1/1     1            1           91m
+```
 
 In the **ibm-cpd-operators** namespace:
-
-- `deployment.apps/ibm-common-service-operator`
-- `deployment.apps/ibm-namespace-scope-operator`
-- `deployment.apps/cpd-platform-operator-manager`
+```bash
+oc -n ibm-cpd-operators get deployments
+NAME                            READY   UP-TO-DATE   AVAILABLE   AGE
+cpd-platform-operator-manager   1/1     1            1           87m
+ibm-common-service-operator     1/1     1            1           87m
+ibm-namespace-scope-operator    1/1     1            1           87m
+```
 
 In the **ibm-cpd** namespace:
+```
+oc -n ibm-cpd get zenservice,ibmcpd,deployments,sts
+NAME                                 AGE
+zenservice.zen.cpd.ibm.com/lite-cr   81m
 
-- `ibmcpd.cpd.ibm.com/ibmcpd`
-- `zenservice.zen.cpd.ibm.com/lite-cr`
-- `statefulset.apps/dsx-influxdb`
-- `statefulset.apps/zen-metastoredb`
-- `deployment.apps/ibm-nginx`
-- `deployment.apps/usermgmt`
-- `deployment.apps/zen-audit`
-- `deployment.apps/zen-core`
-- `deployment.apps/zen-core-api`
-- `deployment.apps/zen-data-sorcerer`
-- `deployment.apps/zen-watchdog`
-- `deployment.apps/zen-watcher`
+NAME                        AGE
+ibmcpd.cpd.ibm.com/ibmcpd   85m
 
-Useful debugging commands:
+NAME                                READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/ibm-nginx           3/3     3            3           62m
+deployment.apps/usermgmt            3/3     3            3           64m
+deployment.apps/zen-audit           1/1     1            1           56m
+deployment.apps/zen-core            3/3     3            3           55m
+deployment.apps/zen-core-api        3/3     3            3           55m
+deployment.apps/zen-data-sorcerer   2/2     2            2           48m
+deployment.apps/zen-watchdog        1/1     1            1           48m
+deployment.apps/zen-watcher         1/1     1            1           55m
 
-- `oc -n ibm-cpd get ibmcpd,zenservice,sts,deployments,jobs,pods`
-- `oc -n ibm-cpd-operators get deployments,pods`
-- `oc -n ibm-common-services get deployments,jobs,pods`
-- `oc -n ibm-cpd get secret admin-user-details -o jsonpath="{.data.initial_admin_password}" | base64 -d`
+NAME                               READY   AGE
+statefulset.apps/dsx-influxdb      1/1     51m
+statefulset.apps/zen-metastoredb   3/3     68m
+```
+
+!!! tip
+    You can retrieve the Cloud Pak for Data password from the **admin-user-details** secret: `oc -n ibm-cpd get secret admin-user-details -o jsonpath="{.data.initial_admin_password}" | base64 -d`
 
 Role Variables
 --------------

--- a/ibm/mas_devops/roles/cp4d/defaults/main.yml
+++ b/ibm/mas_devops/roles/cp4d/defaults/main.yml
@@ -3,6 +3,10 @@
 cpd_primary_storage_class: "{{ lookup('env', 'CPD_PRIMARY_STORAGE_CLASS') }}"
 cpd_metadata_storage_class: "{{ lookup('env', 'CPD_METADATA_STORAGE_CLASS') }}"
 
+# ------ CPD entitlement ----------------------------------------------------------------------------------------------
+cpd_entitlement_username: "{{ lookup('env', 'CPD_ENTITLEMENT_USERNAME') | default('cp', true) }}"
+ibm_entitlement_key: "{{ lookup('env', 'IBM_ENTITLEMENT_KEY') }}"
+cpd_entitlement_key: "{{ lookup('env', 'CPD_ENTITLEMENT_KEY') | default(ibm_entitlement_key, true) }}"
 
 # ------ CPD namespaces -----------------------------------------------------------------------------------------------
 

--- a/ibm/mas_devops/roles/cp4d/tasks/create-subscriptions.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/create-subscriptions.yml
@@ -2,12 +2,12 @@
 
 # 1. Create Namespaces & OperatorGroup
 # -----------------------------------------------------------------------------
-- name: "Create Namespaces for CP4D"
+- name: "create-subscriptions : Create Namespaces for CP4D"
   kubernetes.core.k8s:
     apply: yes
     template: 'templates/namespaces.yml.j2'
 
-- name: "Create OperatorGroup for CP4D"
+- name: "create-subscriptions : Create OperatorGroup for CP4D"
   kubernetes.core.k8s:
     apply: yes
     template: 'templates/operatorGroup.yml.j2'
@@ -26,12 +26,12 @@
 # - ibm-common-service-operator v3
 # - ibm-namespace-scope-operator v3
 
-- name: "Create CP4D Platform & Namespace Scope Operator subscriptions"
+- name: "create-subscriptions : Create CP4D Platform & Namespace Scope Operator subscriptions"
   kubernetes.core.k8s:
     apply: yes
     template: 'templates/subscriptions.yml.j2'
 
-- name: "Wait for cpd-platform-operator-manager to be ready (60s delay)"
+- name: "create-subscriptions : Wait for cpd-platform-operator-manager to be ready (60s delay)"
   kubernetes.core.k8s_info:
     api_version: apps/v1
     name: cpd-platform-operator-manager
@@ -43,7 +43,7 @@
   delay: 60 # 1 minute
 
 # 5.3 Enabling services to use namespace scoping with third-party operators
-- name: "Create NamespaceScope for CP4D Operators"
+- name: "create-subscriptions : Create NamespaceScope for CP4D Operators"
   kubernetes.core.k8s:
     apply: yes
     template: 'templates/namespaceScope.yml.j2'

--- a/ibm/mas_devops/roles/cp4d/tasks/determine-storage-classes.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/determine-storage-classes.yml
@@ -4,7 +4,7 @@
 
 # 1. Lookup storage class availabiity
 # -----------------------------------------------------------------------------
-- name: Lookup storage classes
+- name: "determine-storage-classes : Lookup storage classes"
   kubernetes.core.k8s_info:
     api_version: storage.k8s.io/v1
     kind: StorageClass
@@ -17,7 +17,7 @@
 
 # 2. Set Primary Storage (Required)
 # -----------------------------------------------------------------------------
-- name: Default Primary Storage if not set by user
+- name: "determine-storage-classes : Default Primary Storage if not set by user"
   when: cpd_primary_storage_class is not defined or cpd_primary_storage_class == ""
   vars:
     # ROKS, OCS, Azure
@@ -25,7 +25,7 @@
   set_fact:
     cpd_primary_storage_class: "{{ lookup_storageclasses | ibm.mas_devops.defaultStorageClass(supported_storage_classes) }}"
 
-- name: Assert that primary storage class has been defined
+- name: "determine-storage-classes : Assert that primary storage class has been defined"
   assert:
     that: cpd_primary_storage_class is defined and cpd_primary_storage_class != ""
     fail_msg: "cpd_primary_storage_class must be defined"
@@ -33,7 +33,7 @@
 
 # 2. Set Metadata Storage (Required)
 # -----------------------------------------------------------------------------
-- name: Default Metadata Storage if not set by user
+- name: "determine-storage-classes : Default Metadata Storage if not set by user"
   when: cpd_metadata_storage_class is not defined or cpd_metadata_storage_class == ""
   vars:
     # ROKS, OCS, Azure
@@ -41,7 +41,7 @@
   set_fact:
     cpd_metadata_storage_class: "{{ lookup_storageclasses | ibm.mas_devops.defaultStorageClass(supported_storage_classes) }}"
 
-- name: Assert that metadata storage class has been defined
+- name: "determine-storage-classes : Assert that metadata storage class has been defined"
   assert:
     that: cpd_metadata_storage_class is defined and cpd_metadata_storage_class != ""
     fail_msg: "cpd_metadata_storage_class must be defined"
@@ -49,7 +49,7 @@
 
 # 3. Debug storage class configuration
 # -----------------------------------------------------------------------------
-- name: "Debug CP4D storage class configuration"
+- name: "determine-storage-classes : Debug CP4D storage class configuration"
   debug:
     msg:
       - "Storage class (primary) .......... {{ cpd_primary_storage_class }}"

--- a/ibm/mas_devops/roles/cp4d/tasks/entitlement.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/entitlement.yml
@@ -1,0 +1,21 @@
+---
+
+- name: "entitlement : Create ibm-entitlement secret in CP4D instance namespace"
+  vars:
+    entitledAuthStr: "{{ cpd_entitlement_username }}:{{ cpd_entitlement_key }}"
+    entitledAuth: "{{ entitledAuthStr | b64encode }}"
+    content:
+      - '{"auths":{"cp.icr.io/cp": {"username":"{{ cpd_entitlement_username }}","password":"{{ cpd_entitlement_key }}","auth":"{{ entitledAuth }}"}'
+      - '}'
+      - '}'
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: v1
+      kind: Secret
+      type: kubernetes.io/dockerconfigjson
+      metadata:
+        name: "ibm-entitlement"
+        namespace: "{{ cpd_instance_namespace }}"
+      stringData:
+        # Only way I could get three consecutive "}" into a string :)
+        .dockerconfigjson: "{{ content | join('') | string }}"

--- a/ibm/mas_devops/roles/cp4d/tasks/entitlement.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/entitlement.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: "entitlement : Create ibm-entitlement secret in CP4D instance namespace"
+- name: "entitlement : Create ibm-entitlement-key secret in CP4D instance namespace"
   vars:
     entitledAuthStr: "{{ cpd_entitlement_username }}:{{ cpd_entitlement_key }}"
     entitledAuth: "{{ entitledAuthStr | b64encode }}"
@@ -14,7 +14,7 @@
       kind: Secret
       type: kubernetes.io/dockerconfigjson
       metadata:
-        name: "ibm-entitlement"
+        name: "ibm-entitlement-key"
         namespace: "{{ cpd_instance_namespace }}"
       stringData:
         # Only way I could get three consecutive "}" into a string :)

--- a/ibm/mas_devops/roles/cp4d/tasks/install-cp4d.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/install-cp4d.yml
@@ -4,7 +4,7 @@
 # -----------------------------------------------------------------------------
 # https://www.ibm.com/docs/en/cloud-paks/cp-data/4.0?topic=installing-cloud-pak-data
 
-- name: "Install CloudPak for Data"
+- name: "install-cp4d : Install CloudPak for Data"
   kubernetes.core.k8s:
     apply: yes
     template: 'templates/ibmcpd.yml.j2'
@@ -13,7 +13,7 @@
 # 2. Patch ZenService lite-cr to scaleConfig: medium
 # ----------------------------------------------------------------------------------------------
 # 2.1 Wait for Zen operator ...
-- name: "Wait for ibm-zen-operator to be ready (60s delay)"
+- name: "install-cp4d : Wait for ibm-zen-operator to be ready (60s delay)"
   kubernetes.core.k8s_info:
     api_version: apps/v1
     name: ibm-zen-operator
@@ -25,7 +25,7 @@
   delay: 60 # 1 minute
 
 # 2.2 Wait for lite-cr to be created ...
-- name: "Wait for ZenService lite-cr to be created"
+- name: "install-cp4d : Wait for ZenService lite-cr to be created"
   kubernetes.core.k8s_info:
     api_version: zen.cpd.ibm.com/v1
     name: lite-cr
@@ -39,7 +39,7 @@
   delay: 60 # 1 minute
 
 # 2.3 Apply the patch per recommendation from CP4D team
-- name: "Patch ZenService lite-cr to scaleConfig: medium"
+- name: "install-cp4d : Patch ZenService lite-cr to scaleConfig: medium"
   kubernetes.core.k8s:
     api_version: zen.cpd.ibm.com/v1
     name: lite-cr
@@ -66,7 +66,7 @@
 # 3. Wait for controlPlaneStatus
 # -----------------------------------------------------------------------------
 # oc get Ibmcpd ibmcpd-cr -o jsonpath="{.status.controlPlaneStatus}{'\n'}"
-- name: "Wait for controlPlaneStatus to be 'Completed' (2m delay)"
+- name: "install-cp4d : Wait for controlPlaneStatus to be 'Completed' (2m delay)"
   kubernetes.core.k8s_info:
     api_version: cpd.ibm.com/v1
     name: ibmcpd
@@ -79,7 +79,7 @@
   retries: 60 # Approximately 2 hours before we give up
   delay: 120 # 2 minutes
 
-- name: "Check that the controlPlaneStatus is 'Completed'"
+- name: "install-cp4d : Check that the controlPlaneStatus is 'Completed'"
   assert:
     that: ibmcpd_lookup.resources[0].status.controlPlaneStatus == "Completed"
     fail_msg: "IBM CloudPak for Data install failed (controlPlaneStatus)"
@@ -88,7 +88,7 @@
 # 4. Wait for zenStatus
 # -----------------------------------------------------------------------------
 # oc get ZenService lite-cr -o jsonpath="{.status.zenStatus}{'\n'}"
-- name: "Wait for zenStatus to be ready to be 'Completed' (2m delay)"
+- name: "install-cp4d : Wait for zenStatus to be ready to be 'Completed' (2m delay)"
   kubernetes.core.k8s_info:
     api_version: zen.cpd.ibm.com/v1
     name: lite-cr
@@ -101,7 +101,7 @@
   retries: 60 # Approximately 2 hours before we give up
   delay: 120 # 5 minutes
 
-- name: "Check that the zenStatus is 'Completed'"
+- name: "install-cp4d : Check that the zenStatus is 'Completed'"
   assert:
     that: zenservice_lookup.resources[0].status.zenStatus == "Completed"
     fail_msg: "IBM CloudPak for Data install failed (zenStatus)"
@@ -109,7 +109,7 @@
 
 # 5. Provide CP4D dashboard URL
 # -----------------------------------------------------------------------------
-- name: "Obtain CP4D dashboard URL"
+- name: "install-cp4d : Obtain CP4D dashboard URL"
   debug:
     msg:
       - "CP4D Dashboard ......................... https://{{zenservice_lookup.resources[0].status.url}}"

--- a/ibm/mas_devops/roles/cp4d/tasks/install-cp4d.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/install-cp4d.yml
@@ -66,7 +66,7 @@
 # 3. Wait for controlPlaneStatus
 # -----------------------------------------------------------------------------
 # oc get Ibmcpd ibmcpd-cr -o jsonpath="{.status.controlPlaneStatus}{'\n'}"
-- name: "Wait for controlPlaneStatus to be 'Completed' (60s delay)"
+- name: "Wait for controlPlaneStatus to be 'Completed' (2m delay)"
   kubernetes.core.k8s_info:
     api_version: cpd.ibm.com/v1
     name: ibmcpd
@@ -88,7 +88,7 @@
 # 4. Wait for zenStatus
 # -----------------------------------------------------------------------------
 # oc get ZenService lite-cr -o jsonpath="{.status.zenStatus}{'\n'}"
-- name: "Wait for zenStatus to be ready to be 'Completed' (60s delay)"
+- name: "Wait for zenStatus to be ready to be 'Completed' (2m delay)"
   kubernetes.core.k8s_info:
     api_version: zen.cpd.ibm.com/v1
     name: lite-cr
@@ -98,8 +98,8 @@
   until:
     - zenservice_lookup.resources[0].status.zenStatus is defined
     - zenservice_lookup.resources[0].status.zenStatus == "Completed" or zenservice_lookup.resources[0].status.zenStatus == "Failed"
-  retries: 25 # Approximately 2 hours before we give up
-  delay: 300 # 5 minutes
+  retries: 60 # Approximately 2 hours before we give up
+  delay: 120 # 5 minutes
 
 - name: "Check that the zenStatus is 'Completed'"
   assert:

--- a/ibm/mas_devops/roles/cp4d/tasks/main.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/main.yml
@@ -16,7 +16,7 @@
 - name: "Create CP4D Operator Subscriptions"
   include_tasks: "tasks/create-subscriptions.yml"
 
-# Install ibm-entitlement in ibm-cpd namespace
+# Install ibm-entitlement-key in ibm-cpd namespace
 # Nothing in the cp4d base platform requires entitlement, but the services that we want to enable in CP4D do.
 - name: "Install IBM Entitlement Key"
   include_tasks: "tasks/entitlement.yml"
@@ -66,7 +66,7 @@
     - zen-runtime-sa
     - zen-viewer-sa
 
-# Patch the zen service accounts in ibm-cpd namespace to add ibm-entitlement
+# Patch the zen service accounts in ibm-cpd namespace to add ibm-entitlement-key
 - name: "Patch the zen service accounts"
   kubernetes.core.k8s:
     api_version: v1
@@ -76,7 +76,7 @@
     apply: true
     definition:
       imagePullSecrets:
-        - name: ibm-entitlement
+        - name: ibm-entitlement-key
   with_items:
     - zen-admin-sa
     - zen-editor-sa

--- a/ibm/mas_devops/roles/cp4d/tasks/main.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/main.yml
@@ -47,7 +47,7 @@
 #     - zen-watcher
 
 # Wait for ZenService service accounts to be created
-- name: "Wait for the zen service accounts to appear - {{ item }}"
+- name: "Wait for the zen service accounts to appear"
   kubernetes.core.k8s_info:
     api_version: v1
     kind: ServiceAccount
@@ -67,7 +67,7 @@
     - zen-viewer-sa
 
 # Patch the zen service accounts in ibm-cpd namespace to add ibm-entitlement
-- name: "Patch the zen service accounts - {{ item }}"
+- name: "Patch the zen service accounts"
   kubernetes.core.k8s:
     api_version: v1
     kind: ServiceAccount

--- a/ibm/mas_devops/roles/cp4d/tasks/main.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/main.yml
@@ -2,6 +2,10 @@
 # The following playbook is an attempt to automate the CP4D 4.0 steps documented here:
 # https://www.ibm.com/support/producthub/icpdata/docs/content/SSQNUZ_latest/cpd/install/preinstall-overview.html
 
+- name: Check that an entitlement key has been provided
+  assert:
+    that: cpd_entitlement_key is defined and cpd_entitlement_key != ""
+    fail_msg: "ibm_entitlement_key or cpd_entitlement_key override must be provided"
 
 - name: "Run pre-req check"
   include_tasks: "tasks/prereq-check.yml"
@@ -12,6 +16,11 @@
 - name: "Create CP4D Operator Subscriptions"
   include_tasks: "tasks/create-subscriptions.yml"
 
+# Install ibm-entitlement in ibm-cpd namespace
+# Nothing in the cp4d base platform requires entitlement, but the services that we want to enable in CP4D do.
+- name: "Install IBM Entitlement Key"
+  include_tasks: "tasks/entitlement.yml"
+
 # At this stage:
 # - The two namespaces (ibm-cpd and ibm-cpd-operators) will be created
 # - OperatorGroup will have been created in the ibm-cpd-operators namespace
@@ -19,7 +28,7 @@
 # - IBM Cloud Pak Foundational Services (ibm-common-service-operator) v3 will be installed in ibm-cpd-operators namespace
 # - IBM NamespaceScope Operator (ibm-namespace-scope-operator) v3 will be installed in ibm-cpd-operators namespace
 # - A NamespaceScope will have been created in the ibm-cpd-operators namespace
-# - Nothing will exist in the ibm-cpd namespace yet
+# - Nothing will exist in the ibm-cpd namespace yet except the entitlement key we just created
 
 - name: "Install CP4D"
   include_tasks: "tasks/install-cp4d.yml"
@@ -36,3 +45,40 @@
 #     - zen-data-sorcerer
 #     - zen-watchdog
 #     - zen-watcher
+
+# Wait for ZenService service accounts to be created
+- name: "Wait for the zen service accounts to appear - {{ item }}"
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ServiceAccount
+    name: "{{ item }}"
+    namespace: "{{ cpd_instance_namespace }}"
+  register: zen_sa_lookup
+  retries: 120 # ~approx 5 minutes before we give up waiting for the CRD to be created
+  delay: 5 # seconds
+  until:
+    - zen_sa_lookup.resources is defined
+    - zen_sa_lookup.resources | length > 0
+  with_items:
+    - zen-admin-sa
+    - zen-editor-sa
+    - zen-norbac-sa
+    - zen-runtime-sa
+    - zen-viewer-sa
+
+# Patch the zen service accounts in ibm-cpd namespace to add ibm-entitlement
+- name: "Patch the zen service accounts - {{ item }}"
+  kubernetes.core.k8s:
+    api_version: v1
+    kind: ServiceAccount
+    name: "{{ item }}"
+    namespace: "{{ cpd_instance_namespace }}"
+    definition:
+      imagePullSecrets:
+        - ibm-entitlement
+  with_items:
+    - zen-admin-sa
+    - zen-editor-sa
+    - zen-norbac-sa
+    - zen-runtime-sa
+    - zen-viewer-sa

--- a/ibm/mas_devops/roles/cp4d/tasks/main.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/main.yml
@@ -73,9 +73,10 @@
     kind: ServiceAccount
     name: "{{ item }}"
     namespace: "{{ cpd_instance_namespace }}"
+    apply: true
     definition:
       imagePullSecrets:
-        - ibm-entitlement
+        - name: ibm-entitlement
   with_items:
     - zen-admin-sa
     - zen-editor-sa

--- a/ibm/mas_devops/roles/cp4d/tasks/prereq-check.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/prereq-check.yml
@@ -4,7 +4,7 @@
 
 # 1. Check if required operator catalog is installed and ready
 # -----------------------------------------------------------------------------
-- name: "Lookup ibm-operator-catalog"
+- name: "prereq-check : Lookup ibm-operator-catalog"
   kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
     name: ibm-operator-catalog
@@ -12,7 +12,7 @@
     kind: CatalogSource
   register: catalog_lookup
 
-- name: "Assert that ibm-operator-catalog is available"
+- name: "prereq-check : Assert that ibm-operator-catalog is available"
   assert:
     that:
       - catalog_lookup.resources is defined
@@ -24,7 +24,7 @@
 
 # 2. Check whether IBM Common Services are already installed
 # -----------------------------------------------------------------------------
-- name: "Check if ODLM is available"
+- name: "prereq-check : Check if ODLM is available"
   kubernetes.core.k8s_info:
     api_version: apps/v1
     name: operand-deployment-lifecycle-manager
@@ -32,7 +32,7 @@
     kind: Deployment
   register: odlm_lookup
 
-- name: "Assert that ODLM is available"
+- name: "prereq-check : Assert that ODLM is available"
   assert:
     that:
       - odlm_lookup.resources is defined

--- a/ibm/mas_devops/roles/cp4d_service/README.md
+++ b/ibm/mas_devops/roles/cp4d_service/README.md
@@ -18,12 +18,8 @@ These services can be deployed and configured using this role:
     For more information on how Predict and HP Utilities make use of Watson Studio, refer to [Predict/HP Utilities documentation](https://www.ibm.com/docs/en/mhmpmh-and-p-u/8.2.0?topic=started-getting-data-scientists)
 
 
-!!! note
-    The reconcile many CP4D resources will be marked as Failed multiple times during initial installation.  These are **misleading status updates**, the install is just really slow and the operators can not properly handle this.
-
-    For example, if you are watching the install of CCS you will see that each **rabbitmq-ha** pod takes 10-15 minutes to start up and it looks like there is a problem because the pod log will just stop at a certain point.  If you see something like this as the last message in the pod log `WAL: ra_log_wal init, open tbls: ra_log_open_mem_tables, closed tbls: ra_log_closed_mem_tables` be assured that there's nothing wrong, it's just there's a long delay between that message and the next (`starting system coordination`) being logged.
-
-    During this time the operator is not installing other subsystems because it operates in a blocking mode waiting for each subsystem to be ready before moving onto the next one
+!!! warning
+    The reconcile of many CP4D resources will be marked as Failed multiple times during initial installation, these are **misleading status updates**, the install is just really slow and the operators can not properly handle this.  For example, if you are watching the install of CCS you will see that each **rabbitmq-ha** pod takes 10-15 minutes to start up and it looks like there is a problem because the pod log will just stop at a certain point.  If you see something like this as the last message in the pod log `WAL: ra_log_wal init, open tbls: ra_log_open_mem_tables, closed tbls: ra_log_closed_mem_tables` be assured that there's nothing wrong, it's just there's a long delay between that message and the next (`starting system coordination`) being logged.
 
 
 ### Watson Studio
@@ -468,35 +464,113 @@ Watson Discovery is made up of many moving parts across multiple namespaces.
 
 In the **ibm-common-services** namespace:
 
-- x workloads / x pods
-- x CPU usage / x CPU requests / 3.57 CPU limit (x% utilization)
-- x memory usage, x memory requests / x memory limit (x% utilization)
+- 13 workloads / 16 pods
+- 0.126 CPU usage / 1.11 CPU requests / 3.57 CPU limit (8% utilization)
+- 921.9 MiB memory usage, 2.27 GiB memory requests / 5.72 GiB memory limit (40% utilization)
 
 ```
 oc -n ibm-common-services get deployments
-
+NAME                                            READY   UP-TO-DATE   AVAILABLE   AGE
+cert-manager-cainjector                         1/1     1            1           3h9m
+cert-manager-controller                         1/1     1            1           3h9m
+cert-manager-webhook                            1/1     1            1           3h9m
+configmap-watcher                               1/1     1            1           3h9m
+ibm-cert-manager-operator                       1/1     1            1           3h10m
+ibm-common-service-operator                     1/1     1            1           3h16m
+ibm-common-service-webhook                      1/1     1            1           3h14m
+ibm-namespace-scope-operator                    1/1     1            1           3h15m
+ibm-zen-operator                                1/1     1            1           3h10m
+meta-api-deploy                                 1/1     1            1           3h9m
+operand-deployment-lifecycle-manager            1/1     1            1           3h14m
+postgresql-operator-controller-manager-1-15-0   1/1     1            1           134m
+secretshare                                     1/1     1            1           3h14m
 ```
 
 In the **ibm-cpd-operators** namespace:
 
-- x workloads / x pods
-- x CPU usage / x CPU requests / 3.57 CPU limit (x% utilization)
-- x memory usage, x memory requests / x memory limit (x% utilization)
+- 10 workloads / 10 pods
+- 0.984 CPU usage / 1.65 CPU requests / 7.3 CPU limit (60% utilization)
+- 671.6 MiB memory usage, 2.56 GiB memory requests / 9.46 GiB memory limit (25% utilization)
 
 ```
 oc -n ibm-cpd-operators get deployments
-
+NAME                                                   READY   UP-TO-DATE   AVAILABLE   AGE
+cpd-platform-operator-manager                          1/1     1            1           3h12m
+gateway-operator                                       1/1     1            1           131m
+ibm-common-service-operator                            1/1     1            1           3h12m
+ibm-elasticsearch-operator-ibm-es-controller-manager   1/1     1            1           131m
+ibm-etcd-operator                                      1/1     1            1           131m
+ibm-minio-operator                                     1/1     1            1           131m
+ibm-model-train-classic-operator                       1/1     1            1           131m
+ibm-namespace-scope-operator                           1/1     1            1           3h12m
+ibm-rabbitmq-operator                                  1/1     1            1           131m
+wd-discovery-operator                                  1/1     1            1           131m
 ```
 
 In the **ibm-cpd** namespace:
 
-- x workloads / x pods
-- x CPU usage / x CPU requests / 3.57 CPU limit (x% utilization)
-- x memory usage, x memory requests / x memory limit (x% utilization)
+- 49 workloads / 83 pods
+- 0.994 CPU usage / 20.06 CPU requests / 112.3 CPU limit (5% utilization)
+- 12.2 GiB memory usage, 96.1 GiB memory requests / 195.5 GiB memory limit (12% utilization)
 
 ```
 oc -n ibm-cpd get watsondiscoveries,deployments,sts
+NAME                                          VERSION   READY   READYREASON   UPDATING   UPDATINGREASON   DEPLOYED   VERIFIED   QUIESCE        DATASTOREQUIESCE   AGE
+watsondiscovery.discovery.watson.ibm.com/wd   4.0.9     True    Stable        False      Stable           23/23      23/23      NOT_QUIESCED   NOT_QUIESCED       130m
 
+NAME                                                       READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/ibm-nginx                                  3/3     3            3           174m
+deployment.apps/usermgmt                                   3/3     3            3           176m
+deployment.apps/wd-discovery-cnm-api                       1/1     1            1           39m
+deployment.apps/wd-discovery-converter                     1/1     1            1           39m
+deployment.apps/wd-discovery-crawler                       1/1     1            1           39m
+deployment.apps/wd-discovery-gateway                       1/1     1            1           19m
+deployment.apps/wd-discovery-glimpse-builder               1/1     1            1           37m
+deployment.apps/wd-discovery-glimpse-query                 1/1     1            1           39m
+deployment.apps/wd-discovery-haywire                       1/1     1            1           39m
+deployment.apps/wd-discovery-hdp-rm                        1/1     1            1           39m
+deployment.apps/wd-discovery-ingestion-api                 1/1     1            1           39m
+deployment.apps/wd-discovery-inlet                         1/1     1            1           39m
+deployment.apps/wd-discovery-management                    1/1     1            1           39m
+deployment.apps/wd-discovery-minerapp                      1/1     1            1           24m
+deployment.apps/wd-discovery-orchestrator                  1/1     1            1           39m
+deployment.apps/wd-discovery-outlet                        1/1     1            1           39m
+deployment.apps/wd-discovery-po-box                        1/1     1            1           122m
+deployment.apps/wd-discovery-project-data-prep-agent       1/1     1            1           39m
+deployment.apps/wd-discovery-ranker-master                 1/1     1            1           37m
+deployment.apps/wd-discovery-ranker-monitor-agent          1/1     1            1           39m
+deployment.apps/wd-discovery-ranker-rest                   1/1     1            1           37m
+deployment.apps/wd-discovery-rapi                          1/1     1            1           120m
+deployment.apps/wd-discovery-rcm                           1/1     1            1           122m
+deployment.apps/wd-discovery-serve-ranker                  1/1     1            1           37m
+deployment.apps/wd-discovery-stateless-api-model-runtime   1/1     1            1           39m
+deployment.apps/wd-discovery-stateless-api-rest-proxy      1/1     1            1           39m
+deployment.apps/wd-discovery-support                       0/0     0            0           39m
+deployment.apps/wd-discovery-tooling                       1/1     1            1           24m
+deployment.apps/wd-discovery-training-agents               1/1     1            1           39m
+deployment.apps/wd-discovery-training-crud                 1/1     1            1           39m
+deployment.apps/wd-discovery-training-rest                 1/1     1            1           39m
+deployment.apps/wd-discovery-watson-gateway-gw-instance    1/1     1            1           15m
+deployment.apps/wd-discovery-wd-indexer                    1/1     1            1           122m
+deployment.apps/wd-discovery-wksml                         1/1     1            1           39m
+deployment.apps/zen-audit                                  1/1     1            1           171m
+deployment.apps/zen-core                                   3/3     3            3           171m
+deployment.apps/zen-core-api                               3/3     3            3           171m
+deployment.apps/zen-data-sorcerer                          2/2     2            2           165m
+deployment.apps/zen-watchdog                               1/1     1            1           165m
+deployment.apps/zen-watcher                                1/1     1            1           170m
+
+NAME                                                     READY   AGE
+statefulset.apps/dsx-influxdb                            1/1     167m
+statefulset.apps/wd-discovery-etcd                       3/3     124m
+statefulset.apps/wd-discovery-hdp-worker                 2/2     39m
+statefulset.apps/wd-discovery-sdu                        1/1     24m
+statefulset.apps/wd-ibm-elasticsearch-es-server-client   1/1     121m
+statefulset.apps/wd-ibm-elasticsearch-es-server-data     1/1     121m
+statefulset.apps/wd-ibm-elasticsearch-es-server-master   1/1     121m
+statefulset.apps/wd-minio-discovery                      4/4     125m
+statefulset.apps/wd-rabbitmq-discovery                   1/1     125m
+statefulset.apps/zen-metastoredb                         3/3     179m
 ```
 
 

--- a/ibm/mas_devops/roles/cp4d_service/README.md
+++ b/ibm/mas_devops/roles/cp4d_service/README.md
@@ -20,16 +20,16 @@ These services can be deployed and configured using this role:
 ### Watson Studio
 Subscriptions related to Watson Studio (in the **ibm-cpd-operators** namespace):
 
-- **cpd-platform-operator** on channel `v2.0` (currently v2.0.8)
-- **ibm-cpd-wsl** on channel `v2.0` (currently v2.0.9)
-- **ibm-cpd-ccs** on channel `v1.0` (currently v1.0.9)
-- **ibm-cpd-datarefinery** on channel `v1.0` (currently v1.0.9)
-- **ibm-cpd-ws-runtimes** on channel `v1.0` (currently v1.0.9)
+- **cpd-platform-operator** on channel `v2.0`
+- **ibm-cpd-wsl** on channel `v2.0`
+- **ibm-cpd-ccs** on channel `v1.0`
+- **ibm-cpd-datarefinery** on channel `v1.0`
+- **ibm-cpd-ws-runtimes** on channel `v1.0`
 
 The key resources in the installation of Watson Studio involves are listed below, they are all created in the **ibm-cpd** namespace, note that the operators function in a sequential mode so the installation can take a very long time and you will see these resources created over the course of the 3 hour plus installation:
 
-- `ws.ws.cpd.ibm.com/ws-cr` (reconcile of this resource will fail multiple times with the message `"Unable to install CSS prerequisite` due to timeouts waiting for the CCS resource)
-- `ccs.ccs.cpd.ibm.com/ccs-cr` (reconcile of this resource will fail multiple times with the message `The playbook has failed. See earlier output for exact error` due to timeouts waiting for various statefulsets that it manages)
+- `ws.ws.cpd.ibm.com/ws-cr` (reconcile of this resource will fail multiple times with the message *"Unable to install CSS prerequisite"* due to timeouts waiting for the CCS resource)
+- `ccs.ccs.cpd.ibm.com/ccs-cr` (reconcile of this resource will fail multiple times with the message *"The playbook has failed. See earlier output for exact error"* due to timeouts waiting for various statefulsets that it manages)
 - `deployment.apps/redis-ha-haproxy`
 - `statefulset.apps/elasticsearch-master`
 - `statefulset.apps/redis-ha-server` (can take 15-20 minutes to start up)
@@ -46,9 +46,9 @@ Useful debug commands:
 ### Watson Machine Learning
 Subscriptions related to Watson Machine Learning (in the **ibm-cpd-operators** namespace):
 
-- **cpd-platform-operator** on channel `v2.0` (currently v2.0.8)
-- **ibm-cpd-wml** on channel `v1.1` (currently v2.0.9)
-- **ibm-cpd-ccs** on channel `v1.0` (currently v1.0.9)
+- **cpd-platform-operator** on channel `v2.0`
+- **ibm-cpd-wml** on channel `v1.1`
+- **ibm-cpd-ccs** on channel `v1.0`
 
 Assuming you are adding Watson Machine Learning on top of Watson Studio, the key new resources in the installation are listed below, they are all created in the **ibm-cpd** namespace:
 
@@ -66,8 +66,8 @@ Useful debug commands:
 ### Analytics Engine
 Subscriptions related to Analytics Engine (in the **ibm-cpd-operators** namespace):
 
-- **cpd-platform-operator** on channel `v2.0` (currently v2.0.8)
-- **analyticsengine-operator** on channel `stable-v1` (currently v1.0.9)
+- **cpd-platform-operator** on channel `v2.0`
+- **analyticsengine-operator** on channel `stable-v1`
 
 Assuming you are adding Analytics Engine on top of Watson Studio, the key new resources in the installation are listed below, they are all created in the **ibm-cpd** namespace:
 
@@ -81,18 +81,47 @@ Useful debug commands:
 ### Watson OpenScale
 Subscriptions related to Watson OpenScale (in the **ibm-cpd-operators** namespace):
 
-- **cpd-platform-operator** on channel `v2.0` (currently v2.0.8)
-- **ibm-cpd-wos** on channel `v1.5` (currently v1.5.4)
+- **cpd-platform-operator** on channel `v2.0`
+- **ibm-cpd-wos** on channel `v1.5`
 
 Assuming you are adding Watson OpenScale on top of Watson Studio, the key new resources in the installation are listed below, they are all created in the **ibm-cpd** namespace:
 
 - `woservice.wos.cpd.ibm.com/aiopenscale`
 - `statefulset.apps/aiopenscale-ibm-aios-zookeeper`
+- `statefulset.apps/aiopenscale-ibm-aios-kafka`
+- `statefulset.apps/aiopenscale-ibm-aios-redis`
+- `statefulset.apps/aiopenscale-ibm-aios-etcd`
 
 Useful debug commands:
 - `oc -n ibm-cpd get deployments,sts,pods`
 - `oc -n ibm-cpd get woservice`
 
+### Watson Discovery
+Subscriptions related to Watson Discovery (in the **ibm-cpd-operators** namespace):
+
+- **cpd-platform-operator** on channel `v2.0`
+- **ibm-watson-discovery-operator** on channel `v4.0`
+- **ibm-elasticsearch-operator** on channel `v1.1`
+- **ibm-etcd-operator** on channel `v1.0`
+- **ibm-minio-operator** on channel `v1.0`
+- **ibm-model-train-classic-operator** on channel `v1.0`
+- **ibm-rabbitmq-operator** on channel `v1.0`
+- **ibm-watson-gateway-operator** on channel `v1.0`
+
+Subscriptions related to Watson Discovery (in the **ibm-common-services** namespace):
+
+- **cloud-native-postgresql** on channel `stable`
+
+The key new resources in the installation are listed below, they are all created in the **ibm-cpd** namespace:
+
+- `woservice.wos.cpd.ibm.com/aiopenscale`
+- `statefulset.apps/wd-rabbitmq-discovery`
+- `statefulset.apps/wd-minio-discovery`
+- `statefulset.apps/wd-discovery-etcd`
+
+Useful debug commands:
+- `oc -n ibm-cpd get deployments,sts,pods`
+- `oc -n ibm-cpd get watsondiscoveries`
 
 Role Variables - Installation
 -----------------------------

--- a/ibm/mas_devops/roles/cp4d_service/README.md
+++ b/ibm/mas_devops/roles/cp4d_service/README.md
@@ -14,9 +14,52 @@ These services can be deployed and configured using this role:
 - [Watson Discovery](https://www.ibm.com/docs/en/cloud-paks/cp-data/4.0?topic=services-watson-discovery) required by Assist
 - [Decision Optimization](https://www.ibm.com/docs/en/cloud-paks/cp-data/4.0?topic=services-decision-optimization) an optional dependency for [Maximo Scheduler Optimization](https://www.ibm.com/docs/en/mas87/8.7.0?topic=ons-maximo-scheduler-optimization) - Requires Watson Studio and Watson Machine Learning.
 
-
 !!! info "Application Support"
     For more information on how Predict and HP Utilities make use of Watson Studio, refer to [Predict/HP Utilities documentation](https://www.ibm.com/docs/en/mhmpmh-and-p-u/8.2.0?topic=started-getting-data-scientists)
+
+Installation of Watson Studio involves the following being created in the **ibm-cpd** namespace, note that the operators function in a sequential mode so the installation can take a very long time and you will see these resources created over the course of the 3 hours installation:
+- `ws.ws.cpd.ibm.com/ws-cr` (reconcile of this resource will fail multiple times with the message `"Unable to install CSS prerequisite` due to timeouts waiting for the CCS resource)
+- `ccs.ccs.cpd.ibm.com/ccs-cr` (reconcile of this resource will fail multiple times with the message `The playbook has failed. See earlier output for exact error` due to timeouts waiting for various statefulsets that it manages)
+    - `deployment.apps/asset-files-api`
+    - `deployment.apps/ax-environments-api-deploy`
+    - `deployment.apps/ax-environments-ui-deploy`
+    - `deployment.apps/catalog-api`
+    - `deployment.apps/dap-dashboards-api`
+    - `deployment.apps/dataview-api-service`
+    - `deployment.apps/dc-main`
+    - `deployment.apps/event-logger-api`
+    - `deployment.apps/jobs-api`
+    - `deployment.apps/jobs-ui`
+    - `deployment.apps/ngp-projects-api`
+    - `deployment.apps/portal-catalog`
+    - `deployment.apps/portal-common-api`
+    - `deployment.apps/portal-dashboards`
+    - `deployment.apps/portal-job-manager`
+    - `deployment.apps/portal-main`
+    - `deployment.apps/portal-notifications`
+    - `deployment.apps/portal-projects`
+    - `deployment.apps/redis-ha-haproxy`
+    - `deployment.apps/runtime-assemblies-operator`
+    - `deployment.apps/runtime-manager-api`
+    - `deployment.apps/spaces`
+    - `deployment.apps/spawner-api`
+    - `deployment.apps/wdp-connect-connection`
+    - `deployment.apps/wdp-connect-connector`
+    - `deployment.apps/wdp-connect-flight`
+    - `deployment.apps/wdp-dataview`
+    - `deployment.apps/wml-main`
+    - `deployment.apps/wkc-search`
+    - `statefulset.apps/elasticsearch-master`
+    - `statefulset.apps/redis-ha-server` (can take 15-20 minutes to start up)
+    - `statefulset.apps/rabbitmq-ha` (can take 30-40 minutes to start up as each pod is started in sequence)
+    - `statefulset.apps/wdp-couchdb` (can take 5-10 minutes to start up)
+
+!!! note
+    If you are watching the install you will see that each **rabbitmq-ha** pod takes 10-15 minutes to start up and it looks like there is a problem because the pod log will just stop at a certain point.  If you see something like this as the last message in the pod log `WAL: ra_log_wal init, open tbls: ra_log_open_mem_tables, closed tbls: ra_log_closed_mem_tables` be assured that there's nothing wrong, it's just there's a long delay between that message and the next (`starting system coordination`) being logged.
+
+Useful debug commands:
+- `oc -n ibm-cpd get deployments,sts,pods`
+- `oc -n ibm-cpd get ccs,WS,DataRefinery,notebookruntimes`
 
 
 Role Variables - Installation

--- a/ibm/mas_devops/roles/cp4d_service/README.md
+++ b/ibm/mas_devops/roles/cp4d_service/README.md
@@ -17,42 +17,25 @@ These services can be deployed and configured using this role:
 !!! info "Application Support"
     For more information on how Predict and HP Utilities make use of Watson Studio, refer to [Predict/HP Utilities documentation](https://www.ibm.com/docs/en/mhmpmh-and-p-u/8.2.0?topic=started-getting-data-scientists)
 
-Installation of Watson Studio involves the following being created in the **ibm-cpd** namespace, note that the operators function in a sequential mode so the installation can take a very long time and you will see these resources created over the course of the 3 hours installation:
+### Watson Studio
+
+Subscriptions related to Watson Studio (in the **ibm-cpd-operators** namespace):
+
+- **cpd-platform-operator** on channel `v2.0` (currently v2.0.8)
+- **ibm-cpd-wsl** on channel `v2.0` (currently v2.0.9)
+- **ibm-cpd-ccs** on channel `v1.0` (currently v1.0.9)
+- **ibm-cpd-datarefinery** on channel `v1.0` (currently v1.0.9)
+- **ibm-cpd-ws-runtimes** on channel `v1.0` (currently v1.0.9)
+
+The key resources in the installation of Watson Studio involves are listed below, they are all created in the **ibm-cpd** namespace, note that the operators function in a sequential mode so the installation can take a very long time and you will see these resources created over the course of the 3 hour plus installation:
+
 - `ws.ws.cpd.ibm.com/ws-cr` (reconcile of this resource will fail multiple times with the message `"Unable to install CSS prerequisite` due to timeouts waiting for the CCS resource)
 - `ccs.ccs.cpd.ibm.com/ccs-cr` (reconcile of this resource will fail multiple times with the message `The playbook has failed. See earlier output for exact error` due to timeouts waiting for various statefulsets that it manages)
-    - `deployment.apps/asset-files-api`
-    - `deployment.apps/ax-environments-api-deploy`
-    - `deployment.apps/ax-environments-ui-deploy`
-    - `deployment.apps/catalog-api`
-    - `deployment.apps/dap-dashboards-api`
-    - `deployment.apps/dataview-api-service`
-    - `deployment.apps/dc-main`
-    - `deployment.apps/event-logger-api`
-    - `deployment.apps/jobs-api`
-    - `deployment.apps/jobs-ui`
-    - `deployment.apps/ngp-projects-api`
-    - `deployment.apps/portal-catalog`
-    - `deployment.apps/portal-common-api`
-    - `deployment.apps/portal-dashboards`
-    - `deployment.apps/portal-job-manager`
-    - `deployment.apps/portal-main`
-    - `deployment.apps/portal-notifications`
-    - `deployment.apps/portal-projects`
-    - `deployment.apps/redis-ha-haproxy`
-    - `deployment.apps/runtime-assemblies-operator`
-    - `deployment.apps/runtime-manager-api`
-    - `deployment.apps/spaces`
-    - `deployment.apps/spawner-api`
-    - `deployment.apps/wdp-connect-connection`
-    - `deployment.apps/wdp-connect-connector`
-    - `deployment.apps/wdp-connect-flight`
-    - `deployment.apps/wdp-dataview`
-    - `deployment.apps/wml-main`
-    - `deployment.apps/wkc-search`
-    - `statefulset.apps/elasticsearch-master`
-    - `statefulset.apps/redis-ha-server` (can take 15-20 minutes to start up)
-    - `statefulset.apps/rabbitmq-ha` (can take 30-40 minutes to start up as each pod is started in sequence)
-    - `statefulset.apps/wdp-couchdb` (can take 5-10 minutes to start up)
+- `deployment.apps/redis-ha-haproxy`
+- `statefulset.apps/elasticsearch-master`
+- `statefulset.apps/redis-ha-server` (can take 15-20 minutes to start up)
+- `statefulset.apps/rabbitmq-ha` (can take 30-40 minutes to start up as each pod is started in sequence)
+- `statefulset.apps/wdp-couchdb` (can take 5-10 minutes to start up)
 
 !!! note
     If you are watching the install you will see that each **rabbitmq-ha** pod takes 10-15 minutes to start up and it looks like there is a problem because the pod log will just stop at a certain point.  If you see something like this as the last message in the pod log `WAL: ra_log_wal init, open tbls: ra_log_open_mem_tables, closed tbls: ra_log_closed_mem_tables` be assured that there's nothing wrong, it's just there's a long delay between that message and the next (`starting system coordination`) being logged.
@@ -62,10 +45,49 @@ Useful debug commands:
 - `oc -n ibm-cpd get ccs,WS,DataRefinery,notebookruntimes`
 
 
+### Watson Machine Learning
+
+Subscriptions related to Watson Machine Learning (in the **ibm-cpd-operators** namespace):
+
+- **cpd-platform-operator** on channel `v2.0` (currently v2.0.8)
+- **ibm-cpd-wml** on channel `v1.1` (currently v2.0.9)
+- **ibm-cpd-ccs** on channel `v1.0` (currently v1.0.9)
+
+Assuming you are adding Watson Machine Learning on top of Watson Studio, the key new resources in the installation are listed below, they are all created in the **ibm-cpd** namespace:
+
+- `wmlbase.wml.cpd.ibm.com/wml-cr`
+- `deployment.apps/wmltraining`
+- `deployment.apps/wmltrainingorchestrator`
+- `statefulset.apps/wml-deployments-etcd`
+- `statefulset.apps/wml-deployment-agent`
+- `statefulset.apps/wml-deployment-manager`
+
+Useful debug commands:
+- `oc -n ibm-cpd get deployments,sts,pods`
+- `oc -n ibm-cpd get ccs,wmlbase`
+
+### Analytics Engine
+
+Subscriptions related to Analytics Engine (in the **ibm-cpd-operators** namespace):
+
+- **cpd-platform-operator** on channel `v2.0` (currently v2.0.8)
+- **analyticsengine-operator** on channel `stable-v1` (currently v1.0.9)
+
+Assuming you are adding Analytics Engine on top of Watson Studio, the key new resources in the installation are listed below, they are all created in the **ibm-cpd** namespace:
+
+- `analyticsengine.ae.cpd.ibm.com/analyticsengine-sample`
+- `deployment.apps/spark-hb-control-plane`
+
+Useful debug commands:
+- `oc -n ibm-cpd get deployments,sts,pods`
+- `oc -n ibm-cpd get ccs,wmlbase`
+
+spark-hb-control-plane
+
 Role Variables - Installation
 -----------------------------
 ### cpd_service_name
-Name of the service to install, supported values are: `wsl`
+Name of the service to install, supported values are: `wsl`, `wml`, `wd`, `aiopenscale`, `dods`, and `spark`
 
 - **Required**
 - Environment Variable: `CPD_SERVICE_NAME`
@@ -92,6 +114,20 @@ Namespace where the CP4D instance is deployed.
 - Environment Variable: `CPD_OPERATORS_NAMESPACE`
 - Default Value: `ibm-cpd-operators`
 
+### cpd_admin_username
+The CP4D Admin username to authenticate with CP4D APIs. If you didn't change the initial admin username after installing CP4D then you don't need to provide this.
+
+- Optional
+- Environment Variable: `CP4D_ADMIN_USERNAME`
+- Default Value: `admin`
+
+### cpd_admin_password
+The CP4D Admin User password to call CP4D API to provision Discovery Instance. If you didn't change the initial admin password after CP4D install, you don't need to provide it.  The initial admin user password for `admin` will be used.
+
+- Optional
+- Environment Variable: `CP4D_ADMIN_PASSWORD`
+- Default Value: Looked up from the `admin-user-details` secret in the `cpd_instance_namespace` namespace
+
 
 Role Variables - Watson Studio
 ------------------------------
@@ -116,8 +152,9 @@ Optional - Stores the CP4D Watson Studio Project description that can be used to
 - Environment Variable: `CPD_WSL_PROJECT_DESCRIPTION`
 - Default Value: `Watson Studio Project for Maximo Application Suite`
 
+
 Role Variables - MAS Configuration Generation
-----------------------------------==---------
+---------------------------------------------
 ### mas_instance_id
 The instance ID of Maximo Application Suite that a generated configuration will target.  If this or `mas_config_dir` are not set then the role will not generate a resource template.
 
@@ -146,122 +183,6 @@ Example Playbook
   roles:
     - ibm.mas_devops.cp4d_service
 
-```
-
-License
--------
-
-EPL-2.0
-
-
-
-
-Content from cp4d_wds role that needs to be merged into here
----------------------------------------
-
-
-cp4d_wds
-==========
-
-It's only for WDS 4.0.x install on the existing CP4D 4.0.x and WDS instance provisioning, and also generated WDScfg (For Assist Install) related yaml to MAS config Directory.
-
-It's also used for WDScfg (For Assist Install) related yaml preparation if you want to use the existing external WDS instance.
-
-Role Variables
---------------
-### cp4d_username
-The CP4D Admin User name used to call CP4D API to provision Discovery Instance. If you didn't change the initial admin password after CP4D install,you don't need to provide it. And the initial admin user name `admin` will be used.
-- Environment Variable: `CP4D_USERNAME`
-- Default Value: None
-
-### cp4d_password
-The CP4D Admin User password to call CP4D API to provision Discovery Instance. If you didn't change the initial admin password after CP4D install, you don't need to provide it.
-And the initial admin user password for `admin` will be used.
-- Environment Variable: `CP4D_PASSWORD`
-- Default Value: None
-
-### wdschannel
-The discovery channel used by discovery install. By default the `v4.0`  will be used as channel name for discovery install.
-- Environment Variable: `WDS_CHANNEL`
-- Default Value: v4.0
-
-### wdsversion
-The discovery version used by discovery install. By default the discovery `4.0.6` version will be installed.
-- Environment Variable: `WDS_VERSION`
-- Default Value: 4.0.6
-
-### wdsstorageclass
-The specific storage class for discovery install, if not specified , the storage class used by CP4D will be auto queried in the cluster and used for discovery install.
-Usually Watson Discovery uses the following storage classes. If you don't use these storage classes on your cluster, ensure that you have a storage class with an equivalent definition:
-OpenShift Container Storage: `ocs-storagecluster-ceph-rbd`
-IBM Cloud OCP cluster: `ibmc-block-gold`,`ibmc-block-gold-gid`
-IBM Spectrum® Scale Container Native: `ibm-spectrum-scale-sc`
-Portworx: `portworx-db-gp2-sc`
-
-- Environment Variable: `WDS_STORAGE_CLASS`
-- Default Value: None
-
-### mas_instance_id
-The instance ID of Maximo Application Suite that the discovery configuration will target.  If this or `mas_config_dir` are not set then the role will not generate a discovery template.
-
-- Environment Variable: `MAS_INSTANCE_ID`
-- Default Value: None
-
-### mas_workspace_id
-The workspace ID of Maximo Application Suite that the discovery instance name will be combined as "discovery-assist-{{ mas_workspace_id }}" if you set.
-Otherwise, single discovery instance will be created named as "discovery-assist".
-
-- Environment Variable: `MAS_WORKSPACE_ID`
-- Default Value: None
-
-### mas_config_dir
-Local directory to save the generated discovery configuration files.  This can be used to manually configure a Assist instance to connect to the discovery cluster, or used as an input to the [suite_config](suite_config.md) role. If this or `mas_instance_id` are not set then the role will not generate a discovery template.
-
-- Environment Variable: `MAS_CONFIG_DIR`
-- Default Value: None
-
-If you want to use the existing available external WDS instance(not in the cluster), the below Environment Variables are `required` to generate the Discovery configuration files. Either is missing will cause the failure to use external Discovery.
-### assist_wds_url
-External Discovery URL for discovery API use
-- Environment Variable: `ASSIST_WDS_URL`
-- Default Value: None
-### assist_wds_admin
-External Discovery admin User name
-- Environment Variable: `ASSIST_WDS_ADMIN`
-- Default Value: None
-### assist_wds_pass
-External Discovery admin User password
-- Environment Variable: `ASSIST_WDS_PASS`
-- Default Value: None
-
-Example Playbook
-----------------
-WDS install and WDS instance in the OCP Env
-```yaml
-- hosts: localhost
-  any_errors_fatal: true
-  vars:
-    # Create the MAS WDSCfg & Secret resource definitions
-    mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
-    mas_config_dir: "{{ lookup('env', 'MAS_CONFIG_DIR') }}"
-  roles:
-    - mas.devops.cp4d_wds
-```
-Use External WDS instance in the OCP Env
-```yaml
-- hosts: localhost
-  any_errors_fatal: true
-  vars:
-    #  Use External WDS instance for assist install
-    assist_wds_url: "{{ lookup('env', 'ASSIST_WDS_URL') }}"
-    assist_wds_admin: "{{ lookup('env', 'ASSIST_WDS_ADMIN') }}"
-    assist_wds_pass: "{{ lookup('env', 'ASSIST_WDS_PASS') }}"
-
-    #  Create the MAS WDSCfg & Secret resource definitions
-    mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
-    mas_config_dir: "{{ lookup('env', 'MAS_CONFIG_DIR') }}"
-  roles:
-    - mas.devops.cp4d_wds
 ```
 
 License

--- a/ibm/mas_devops/roles/cp4d_service/README.md
+++ b/ibm/mas_devops/roles/cp4d_service/README.md
@@ -132,6 +132,13 @@ Name of the service to install, supported values are: `wsl`, `wml`, `wd`, `aiope
 - Environment Variable: `CPD_SERVICE_NAME`
 - Default Value: None
 
+### cpd_product_version
+The product version (also known as operand version) of this service to install.  Currently, due to defects in Cloud Pak for Data the only version that works is the latest (`4.0.9`), but in the future you should be able to set this to any released version of CP4D.
+
+- **Required**
+- Environment Variable: `CPD_PRODUCT_VERSION`
+- Default Value: None
+
 ### cpd_service_storage_class
 This is used to set `spec.storageClass` in all CPD v3.5 services, and many - but not all - CP4D v4.0 services.
 

--- a/ibm/mas_devops/roles/cp4d_service/README.md
+++ b/ibm/mas_devops/roles/cp4d_service/README.md
@@ -359,17 +359,94 @@ Subscriptions related to Watson OpenScale (in the **ibm-cpd-operators** namespac
 - **cpd-platform-operator** on channel `v2.0`
 - **ibm-cpd-wos** on channel `v1.5`
 
-Assuming you are adding Watson OpenScale on top of Watson Studio, the key new resources in the installation are listed below, they are all created in the **ibm-cpd** namespace:
+Analytics Engine is made up of many moving parts across multiple namespaces.
 
-- `woservice.wos.cpd.ibm.com/aiopenscale`
-- `statefulset.apps/aiopenscale-ibm-aios-zookeeper`
-- `statefulset.apps/aiopenscale-ibm-aios-kafka`
-- `statefulset.apps/aiopenscale-ibm-aios-redis`
-- `statefulset.apps/aiopenscale-ibm-aios-etcd`
+In the **ibm-common-services** namespace:
 
-Useful debug commands:
-- `oc -n ibm-cpd get deployments,sts,pods`
-- `oc -n ibm-cpd get woservice`
+- 15 workloads / 12 pods
+- 0.051 CPU usage / 1.11 CPU requests / 3.57 CPU limit (5% utilization)
+- 774.7 MiB memory usage, 2.27 GiB memory requests / 5.72 GiB memory limit (33% utilization)
+
+```
+oc -n ibm-common-services get deployments
+NAME                                   READY   UP-TO-DATE   AVAILABLE   AGE
+cert-manager-cainjector                1/1     1            1           126m
+cert-manager-controller                1/1     1            1           126m
+cert-manager-webhook                   1/1     1            1           126m
+configmap-watcher                      1/1     1            1           126m
+ibm-cert-manager-operator              1/1     1            1           126m
+ibm-common-service-operator            1/1     1            1           131m
+ibm-common-service-webhook             1/1     1            1           130m
+ibm-namespace-scope-operator           1/1     1            1           131m
+ibm-zen-operator                       1/1     1            1           126m
+meta-api-deploy                        1/1     1            1           126m
+operand-deployment-lifecycle-manager   1/1     1            1           130m
+secretshare                            1/1     1            1           130m
+```
+
+In the **ibm-cpd-operators** namespace:
+
+- 4 workloads / 4 pods
+- 0.005 CPU usage / 0.4 CPU requests / 2 CPU limit (1% utilization)
+- 148.1 MiB memory usage, 912 MiB memory requests / 3 GiB memory limit (16% utilization)
+
+```
+oc -n ibm-cpd-operators get deployments
+NAME                            READY   UP-TO-DATE   AVAILABLE   AGE
+cpd-platform-operator-manager   1/1     1            1           145m
+ibm-common-service-operator     1/1     1            1           145m
+ibm-cpd-wos-operator            1/1     1            1           76m
+ibm-namespace-scope-operator    1/1     1            1           145m
+```
+
+In the **ibm-cpd** namespace:
+
+- 32 workloads / 63 pods
+- 0.591 CPU usage / 16.76 CPU requests / 31.9 CPU limit (4% utilization)
+- 7.67 GiB memory usage, 37.32 GiB memory requests / 97.89 GiB memory limit (20% utilization)
+
+```
+oc -n ibm-cpd get woservice,deployments,sts
+NAME                                    TYPE      STORAGE              SCALECONFIG   PHASE   RECONCILED   STATUS
+woservice.wos.cpd.ibm.com/aiopenscale   service   ibmc-file-gold-gid   small         Ready   4.0.9        Completed
+
+NAME                                                        READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/aiopenscale-ibm-aios-bias                   1/1     1            1           61m
+deployment.apps/aiopenscale-ibm-aios-bkpicombined           1/1     1            1           61m
+deployment.apps/aiopenscale-ibm-aios-common-api             1/1     1            1           61m
+deployment.apps/aiopenscale-ibm-aios-configuration          1/1     1            1           61m
+deployment.apps/aiopenscale-ibm-aios-dashboard              1/1     1            1           60m
+deployment.apps/aiopenscale-ibm-aios-datamart               1/1     1            1           60m
+deployment.apps/aiopenscale-ibm-aios-drift                  1/1     1            1           60m
+deployment.apps/aiopenscale-ibm-aios-explainability         1/1     1            1           60m
+deployment.apps/aiopenscale-ibm-aios-fast-path              1/1     1            1           60m
+deployment.apps/aiopenscale-ibm-aios-feedback               1/1     1            1           59m
+deployment.apps/aiopenscale-ibm-aios-ml-gateway-discovery   1/1     1            1           59m
+deployment.apps/aiopenscale-ibm-aios-ml-gateway-service     1/1     1            1           59m
+deployment.apps/aiopenscale-ibm-aios-mrm                    1/1     1            1           59m
+deployment.apps/aiopenscale-ibm-aios-nginx                  1/1     1            1           58m
+deployment.apps/aiopenscale-ibm-aios-notification           1/1     1            1           59m
+deployment.apps/aiopenscale-ibm-aios-payload-logging        1/1     1            1           58m
+deployment.apps/aiopenscale-ibm-aios-payload-logging-api    1/1     1            1           59m
+deployment.apps/aiopenscale-ibm-aios-scheduling             1/1     1            1           58m
+deployment.apps/ibm-nginx                                   3/3     3            3           125m
+deployment.apps/usermgmt                                    3/3     3            3           127m
+deployment.apps/zen-audit                                   1/1     1            1           120m
+deployment.apps/zen-core                                    3/3     3            3           120m
+deployment.apps/zen-core-api                                3/3     3            3           120m
+deployment.apps/zen-data-sorcerer                           2/2     2            2           114m
+deployment.apps/zen-watchdog                                1/1     1            1           114m
+deployment.apps/zen-watcher                                 1/1     1            1           120m
+
+NAME                                              READY   AGE
+statefulset.apps/aiopenscale-ibm-aios-etcd        3/3     62m
+statefulset.apps/aiopenscale-ibm-aios-kafka       3/3     62m
+statefulset.apps/aiopenscale-ibm-aios-redis       3/3     62m
+statefulset.apps/aiopenscale-ibm-aios-zookeeper   3/3     70m
+statefulset.apps/dsx-influxdb                     1/1     116m
+statefulset.apps/zen-metastoredb                  3/3     130m
+```
+
 
 ### Watson Discovery
 Subscriptions related to Watson Discovery (in the **ibm-cpd-operators** namespace):
@@ -387,16 +464,41 @@ Subscriptions related to Watson Discovery (in the **ibm-common-services** namesp
 
 - **cloud-native-postgresql** on channel `stable`
 
-The key new resources in the installation are listed below, they are all created in the **ibm-cpd** namespace:
+Watson Discovery is made up of many moving parts across multiple namespaces.
 
-- `woservice.wos.cpd.ibm.com/aiopenscale`
-- `statefulset.apps/wd-rabbitmq-discovery`
-- `statefulset.apps/wd-minio-discovery`
-- `statefulset.apps/wd-discovery-etcd`
+In the **ibm-common-services** namespace:
 
-Useful debug commands:
-- `oc -n ibm-cpd get deployments,sts,pods`
-- `oc -n ibm-cpd get watsondiscoveries`
+- x workloads / x pods
+- x CPU usage / x CPU requests / 3.57 CPU limit (x% utilization)
+- x memory usage, x memory requests / x memory limit (x% utilization)
+
+```
+oc -n ibm-common-services get deployments
+
+```
+
+In the **ibm-cpd-operators** namespace:
+
+- x workloads / x pods
+- x CPU usage / x CPU requests / 3.57 CPU limit (x% utilization)
+- x memory usage, x memory requests / x memory limit (x% utilization)
+
+```
+oc -n ibm-cpd-operators get deployments
+
+```
+
+In the **ibm-cpd** namespace:
+
+- x workloads / x pods
+- x CPU usage / x CPU requests / 3.57 CPU limit (x% utilization)
+- x memory usage, x memory requests / x memory limit (x% utilization)
+
+```
+oc -n ibm-cpd get watsondiscoveries,deployments,sts
+
+```
+
 
 Role Variables - Installation
 -----------------------------

--- a/ibm/mas_devops/roles/cp4d_service/README.md
+++ b/ibm/mas_devops/roles/cp4d_service/README.md
@@ -18,7 +18,6 @@ These services can be deployed and configured using this role:
     For more information on how Predict and HP Utilities make use of Watson Studio, refer to [Predict/HP Utilities documentation](https://www.ibm.com/docs/en/mhmpmh-and-p-u/8.2.0?topic=started-getting-data-scientists)
 
 ### Watson Studio
-
 Subscriptions related to Watson Studio (in the **ibm-cpd-operators** namespace):
 
 - **cpd-platform-operator** on channel `v2.0` (currently v2.0.8)
@@ -44,9 +43,7 @@ Useful debug commands:
 - `oc -n ibm-cpd get deployments,sts,pods`
 - `oc -n ibm-cpd get ccs,WS,DataRefinery,notebookruntimes`
 
-
 ### Watson Machine Learning
-
 Subscriptions related to Watson Machine Learning (in the **ibm-cpd-operators** namespace):
 
 - **cpd-platform-operator** on channel `v2.0` (currently v2.0.8)
@@ -67,7 +64,6 @@ Useful debug commands:
 - `oc -n ibm-cpd get ccs,wmlbase`
 
 ### Analytics Engine
-
 Subscriptions related to Analytics Engine (in the **ibm-cpd-operators** namespace):
 
 - **cpd-platform-operator** on channel `v2.0` (currently v2.0.8)
@@ -79,10 +75,24 @@ Assuming you are adding Analytics Engine on top of Watson Studio, the key new re
 - `deployment.apps/spark-hb-control-plane`
 
 Useful debug commands:
-- `oc -n ibm-cpd get deployments,sts,pods`
+- `oc -n ibm-cpd get deployments,pods`
 - `oc -n ibm-cpd get ccs,wmlbase`
 
-spark-hb-control-plane
+### Watson OpenScale
+Subscriptions related to Watson OpenScale (in the **ibm-cpd-operators** namespace):
+
+- **cpd-platform-operator** on channel `v2.0` (currently v2.0.8)
+- **ibm-cpd-wos** on channel `v1.5` (currently v1.5.4)
+
+Assuming you are adding Watson OpenScale on top of Watson Studio, the key new resources in the installation are listed below, they are all created in the **ibm-cpd** namespace:
+
+- `woservice.wos.cpd.ibm.com/aiopenscale`
+- `statefulset.apps/aiopenscale-ibm-aios-zookeeper`
+
+Useful debug commands:
+- `oc -n ibm-cpd get deployments,sts,pods`
+- `oc -n ibm-cpd get woservice`
+
 
 Role Variables - Installation
 -----------------------------

--- a/ibm/mas_devops/roles/cp4d_service/defaults/main.yml
+++ b/ibm/mas_devops/roles/cp4d_service/defaults/main.yml
@@ -7,11 +7,10 @@
 # been told to basically install a fixed version operator catalog for CP4D.  It's unfortunate, but it's out
 # of our control -- the only version of CP4D that works with MAS 8.7 is v4.0.7, but we can't install that
 # from the IBM operator catalog at present, much more work is needed in this collection to support the operating
-# model of the Cloud Pak teams :/
+# model of the Cloud Pak for Data team :/
 cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default('4.0.8', true) }}"
 
-# CP4D Admin User Crdential used to call CP4D APIs
-# If not specified, the script will look these up
+# CP4D Admin User credential used to call CP4D APIs, if not specified, the script will look these up
 cpd_admin_username: "{{ lookup('env', 'CPD_ADMIN_USERNAME') }}"
 cpd_admin_password: "{{ lookup('env', 'CPD_ADMIN_PASSWORD') }}"
 

--- a/ibm/mas_devops/roles/cp4d_service/defaults/main.yml
+++ b/ibm/mas_devops/roles/cp4d_service/defaults/main.yml
@@ -8,7 +8,7 @@
 # of our control -- the only version of CP4D that works with MAS 8.7 is v4.0.7, but we can't install that
 # from the IBM operator catalog at present, much more work is needed in this collection to support the operating
 # model of the Cloud Pak for Data team :/
-cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default('4.0.8', true) }}"
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') }}"
 
 # CP4D Admin User credential used to call CP4D APIs, if not specified, the script will look these up
 cpd_admin_username: "{{ lookup('env', 'CPD_ADMIN_USERNAME') }}"

--- a/ibm/mas_devops/roles/cp4d_service/tasks/gencfg/gencfg-wd.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/gencfg/gencfg-wd.yml
@@ -10,7 +10,7 @@
       kubernetes.core.k8s_info:
         api_version: route.openshift.io/v1
         kind: Route
-        namespace: "{{ cpdnamespace }}"
+        namespace: "{{ cpd_instance_namespace }}"
       register: cp4d_routes
     - name: "embeddedwds: Find route info for CP4D "
       set_fact:
@@ -112,7 +112,7 @@
   block:
     - name: Get the CP4D instance url
       set_fact:
-        wds_url: "{{ cp4d_host_url}}/discovery/{{ cpdnamespace }}-wd/instances/{{ wds_number }}/api"
+        wds_url: "{{ cp4d_host_url}}/discovery/{{ cpd_instance_namespace }}-wd/instances/{{ wds_number }}/api"
     - name: Print the WDS related info
       debug:
         msg:

--- a/ibm/mas_devops/roles/cp4d_service/tasks/install.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/install.yml
@@ -72,28 +72,6 @@
     apply: yes
     template: "templates/services/{{ cpd_service_name }}.yml.j2"
 
-# 6.2 Hacks & Workarounds
-# TODO: Implement me so that we don't need the cluster scoped image pull secret
-# and the associated node reboot in IBMCloud ROKS
-
-# 6.2.1. Install ibm-entitlement secret in ibm-cpd namespace
-
-# 6.2.2. Patch the zen service accounts in ibm-cpd namespace to add ibm-entitlement
-# - zen-admin-sa
-# - zen-editor-sa
-# - zen-norbac-sa
-# - zen-runtime-sa
-# - zen-viewer-sa
-#
-# e.g.
-# imagePullSecrets:
-# - name: zen-viewer-sa-dockercfg-t2cvz
-# - name: ibm-entitlement
-
-# 6.2.3. Patch the runtime service accounts in ibm-cpd namespace to add ibm-entitlement
-# - runtime-assemblies-operator
-# - runtime-manager-api
-
 
 # 7. Wait for CP4D Service to be ready
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/cp4d_service/tasks/install.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/install.yml
@@ -66,10 +66,33 @@
 
 # 6. Install CP4D Service CRs
 # -----------------------------------------------------------------------------
+# 6.1 The actual install
 - name: "Install Service CR"
   kubernetes.core.k8s:
     apply: yes
     template: "templates/services/{{ cpd_service_name }}.yml.j2"
+
+# 6.2 Hacks & Workarounds
+# TODO: Implement me so that we don't need the cluster scoped image pull secret
+# and the associated node reboot in IBMCloud ROKS
+
+# 6.2.1. Install ibm-entitlement secret in ibm-cpd namespace
+
+# 6.2.2. Patch the zen service accounts in ibm-cpd namespace to add ibm-entitlement
+# - zen-admin-sa
+# - zen-editor-sa
+# - zen-norbac-sa
+# - zen-runtime-sa
+# - zen-viewer-sa
+#
+# e.g.
+# imagePullSecrets:
+# - name: zen-viewer-sa-dockercfg-t2cvz
+# - name: ibm-entitlement
+
+# 6.2.3. Patch the runtime service accounts in ibm-cpd namespace to add ibm-entitlement
+# - runtime-assemblies-operator
+# - runtime-manager-api
 
 
 # 7. Wait for CP4D Service to be ready

--- a/ibm/mas_devops/roles/cp4d_service/tasks/main.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/main.yml
@@ -1,15 +1,19 @@
 ---
 # 1. Debug
 # -----------------------------------------------------------------------------
-- name: "Check that CPD Service name has been provided"
+- name: "Check that CPD Service name and product version has been provided"
   assert:
-    that: cpd_service_name is defined and cpd_service_name != ""
-    fail_msg: "CPD service name (cpd_service_name) is a required parameter to run this role"
+    that:
+      - cpd_service_name is defined and cpd_service_name != ""
+      - cpd_product_version is defined and cpd_product_version != ""
+    fail_msg: "CPD service name (cpd_service_name) and version (cpd_product_version) are required parameter to run this role"
 
 - debug:
     msg:
-      - "CPD Product Version .................... {{ cpd_product_version }}"
-      - "CPD Service ............................ {{ cpd_service_name }}"
+      - "CPD operators namespace ................ {{ cpd_operators_namespace }}"
+      - "CPD instance namespace ................. {{ cpd_instance_namespace }}"
+      - "CPD service ............................ {{ cpd_service_name }}"
+      - "CPD product version .................... {{ cpd_product_version }}"
 
 
 # 2. Run the installation

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-aiopenscale.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-aiopenscale.yml
@@ -2,9 +2,6 @@
 
 # 1. Wait for CP4D service CR to be ready
 # -----------------------------------------------------------------------------
-# Unfortunately CP4D do not have a standard approach to managing status across
-# their services like MAS does, so we need module-specific wait code.
-
 - name: "wait-aiopenscale : Wait for wosStatus 'Completed' or 'Failed'"
   kubernetes.core.k8s_info:
     api_version: "{{ cpd_service_info[cpd_service_name].api_version }}"

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-ccs.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-ccs.yml
@@ -33,7 +33,14 @@
     - runtime-assemblies-operator
     - runtime-manager-api
 
-# 1.3. Lookup and restart the runtimes operator pod if it's in ImagePullBackOff state
+# 1.3 If we look for pods in image pull backoff too early then we won't know which ones to
+# boot so that they pick up the image pull secret as it takes a while for pods to get
+# into "ImagePullBackOff" or "ErrImagePull" state
+- name: "wait-ccs : Pause for 5 minutes to allow the runtimes operator pod to start up"
+  pause:
+    minutes: 5
+
+# 1.4. Lookup and restart the runtimes operator pod if it's in ImagePullBackOff state
 - name: "wait-ccs : Lookup runtimes operator pod"
   kubernetes.core.k8s_info:
     api_version: v1

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-ccs.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-ccs.yml
@@ -1,0 +1,98 @@
+---
+# 1. Patch service accounts
+# -----------------------------------------------------------------------------
+# 1.1. Wait for Runtime service accounts to be created
+- name: "wait-ccs : Wait for the Runtime service accounts to appear"
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ServiceAccount
+    name: "{{ item }}"
+    namespace: "{{ cpd_instance_namespace }}"
+  register: runtime_sa_lookup
+  retries: 24 # Up to 2 hours
+  delay: 300 # Every 5 minutes
+  until:
+    - runtime_sa_lookup.resources is defined
+    - runtime_sa_lookup.resources | length > 0
+  with_items:
+    - runtime-assemblies-operator
+    - runtime-manager-api
+
+# 1.2. Patch the runtime service accounts in ibm-cpd namespace to add ibm-entitlement-key
+- name: "wait-ccs : Patch the Runtime service accounts"
+  kubernetes.core.k8s:
+    api_version: v1
+    kind: ServiceAccount
+    name: "{{ item }}"
+    namespace: "{{ cpd_instance_namespace }}"
+    definition:
+      imagePullSecrets:
+        - name: ibm-entitlement-key
+  with_items:
+    - runtime-assemblies-operator
+    - runtime-manager-api
+
+# 1.3. Lookup and restart the runtimes operator pod if it's in ImagePullBackOff state
+- name: "wait-ccs : Lookup runtimes operator pod"
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Pod
+    label_selectors:
+      - app.kubernetes.io/name = runtime-assemblies-operator
+    namespace: "{{ cpd_instance_namespace }}"
+  register: runtime_operator_pod_lookup
+  retries: 10 # Up to 10 minutes
+  delay: 60 # Every 1 minute
+
+- name: "wait-ccs : Delete runtimes operator pod if it's in image pull backoff"
+  when:
+    - runtime_operator_pod_lookup.resources[0] | length > 0
+    - runtime_operator_pod_lookup.resources[0].status.containerStatuses[0].state is defined
+    - runtime_operator_pod_lookup.resources[0].status.containerStatuses[0].state.waiting is defined
+    - runtime_operator_pod_lookup.resources[0].status.containerStatuses[0].state.waiting.reason is defined
+    - runtime_operator_pod_lookup.resources[0].status.containerStatuses[0].state.waiting.reason is in ["ImagePullBackOff", "ErrImagePull"]
+  kubernetes.core.k8s:
+    state: absent
+    api_version: v1
+    kind: Pod
+    name: "{{ runtime_operator_pod_lookup.resources[0].metadata.name }}"
+    namespace: "{{ cpd_instance_namespace }}"
+
+- name: "wait-ccs : Wait for the runtimes operator deployment to be ready"
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Deployment
+    name: runtime-assemblies-operator
+    namespace: "{{ cpd_instance_namespace }}"
+    wait: true
+    wait_condition:
+      type: Available
+      status: True
+    wait_sleep: 10 # seconds
+    wait_timeout : 300 # 5 minutes
+
+
+# 2. Wait for CCS CR to be ready
+# -----------------------------------------------------------------------------
+# We can't stop waiting on Failed status, as it will report failed multiple
+# times during initial reconcile ... we just need to keep waiting.
+- name: "wait-ccs : Wait for ccsStatus 'Completed'"
+  kubernetes.core.k8s_info:
+    api_version: "ccs.cpd.ibm.com/v1beta1"
+    kind: CCS
+    name: "ccs-cr"
+    namespace: "{{ cpd_instance_namespace }}"
+  register: ccs_cr_lookup
+  until:
+    - ccs_cr_lookup.resources is defined
+    - ccs_cr_lookup.resources | length == 1
+    - ccs_cr_lookup.resources[0].status is defined
+    - ccs_cr_lookup.resources[0].status.ccsStatus is defined
+    - ccs_cr_lookup.resources[0].status.ccsStatus == "Completed" #  or ccs_cr_lookup.resources[0].status.wmlStatus == "Failed"
+  retries: 24 # Up to 2 hours
+  delay: 300 # Every 5 minutes
+
+- name: "wait-ccs : Check that the CCS ccsStatus is 'Completed'"
+  assert:
+    that: ccs_cr_lookup.resources[0].status.ccsStatus == "Completed"
+    fail_msg: "Watson Machine Learning install failed (ccsStatus)"

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-ccs.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-ccs.yml
@@ -1,7 +1,8 @@
 ---
 # 1. Patch service accounts
 # -----------------------------------------------------------------------------
-# 1.1. Wait for Runtime service accounts to be created
+# 1.1. Wait for Runtime service accounts to be created (this will take in
+# excess of 1 hour for a new install)
 - name: "wait-ccs : Wait for the Runtime service accounts to appear"
   kubernetes.core.k8s_info:
     api_version: v1
@@ -74,8 +75,13 @@
 
 # 2. Wait for CCS CR to be ready
 # -----------------------------------------------------------------------------
-# We can't stop waiting on Failed status, as it will report failed multiple
-# times during initial reconcile ... we just need to keep waiting.
+# Although the overall time to install CCS is huge, by the time the runtimes
+# operator is deployed it will already have deployed the time-intensive parts
+# of CCS (RabbitMQ, Redis, CouchDb, Elasticsearch) and this should report
+# success within 1 hour.
+
+# Note: We can't fail early when we see Failed status, as the operator will
+# report failed multiple times during initial reconcile.
 - name: "wait-ccs : Wait for ccsStatus 'Completed'"
   kubernetes.core.k8s_info:
     api_version: "ccs.cpd.ibm.com/v1beta1"
@@ -89,8 +95,8 @@
     - ccs_cr_lookup.resources[0].status is defined
     - ccs_cr_lookup.resources[0].status.ccsStatus is defined
     - ccs_cr_lookup.resources[0].status.ccsStatus == "Completed" #  or ccs_cr_lookup.resources[0].status.wmlStatus == "Failed"
-  retries: 24 # Up to 2 hours
-  delay: 300 # Every 5 minutes
+  retries: 30 # Up to 1 hour
+  delay: 120 # Every 2 minutes
 
 - name: "wait-ccs : Check that the CCS ccsStatus is 'Completed'"
   assert:

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-ccs.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-ccs.yml
@@ -47,7 +47,7 @@
 
 - name: "wait-ccs : Delete runtimes operator pod if it's in image pull backoff"
   when:
-    - runtime_operator_pod_lookup.resources[0] | length > 0
+    - runtime_operator_pod_lookup.resources | length > 0
     - runtime_operator_pod_lookup.resources[0].status.containerStatuses[0].state is defined
     - runtime_operator_pod_lookup.resources[0].status.containerStatuses[0].state.waiting is defined
     - runtime_operator_pod_lookup.resources[0].status.containerStatuses[0].state.waiting.reason is defined

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-dods.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-dods.yml
@@ -2,9 +2,6 @@
 
 # 1. Wait for CP4D service CR to be ready
 # -----------------------------------------------------------------------------
-# Unfortunately CP4D do not have a standard approach to managing status across
-# their services like MAS does, so we need module-specific wait code.
-
 - name: "wait-dods : Wait for dodsStatus 'Completed' or 'Failed'"
   kubernetes.core.k8s_info:
     api_version: "{{ cpd_service_info[cpd_service_name].api_version }}"

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-spark.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-spark.yml
@@ -2,9 +2,6 @@
 
 # 1. Wait for CP4D service CR to be ready
 # -----------------------------------------------------------------------------
-# Unfortunately CP4D do not have a standard approach to managing status across
-# their services like MAS does, so we need module-specific wait code.
-
 - name: "wait-spark : Wait for analyticsengineStatus 'Completed' or 'Failed'"
   kubernetes.core.k8s_info:
     api_version: "{{ cpd_service_info[cpd_service_name].api_version }}"
@@ -18,8 +15,8 @@
     - cpd_cr_lookup.resources[0].status is defined
     - cpd_cr_lookup.resources[0].status.analyticsengineStatus is defined
     - cpd_cr_lookup.resources[0].status.analyticsengineStatus == "Completed" or cpd_cr_lookup.resources[0].status.analyticsengineStatus == "Failed"
-  retries: 30 # Up to 1 hour
-  delay: 120 # Every 2 minutes
+  retries: 30 # Up to 2 hours
+  delay: 240 # Every 4 minutes
 
 - name: "wait-spark : Check that the WML analyticsengineStatus is 'Completed'"
   assert:

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wd.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wd.yml
@@ -1,6 +1,11 @@
 ---
+# 1. Wait for CCS
+# -----------------------------------------------------------------------------
+- name: "Wait for CCS"
+  include_tasks: "wait-ccs.yml"
 
-# 1. Wait for CP4D service CR to be ready
+
+# 2. Wait for CP4D service CR to be ready
 # -----------------------------------------------------------------------------
 - name: "wait-wd : Wait for watsonDiscoveryStatus 'Completed' or 'Failed'"
   kubernetes.core.k8s_info:

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wd.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wd.yml
@@ -15,7 +15,7 @@
     - cpd_cr_lookup.resources[0].status is defined
     - cpd_cr_lookup.resources[0].status.watsonDiscoveryStatus is defined
     - cpd_cr_lookup.resources[0].status.watsonDiscoveryStatus == "Completed" or cpd_cr_lookup.resources[0].status.watsonDiscoveryStatus == "Failed"
-  retries: 24 # Up to 2 hours
+  retries: 60 # Up to 5 (yes, FIVE !!) hours
   delay: 300 # Every 5 minutes
 
 - name: "wait-wd : Check that the WD watsonDiscoveryStatus is 'Completed'"

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wd.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wd.yml
@@ -1,11 +1,71 @@
 ---
-# 1. Wait for CCS
+# 1. Patch service account
 # -----------------------------------------------------------------------------
-- name: "Wait for CCS"
+# 1.1. Wait for Discovery CN postgress service accounts to be created
+# https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/3481#issuecomment-44648280
+- name: "wait-wd : Wait for thewd-discovery-cn-postgres service account to appear"
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ServiceAccount
+    name: "{{ item }}"
+    namespace: "{{ cpd_instance_namespace }}"
+  register: discovery_sa_lookup
+  retries: 24 # Up to 2 hours
+  delay: 300 # Every 5 minutes
+  until:
+    - discovery_sa_lookup.resources is defined
+    - discovery_sa_lookup.resources | length > 0
+  with_items:
+    - wd-discovery-cn-postgres
+
+# 1.2. Patch the Discovery CN postgress service accounts in ibm-cpd namespace to add ibm-entitlement-key
+- name: "wait-wd : Patch the wd-discovery-cn-postgres service account"
+  kubernetes.core.k8s:
+    api_version: v1
+    kind: ServiceAccount
+    name: "{{ item }}"
+    namespace: "{{ cpd_instance_namespace }}"
+    definition:
+      imagePullSecrets:
+        - name: ibm-entitlement-key
+  with_items:
+    - wd-discovery-cn-postgres
+
+# 1.3. Lookup and restart the runtimes operator pod if it's in ImagePullBackOff state
+- name: "wait-wd : Lookup discovery pods"
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Pod
+    label_selectors:
+      - app.kubernetes.io/name = discovery
+    namespace: "{{ cpd_instance_namespace }}"
+  register: discovery_pod_lookup
+  retries: 10 # Up to 10 minutes
+  delay: 60 # Every 1 minute
+
+- name: "wait-wd : Delete discovery pod if it's in image pull backoff"
+  when:
+    - discovery_pod_lookup.resources | length > 0
+    - item.status.containerStatuses[0].state is defined
+    - item.status.containerStatuses[0].state.waiting is defined
+    - item.status.containerStatuses[0].state.waiting.reason is defined
+    - item.status.containerStatuses[0].state.waiting.reason is in ["ImagePullBackOff", "ErrImagePull"]
+  kubernetes.core.k8s:
+    state: absent
+    api_version: v1
+    kind: Pod
+    name: "{{ discovery_pod_lookup.resources[0].metadata.name }}"
+    namespace: "{{ cpd_instance_namespace }}"
+  with_items: "{{ discovery_pod_lookup.resources }}"
+
+
+# 2. Wait for CCS
+# -----------------------------------------------------------------------------
+- name: "wait-wd : Wait for CCS"
   include_tasks: "wait-ccs.yml"
 
 
-# 2. Wait for CP4D service CR to be ready
+# 3. Wait for CP4D service CR to be ready
 # -----------------------------------------------------------------------------
 - name: "wait-wd : Wait for watsonDiscoveryStatus 'Completed' or 'Failed'"
   kubernetes.core.k8s_info:

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wd.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wd.yml
@@ -31,7 +31,14 @@
   with_items:
     - wd-discovery-cn-postgres
 
-# 1.3. Lookup and restart the runtimes operator pod if it's in ImagePullBackOff state
+# 1.3 If we look for pods in image pull backoff too early then we won't know which ones to
+# boot so that they pick up the image pull secret as it takes a while for pods to get
+# into "ImagePullBackOff" or "ErrImagePull" state
+- name: "wait-wd : Pause for 5 minutes to allow the runtimes operator pod to start up"
+  pause:
+    minutes: 5
+
+# 1.4. Lookup and restart the runtimes operator pod if it's in ImagePullBackOff state
 - name: "wait-wd : Lookup discovery pods"
   kubernetes.core.k8s_info:
     api_version: v1

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wd.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wd.yml
@@ -59,13 +59,7 @@
   with_items: "{{ discovery_pod_lookup.resources }}"
 
 
-# 2. Wait for CCS
-# -----------------------------------------------------------------------------
-- name: "wait-wd : Wait for CCS"
-  include_tasks: "wait-ccs.yml"
-
-
-# 3. Wait for CP4D service CR to be ready
+# 2. Wait for CP4D service CR to be ready
 # -----------------------------------------------------------------------------
 - name: "wait-wd : Wait for watsonDiscoveryStatus 'Completed' or 'Failed'"
   kubernetes.core.k8s_info:

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wd.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wd.yml
@@ -2,9 +2,6 @@
 
 # 1. Wait for CP4D service CR to be ready
 # -----------------------------------------------------------------------------
-# Unfortunately CP4D do not have a standard approach to managing status across
-# their services like MAS does, so we need module-specific wait code.
-
 - name: "wait-wd : Wait for watsonDiscoveryStatus 'Completed' or 'Failed'"
   kubernetes.core.k8s_info:
     api_version: "{{ cpd_service_info[cpd_service_name].api_version }}"

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wml.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wml.yml
@@ -2,6 +2,11 @@
 
 # 1. Wait for CP4D service CR to be ready
 # -----------------------------------------------------------------------------
+# We can't exit early if the status goes to Failed because the reconcile will
+# report failure multiple times during initial install due to timeouts (CCS takes
+# a very long time to install because it's single threaded)
+#
+# https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/3480
 - name: "wait-wml : Wait for wmlStatus 'Completed' or 'Failed'"
   kubernetes.core.k8s_info:
     api_version: "{{ cpd_service_info[cpd_service_name].api_version }}"
@@ -14,7 +19,7 @@
     - cpd_cr_lookup.resources | length == 1
     - cpd_cr_lookup.resources[0].status is defined
     - cpd_cr_lookup.resources[0].status.wmlStatus is defined
-    - cpd_cr_lookup.resources[0].status.wmlStatus == "Completed" or cpd_cr_lookup.resources[0].status.wmlStatus == "Failed"
+    - cpd_cr_lookup.resources[0].status.wmlStatus == "Completed" #  or cpd_cr_lookup.resources[0].status.wmlStatus == "Failed"
   retries: 24 # Up to 2 hours
   delay: 300 # Every 5 minutes
 

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wml.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wml.yml
@@ -2,9 +2,6 @@
 
 # 1. Wait for CP4D service CR to be ready
 # -----------------------------------------------------------------------------
-# Unfortunately CP4D do not have a standard approach to managing status across
-# their services like MAS does, so we need module-specific wait code.
-
 - name: "wait-wml : Wait for wmlStatus 'Completed' or 'Failed'"
   kubernetes.core.k8s_info:
     api_version: "{{ cpd_service_info[cpd_service_name].api_version }}"

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wml.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wml.yml
@@ -1,32 +1,12 @@
 ---
 
-# 1. Wait for CCS CR to be ready
+# 1. Wait for CCS
 # -----------------------------------------------------------------------------
-# We can't stop waiting on Failed status, as it will report failed multiple
-# times during initial reconcile ... we just need to keep waiting.
-- name: "wait-wsl : Wait for ccsStatus 'Completed'"
-  kubernetes.core.k8s_info:
-    api_version: "ccs.cpd.ibm.com/v1beta1"
-    kind: CCS
-    name: "ccs-cr"
-    namespace: "{{ cpd_instance_namespace }}"
-  register: ccs_cr_lookup
-  until:
-    - ccs_cr_lookup.resources is defined
-    - ccs_cr_lookup.resources | length == 1
-    - ccs_cr_lookup.resources[0].status is defined
-    - ccs_cr_lookup.resources[0].status.ccsStatus is defined
-    - ccs_cr_lookup.resources[0].status.ccsStatus == "Completed" #  or ccs_cr_lookup.resources[0].status.wmlStatus == "Failed"
-  retries: 24 # Up to 2 hours
-  delay: 300 # Every 5 minutes
-
-- name: "wait-wsl : Check that the CCS ccsStatus is 'Completed'"
-  assert:
-    that: ccs_cr_lookup.resources[0].status.ccsStatus == "Completed"
-    fail_msg: "Watson Machine Learning install failed (ccsStatus)"
+- name: "Wait for CCS"
+  include_tasks: "wait-ccs.yml"
 
 
-# 2. Wait for CP4D service CR to be ready
+# 2. Wait for WML CR to be ready
 # -----------------------------------------------------------------------------
 # We can't exit early if the status goes to Failed because the reconcile will
 # report failure multiple times during initial install due to timeouts (CCS takes

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wml.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wml.yml
@@ -1,6 +1,32 @@
 ---
 
-# 1. Wait for CP4D service CR to be ready
+# 1. Wait for CCS CR to be ready
+# -----------------------------------------------------------------------------
+# We can't stop waiting on Failed status, as it will report failed multiple
+# times during initial reconcile ... we just need to keep waiting.
+- name: "wait-wsl : Wait for ccsStatus 'Completed'"
+  kubernetes.core.k8s_info:
+    api_version: "ccs.cpd.ibm.com/v1beta1"
+    kind: CCS
+    name: "ccs-cr"
+    namespace: "{{ cpd_instance_namespace }}"
+  register: ccs_cr_lookup
+  until:
+    - ccs_cr_lookup.resources is defined
+    - ccs_cr_lookup.resources | length == 1
+    - ccs_cr_lookup.resources[0].status is defined
+    - ccs_cr_lookup.resources[0].status.ccsStatus is defined
+    - ccs_cr_lookup.resources[0].status.ccsStatus == "Completed" #  or ccs_cr_lookup.resources[0].status.wmlStatus == "Failed"
+  retries: 24 # Up to 2 hours
+  delay: 300 # Every 5 minutes
+
+- name: "wait-wsl : Check that the CCS ccsStatus is 'Completed'"
+  assert:
+    that: ccs_cr_lookup.resources[0].status.ccsStatus == "Completed"
+    fail_msg: "Watson Machine Learning install failed (ccsStatus)"
+
+
+# 2. Wait for CP4D service CR to be ready
 # -----------------------------------------------------------------------------
 # We can't exit early if the status goes to Failed because the reconcile will
 # report failure multiple times during initial install due to timeouts (CCS takes

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wsl.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wsl.yml
@@ -1,10 +1,134 @@
 ---
 
-# 1. Wait for CP4D service CR to be ready
+# 1 Hacks & Workarounds
+# TODO: Implement me so that we don't need the cluster scoped image pull secret
+# and the associated node reboot in IBMCloud ROKS
+
+# 1.1. Wait for ZenService service accounts to be created
+- name: "Wait for the zen service accounts to appear - {{ item }}"
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ServiceAccount
+    name: "{{ item }}"
+    namespace: "{{ cpd_instance_namespace }}"
+  register: zen_sa_lookup
+  retries: 120 # ~approx 5 minutes before we give up waiting for the CRD to be created
+  delay: 5 # seconds
+  until:
+    - zen_sa_lookup.resources is defined
+    - zen_sa_lookup.resources | length > 0
+  with_items:
+    - zen-admin-sa
+    - zen-editor-sa
+    - zen-norbac-sa
+    - zen-runtime-sa
+    - zen-viewer-sa
+
+# 1.2. Patch the zen service accounts in ibm-cpd namespace to add ibm-entitlement
+- name: "Patch the zen service accounts - {{ item }}"
+  kubernetes.core.k8s:
+    api_version: v1
+    kind: ServiceAccount
+    name: "{{ item }}"
+    namespace: "{{ cpd_instance_namespace }}"
+    definition:
+      imagePullSecrets:
+        - ibm-entitlement
+  with_items:
+    - zen-admin-sa
+    - zen-editor-sa
+    - zen-norbac-sa
+    - zen-runtime-sa
+    - zen-viewer-sa
+
+# 1.3. Wait for Runtime service accounts to be created
+- name: "Wait for the Runtime service accounts to appear - {{ item }}"
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ServiceAccount
+    name: "{{ item }}"
+    namespace: "{{ cpd_instance_namespace }}"
+  register: runtime_sa_lookup
+  retries: 120 # ~approx 5 minutes before we give up waiting for the CRD to be created
+  delay: 5 # seconds
+  until:
+    - runtime_sa_lookup.resources is defined
+    - runtime_sa_lookup.resources | length > 0
+  with_items:
+    - runtime-assemblies-operator
+    - runtime-manager-api
+
+# 1.4. Patch the runtime service accounts in ibm-cpd namespace to add ibm-entitlement
+- name: "Patch the Runtime service accounts - {{ item }}"
+  kubernetes.core.k8s:
+    api_version: v1
+    kind: ServiceAccount
+    name: "{{ item }}"
+    namespace: "{{ cpd_instance_namespace }}"
+    definition:
+      imagePullSecrets:
+        - ibm-entitlement
+  with_items:
+    - runtime-assemblies-operator
+    - runtime-manager-api
+
+
+# 2. Wait for CCS CR to be ready
+# -----------------------------------------------------------------------------
+# We can't stop waiting on Failed status, as it will report failed multiple
+# times during initial reconcile ... we just need to keep waiting.
+- name: "wait-wsl : Wait for ccsStatus 'Completed'"
+  kubernetes.core.k8s_info:
+    api_version: "ccs.cpd.ibm.com/v1beta1"
+    kind: CCS
+    name: "ccs-cr"
+    namespace: "{{ cpd_instance_namespace }}"
+  register: ccs_cr_lookup
+  until:
+    - ccs_cr_lookup.resources is defined
+    - ccs_cr_lookup.resources | length == 1
+    - ccs_cr_lookup.resources[0].status is defined
+    - ccs_cr_lookup.resources[0].status.ccsStatus is defined
+    - ccs_cr_lookup.resources[0].status.ccsStatus == "Completed"
+  retries: 24 # Up to 2 hours
+  delay: 300 # Every 5 minutes
+
+- name: "wait-wsl : Check that the CCS ccsStatus is 'Completed'"
+  assert:
+    that: ccs_cr_lookup.resources[0].status.ccsStatus == "Completed"
+    fail_msg: "Watson Studio install failed (ccsStatus)"
+
+
+# 3. Wait for DataRefinery CR to be ready
+# -----------------------------------------------------------------------------
+# We can't stop waiting on Failed status, as it will report failed multiple
+# times during initial reconcile ... we just need to keep waiting.
+- name: "wait-wsl : Wait for datarefineryStatus 'Completed'"
+  kubernetes.core.k8s_info:
+    api_version: "datarefinery.cpd.ibm.com/v1beta1"
+    kind: DataRefinery
+    name: "datarefinery-sample"
+    namespace: "{{ cpd_instance_namespace }}"
+  register: dr_cr_lookup
+  until:
+    - dr_cr_lookup.resources is defined
+    - dr_cr_lookup.resources | length == 1
+    - dr_cr_lookup.resources[0].status is defined
+    - dr_cr_lookup.resources[0].status.datarefineryStatus is defined
+    - dr_cr_lookup.resources[0].status.datarefineryStatus == "Completed"
+  retries: 24 # Up to 2 hours
+  delay: 300 # Every 5 minutes
+
+- name: "wait-wsl : Check that the CCS ccsStatus is 'Completed'"
+  assert:
+    that: dr_cr_lookup.resources[0].status.datarefineryStatus == "Completed"
+    fail_msg: "Watson Studio install failed (datarefineryStatus)"
+
+
+# 4. Wait for WSL service CR to be ready
 # -----------------------------------------------------------------------------
 # Unfortunately CP4D do not have a standard approach to managing status across
 # their services like MAS does, so we need module-specific wait code.
-
 - name: "wait-wsl : Wait for wsStatus 'Completed' or 'Failed'"
   kubernetes.core.k8s_info:
     api_version: "{{ cpd_service_info[cpd_service_name].api_version }}"
@@ -18,7 +142,7 @@
     - cpd_cr_lookup.resources[0].status is defined
     - cpd_cr_lookup.resources[0].status.wsStatus is defined
     - cpd_cr_lookup.resources[0].status.wsStatus == "Completed" or cpd_cr_lookup.resources[0].status.wsStatus == "Failed"
-  retries: 36 # Up to 3 hours
+  retries: 24 # Up to 2 hours
   delay: 300 # Every 5 minutes
 
 - name: "wait-wsl : Check that the WSL wsStatus is 'Completed'"

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wsl.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wsl.yml
@@ -1,105 +1,12 @@
 ---
 
-# 1. Patch service accounts
+# 1. Wait for CCS
 # -----------------------------------------------------------------------------
-# 1.1. Wait for Runtime service accounts to be created
-- name: "Wait for the Runtime service accounts to appear"
-  kubernetes.core.k8s_info:
-    api_version: v1
-    kind: ServiceAccount
-    name: "{{ item }}"
-    namespace: "{{ cpd_instance_namespace }}"
-  register: runtime_sa_lookup
-  retries: 24 # Up to 2 hours
-  delay: 300 # Every 5 minutes
-  until:
-    - runtime_sa_lookup.resources is defined
-    - runtime_sa_lookup.resources | length > 0
-  with_items:
-    - runtime-assemblies-operator
-    - runtime-manager-api
-
-# 1.2. Patch the runtime service accounts in ibm-cpd namespace to add ibm-entitlement-key
-- name: "Patch the Runtime service accounts"
-  kubernetes.core.k8s:
-    api_version: v1
-    kind: ServiceAccount
-    name: "{{ item }}"
-    namespace: "{{ cpd_instance_namespace }}"
-    definition:
-      imagePullSecrets:
-        - name: ibm-entitlement-key
-  with_items:
-    - runtime-assemblies-operator
-    - runtime-manager-api
-
-# 1.3. Lookup and restart the runtimes operator pod if it's in ImagePullBackOff state
-- name: "Lookup runtimes operator pod"
-  kubernetes.core.k8s_info:
-    api_version: v1
-    kind: Pod
-    label_selectors:
-      - app.kubernetes.io/name = runtime-assemblies-operator
-    namespace: "{{ cpd_instance_namespace }}"
-  register: runtime_operator_pod_lookup
-  retries: 10 # Up to 10 minutes
-  delay: 60 # Every 1 minute
-
-- name: "Delete runtimes operator pod if it's in image pull backoff"
-  when:
-    - runtime_operator_pod_lookup.resources[0] | length > 0
-    - runtime_operator_pod_lookup.resources[0].status.containerStatuses[0].state is defined
-    - runtime_operator_pod_lookup.resources[0].status.containerStatuses[0].state.waiting is defined
-    - runtime_operator_pod_lookup.resources[0].status.containerStatuses[0].state.waiting.reason is defined
-    - runtime_operator_pod_lookup.resources[0].status.containerStatuses[0].state.waiting.reason is in ["ImagePullBackOff", "ErrImagePull"]
-  kubernetes.core.k8s:
-    state: absent
-    api_version: v1
-    kind: Pod
-    name: "{{ runtime_operator_pod_lookup.resources[0].metadata.name }}"
-    namespace: "{{ cpd_instance_namespace }}"
-
-- name: "Wait for the runtimes operator deployment to be ready"
-  kubernetes.core.k8s_info:
-    api_version: v1
-    kind: Deployment
-    name: runtime-assemblies-operator
-    namespace: "{{ cpd_instance_namespace }}"
-    wait: true
-    wait_condition:
-      type: Available
-      status: True
-    wait_sleep: 10 # seconds
-    wait_timeout : 300 # 5 minutes
+- name: "Wait for CCS"
+  include_tasks: "wait-ccs.yml"
 
 
-# 2. Wait for CCS CR to be ready
-# -----------------------------------------------------------------------------
-# We can't stop waiting on Failed status, as it will report failed multiple
-# times during initial reconcile ... we just need to keep waiting.
-- name: "wait-wsl : Wait for ccsStatus 'Completed'"
-  kubernetes.core.k8s_info:
-    api_version: "ccs.cpd.ibm.com/v1beta1"
-    kind: CCS
-    name: "ccs-cr"
-    namespace: "{{ cpd_instance_namespace }}"
-  register: ccs_cr_lookup
-  until:
-    - ccs_cr_lookup.resources is defined
-    - ccs_cr_lookup.resources | length == 1
-    - ccs_cr_lookup.resources[0].status is defined
-    - ccs_cr_lookup.resources[0].status.ccsStatus is defined
-    - ccs_cr_lookup.resources[0].status.ccsStatus == "Completed" #  or ccs_cr_lookup.resources[0].status.wmlStatus == "Failed"
-  retries: 24 # Up to 2 hours
-  delay: 300 # Every 5 minutes
-
-- name: "wait-wsl : Check that the CCS ccsStatus is 'Completed'"
-  assert:
-    that: ccs_cr_lookup.resources[0].status.ccsStatus == "Completed"
-    fail_msg: "Watson Studio install failed (ccsStatus)"
-
-
-# 3. Wait for DataRefinery CR to be ready
+# 2. Wait for DataRefinery CR to be ready
 # -----------------------------------------------------------------------------
 # We can't stop waiting on Failed status, as it will report failed multiple
 # times during initial reconcile ... we just need to keep waiting.
@@ -125,7 +32,7 @@
     fail_msg: "Watson Studio install failed (datarefineryStatus)"
 
 
-# 4. Wait for WSL service CR to be ready
+# 3. Wait for WSL service CR to be ready
 # -----------------------------------------------------------------------------
 - name: "wait-wsl : Wait for wsStatus 'Completed' or 'Failed'"
   kubernetes.core.k8s_info:

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wsl.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wsl.yml
@@ -3,7 +3,7 @@
 # 1. Patch service accounts
 # -----------------------------------------------------------------------------
 # 1.1. Wait for Runtime service accounts to be created
-- name: "Wait for the Runtime service accounts to appear - {{ item }}"
+- name: "Wait for the Runtime service accounts to appear"
   kubernetes.core.k8s_info:
     api_version: v1
     kind: ServiceAccount
@@ -20,7 +20,7 @@
     - runtime-manager-api
 
 # 1.2. Patch the runtime service accounts in ibm-cpd namespace to add ibm-entitlement
-- name: "Patch the Runtime service accounts - {{ item }}"
+- name: "Patch the Runtime service accounts"
   kubernetes.core.k8s:
     api_version: v1
     kind: ServiceAccount

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wsl.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wsl.yml
@@ -34,6 +34,8 @@
 
 # 3. Wait for WSL service CR to be ready
 # -----------------------------------------------------------------------------
+# We can't stop waiting on Failed status, as it will report failed multiple
+# times during initial reconcile ... we just need to keep waiting.
 - name: "wait-wsl : Wait for wsStatus 'Completed' or 'Failed'"
   kubernetes.core.k8s_info:
     api_version: "{{ cpd_service_info[cpd_service_name].api_version }}"
@@ -46,7 +48,7 @@
     - cpd_cr_lookup.resources | length == 1
     - cpd_cr_lookup.resources[0].status is defined
     - cpd_cr_lookup.resources[0].status.wsStatus is defined
-    - cpd_cr_lookup.resources[0].status.wsStatus == "Completed" or cpd_cr_lookup.resources[0].status.wsStatus == "Failed"
+    - cpd_cr_lookup.resources[0].status.wsStatus == "Completed" # or cpd_cr_lookup.resources[0].status.wsStatus == "Failed"
   retries: 24 # Up to 2 hours
   delay: 300 # Every 5 minutes
 

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wsl.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wsl.yml
@@ -114,8 +114,6 @@
 
 # 4. Wait for WSL service CR to be ready
 # -----------------------------------------------------------------------------
-# Unfortunately CP4D do not have a standard approach to managing status across
-# their services like MAS does, so we need module-specific wait code.
 - name: "wait-wsl : Wait for wsStatus 'Completed' or 'Failed'"
   kubernetes.core.k8s_info:
     api_version: "{{ cpd_service_info[cpd_service_name].api_version }}"

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wsl.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wsl.yml
@@ -1,47 +1,8 @@
 ---
 
-# 1 Hacks & Workarounds
-# TODO: Implement me so that we don't need the cluster scoped image pull secret
-# and the associated node reboot in IBMCloud ROKS
-
-# 1.1. Wait for ZenService service accounts to be created
-- name: "Wait for the zen service accounts to appear - {{ item }}"
-  kubernetes.core.k8s_info:
-    api_version: v1
-    kind: ServiceAccount
-    name: "{{ item }}"
-    namespace: "{{ cpd_instance_namespace }}"
-  register: zen_sa_lookup
-  retries: 120 # ~approx 5 minutes before we give up waiting for the CRD to be created
-  delay: 5 # seconds
-  until:
-    - zen_sa_lookup.resources is defined
-    - zen_sa_lookup.resources | length > 0
-  with_items:
-    - zen-admin-sa
-    - zen-editor-sa
-    - zen-norbac-sa
-    - zen-runtime-sa
-    - zen-viewer-sa
-
-# 1.2. Patch the zen service accounts in ibm-cpd namespace to add ibm-entitlement
-- name: "Patch the zen service accounts - {{ item }}"
-  kubernetes.core.k8s:
-    api_version: v1
-    kind: ServiceAccount
-    name: "{{ item }}"
-    namespace: "{{ cpd_instance_namespace }}"
-    definition:
-      imagePullSecrets:
-        - ibm-entitlement
-  with_items:
-    - zen-admin-sa
-    - zen-editor-sa
-    - zen-norbac-sa
-    - zen-runtime-sa
-    - zen-viewer-sa
-
-# 1.3. Wait for Runtime service accounts to be created
+# 1. Patch service accounts
+# -----------------------------------------------------------------------------
+# 1.1. Wait for Runtime service accounts to be created
 - name: "Wait for the Runtime service accounts to appear - {{ item }}"
   kubernetes.core.k8s_info:
     api_version: v1
@@ -49,8 +10,8 @@
     name: "{{ item }}"
     namespace: "{{ cpd_instance_namespace }}"
   register: runtime_sa_lookup
-  retries: 120 # ~approx 5 minutes before we give up waiting for the CRD to be created
-  delay: 5 # seconds
+  retries: 24 # Up to 2 hours
+  delay: 300 # Every 5 minutes
   until:
     - runtime_sa_lookup.resources is defined
     - runtime_sa_lookup.resources | length > 0
@@ -58,7 +19,7 @@
     - runtime-assemblies-operator
     - runtime-manager-api
 
-# 1.4. Patch the runtime service accounts in ibm-cpd namespace to add ibm-entitlement
+# 1.2. Patch the runtime service accounts in ibm-cpd namespace to add ibm-entitlement
 - name: "Patch the Runtime service accounts - {{ item }}"
   kubernetes.core.k8s:
     api_version: v1
@@ -67,10 +28,36 @@
     namespace: "{{ cpd_instance_namespace }}"
     definition:
       imagePullSecrets:
-        - ibm-entitlement
+        - name: ibm-entitlement
   with_items:
     - runtime-assemblies-operator
     - runtime-manager-api
+
+# 1.3. Lookup and restart the runtimes operator pod if it's in ImagePullBackOff state
+- name: "Lookup runtimes operator pod"
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Pod
+    label_selectors:
+      - app.kubernetes.io/name = runtime-assemblies-operator
+    namespace: "{{ cpd_instance_namespace }}"
+  register: runtime_operator_pod_lookup
+  retries: 10 # Up to 10 minutes
+  delay: 60 # Every 1 minute
+
+- name: "Delete runtimes operator pod if it's in image pull backoff"
+  when:
+    - runtime_operator_pod_lookup.resources[0] | length > 0
+    - runtime_operator_pod_lookup.resources[0].status.containerStatuses[0].state is defined
+    - runtime_operator_pod_lookup.resources[0].status.containerStatuses[0].state.waiting is defined
+    - runtime_operator_pod_lookup.resources[0].status.containerStatuses[0].state.waiting.reason is defined
+    - runtime_operator_pod_lookup.resources[0].status.containerStatuses[0].state.waiting.reason == "ImagePullBackOff"
+  kubernetes.core.k8s:
+    state: absent
+    api_version: v1
+    kind: Pod
+    name: "{{ runtime_operator_pod_lookup.resources[0].metadata.name }}"
+    namespace: "{{ cpd_instance_namespace }}"
 
 
 # 2. Wait for CCS CR to be ready
@@ -119,7 +106,7 @@
   retries: 24 # Up to 2 hours
   delay: 300 # Every 5 minutes
 
-- name: "wait-wsl : Check that the CCS ccsStatus is 'Completed'"
+- name: "wait-wsl : Check that the DataRefinery datarefineryStatus is 'Completed'"
   assert:
     that: dr_cr_lookup.resources[0].status.datarefineryStatus == "Completed"
     fail_msg: "Watson Studio install failed (datarefineryStatus)"

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wsl.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wsl.yml
@@ -19,7 +19,7 @@
     - runtime-assemblies-operator
     - runtime-manager-api
 
-# 1.2. Patch the runtime service accounts in ibm-cpd namespace to add ibm-entitlement
+# 1.2. Patch the runtime service accounts in ibm-cpd namespace to add ibm-entitlement-key
 - name: "Patch the Runtime service accounts"
   kubernetes.core.k8s:
     api_version: v1
@@ -28,7 +28,7 @@
     namespace: "{{ cpd_instance_namespace }}"
     definition:
       imagePullSecrets:
-        - name: ibm-entitlement
+        - name: ibm-entitlement-key
   with_items:
     - runtime-assemblies-operator
     - runtime-manager-api

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wsl.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wsl.yml
@@ -18,7 +18,7 @@
     - cpd_cr_lookup.resources[0].status is defined
     - cpd_cr_lookup.resources[0].status.wsStatus is defined
     - cpd_cr_lookup.resources[0].status.wsStatus == "Completed" or cpd_cr_lookup.resources[0].status.wsStatus == "Failed"
-  retries: 24 # Up to 2 hours
+  retries: 36 # Up to 3 hours
   delay: 300 # Every 5 minutes
 
 - name: "wait-wsl : Check that the WSL wsStatus is 'Completed'"

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wsl.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wsl.yml
@@ -51,13 +51,26 @@
     - runtime_operator_pod_lookup.resources[0].status.containerStatuses[0].state is defined
     - runtime_operator_pod_lookup.resources[0].status.containerStatuses[0].state.waiting is defined
     - runtime_operator_pod_lookup.resources[0].status.containerStatuses[0].state.waiting.reason is defined
-    - runtime_operator_pod_lookup.resources[0].status.containerStatuses[0].state.waiting.reason == "ImagePullBackOff"
+    - runtime_operator_pod_lookup.resources[0].status.containerStatuses[0].state.waiting.reason is in ["ImagePullBackOff", "ErrImagePull"]
   kubernetes.core.k8s:
     state: absent
     api_version: v1
     kind: Pod
     name: "{{ runtime_operator_pod_lookup.resources[0].metadata.name }}"
     namespace: "{{ cpd_instance_namespace }}"
+
+- name: "Wait for the runtimes operator deployment to be ready"
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Deployment
+    name: runtime-assemblies-operator
+    namespace: "{{ cpd_instance_namespace }}"
+    wait: true
+    wait_condition:
+      type: Available
+      status: True
+    wait_sleep: 10 # seconds
+    wait_timeout : 300 # 5 minutes
 
 
 # 2. Wait for CCS CR to be ready
@@ -76,7 +89,7 @@
     - ccs_cr_lookup.resources | length == 1
     - ccs_cr_lookup.resources[0].status is defined
     - ccs_cr_lookup.resources[0].status.ccsStatus is defined
-    - ccs_cr_lookup.resources[0].status.ccsStatus == "Completed"
+    - ccs_cr_lookup.resources[0].status.ccsStatus == "Completed" #  or ccs_cr_lookup.resources[0].status.wmlStatus == "Failed"
   retries: 24 # Up to 2 hours
   delay: 300 # Every 5 minutes
 
@@ -102,7 +115,7 @@
     - dr_cr_lookup.resources | length == 1
     - dr_cr_lookup.resources[0].status is defined
     - dr_cr_lookup.resources[0].status.datarefineryStatus is defined
-    - dr_cr_lookup.resources[0].status.datarefineryStatus == "Completed"
+    - dr_cr_lookup.resources[0].status.datarefineryStatus == "Completed" #  or dr_cr_lookup.resources[0].status.wmlStatus == "Failed"
   retries: 24 # Up to 2 hours
   delay: 300 # Every 5 minutes
 

--- a/ibm/mas_devops/roles/cp4d_service/templates/services/aiopenscale.yml.j2
+++ b/ibm/mas_devops/roles/cp4d_service/templates/services/aiopenscale.yml.j2
@@ -11,4 +11,6 @@ spec:
     license: Standard
   type: service
   storageClass: "{{ cpd_service_storage_class }}"
-  version: 4.0.8 # openscale does not support 'version':'latest' and if we remove 'version', their operator will consider it 'latest', looks like a bug in openscale
+
+  version: "{{ cpd_product_version }}"
+  ccs_operand_version: "{{ cpd_product_version }}"

--- a/ibm/mas_devops/roles/cp4d_service/templates/services/spark.yml.j2
+++ b/ibm/mas_devops/roles/cp4d_service/templates/services/spark.yml.j2
@@ -9,3 +9,6 @@ spec:
     accept: true
     license: Standard
   storageClass: "{{ cpd_service_storage_class }}"
+
+  version: "{{ cpd_product_version }}"
+  ccs_operand_version: "{{ cpd_product_version }}"

--- a/ibm/mas_devops/roles/cp4d_service/templates/services/wd.yml.j2
+++ b/ibm/mas_devops/roles/cp4d_service/templates/services/wd.yml.j2
@@ -10,6 +10,7 @@ spec:
   license:
     accept: true
   shared:
+    imagePullSecret: ibm-entitlement-key
     storageClassName: "{{ cpd_service_storage_class }}"
   watsonGateway:
     version: main
@@ -24,13 +25,19 @@ spec:
       persistence:
         size: 2Gi
   etcd:
+    # Not technically required, it *should* inherit the value from shared.imagePullSecret
+    # imagePullSecret: ibm-entitlement-key
     storageSize: 10Gi
   minio:
+    # Not technically required, it *should* inherit the value from shared.imagePullSecret
+    # imagePullSecret: ibm-entitlement-key
     persistence:
       size: 100Gi
   postgres:
     database:
       storageRequest: 30Gi
   rabbitmq:
+    # Not technically required, it *should* inherit the value from shared.imagePullSecret
+    # imagePullSecret: ibm-entitlement-key
     persistentVolume:
       size: 5Gi

--- a/ibm/mas_devops/roles/cp4d_service/templates/services/wd.yml.j2
+++ b/ibm/mas_devops/roles/cp4d_service/templates/services/wd.yml.j2
@@ -25,19 +25,22 @@ spec:
       persistence:
         size: 2Gi
   etcd:
-    # Not technically required, it *should* inherit the value from shared.imagePullSecret
-    # imagePullSecret: ibm-entitlement-key
+    # Not technically required, it *should* inherit the value from shared.imagePullSecret, but doesn't work
+    # https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/3481
+    imagePullSecret: ibm-entitlement-key
     storageSize: 10Gi
   minio:
-    # Not technically required, it *should* inherit the value from shared.imagePullSecret
-    # imagePullSecret: ibm-entitlement-key
+    # Not technically required, it *should* inherit the value from shared.imagePullSecret, but doesn't work
+    # https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/3481
+    imagePullSecret: ibm-entitlement-key
     persistence:
       size: 100Gi
   postgres:
     database:
       storageRequest: 30Gi
   rabbitmq:
-    # Not technically required, it *should* inherit the value from shared.imagePullSecret
-    # imagePullSecret: ibm-entitlement-key
+    # Not technically required, it *should* inherit the value from shared.imagePullSecret but doesn't work
+    # https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/3481
+    imagePullSecret: ibm-entitlement-key
     persistentVolume:
       size: 5Gi

--- a/ibm/mas_devops/roles/cp4d_service/templates/services/wml.yml.j2
+++ b/ibm/mas_devops/roles/cp4d_service/templates/services/wml.yml.j2
@@ -11,3 +11,6 @@ spec:
     license: Standard
   storageClass: "{{ cpd_service_storage_class }}"
   scaleConfig: small
+
+  version: "{{ cpd_product_version }}"
+  ccs_operand_version: "{{ cpd_product_version }}"

--- a/ibm/mas_devops/roles/cp4d_service/templates/services/wsl.yml.j2
+++ b/ibm/mas_devops/roles/cp4d_service/templates/services/wsl.yml.j2
@@ -10,3 +10,6 @@ spec:
     license: Standard
   scaleConfig: small
   storageClass: "{{ cpd_service_storage_class }}"
+  version: "{{ cpd_product_version }}"
+  ccs_operand_version: "{{ cpd_product_version }}"
+  datarefinery_operand_version: "{{ cpd_product_version }}"

--- a/ibm/mas_devops/roles/cp4d_service/templates/services/wsl.yml.j2
+++ b/ibm/mas_devops/roles/cp4d_service/templates/services/wsl.yml.j2
@@ -10,6 +10,7 @@ spec:
     license: Standard
   scaleConfig: small
   storageClass: "{{ cpd_service_storage_class }}"
+
   version: "{{ cpd_product_version }}"
   ccs_operand_version: "{{ cpd_product_version }}"
   datarefinery_operand_version: "{{ cpd_product_version }}"

--- a/ibm/mas_devops/roles/cp4d_service/templates/wd/wds.json.j2
+++ b/ibm/mas_devops/roles/cp4d_service/templates/wd/wds.json.j2
@@ -1,6 +1,6 @@
 {
 "name": "{{ wds_instname }}",
-"deployment_id": "{{ cpdnamespace }}-wd",
-"description": "wds_for_assist",
-"url":"https://wd-discovery-gateway.{{ cpdnamespace }}.svc.cluster.local:60443/v2/service_instances"
+"deployment_id": "{{ cpd_instance_namespace }}-wd",
+"description": "Watson Discovery for MAS",
+"url":"https://wd-discovery-gateway.{{ cpd_instance_namespace }}.svc.cluster.local:60443/v2/service_instances"
 }

--- a/ibm/mas_devops/roles/db2/README.md
+++ b/ibm/mas_devops/roles/db2/README.md
@@ -1,5 +1,5 @@
-db2u
-==========
+db2
+===
 
 This role creates a Db2 Warehouse instance using the Db2u Operator. A namespace called `db2u` will be created and the db2u operator will be installed into the `ibm-common-services` namespace to service the `db2ucluster` requests in `db2u` namespace. A private root CA certificate is created and is used to secure the TLS connections to the database. A Db2 Warehouse cluster will be created along with a public TLS encrypted route to allow external access to the cluster (access is via the ssl-server nodeport port on the *-db2u-engn-svc service). Internal access is via the *-db2u-engn-svc service and port 50001. Both the external route and the internal service use the same server certificate.
 
@@ -18,188 +18,241 @@ If the `db2_node_label` and `db2_dedicated_node` variables are defined then role
 
 If the `mas_instance_id` and `mas_config_dir` are provided then the role will generate the JdbcCfg yaml that can be used to configure MAS to connect to this database. It does not apply the yaml to the cluster but does provide you with the yaml files to apply if needed.
 
-Role Variables
---------------
 
-### [required] db2_instance_name
-Required.  Name of the database instance, note that this is the instance **name**.
+Role Variables - Installation
+-----------------------------
+### db2_instance_name
+Name of the database instance, note that this is the instance **name**.
 
+- **Required**
 - Environment Variable: `DB2_INSTANCE_NAME`
 - Default: None
 
-### [optional] db2_dbname
+### ibm_entitlement_key
+Provide your [IBM entitlement key](https://myibm.ibm.com/products-services/containerlibrary).
+
+- **Required**
+- Environment Variable: `IBM_ENTITLEMENT_KEY`
+- Default: None
+
+### db2_entitlement_key
+An IBM entitlement key specific for Db2 installation, primarily used to override `ibm_entitlement_key` in development.
+
+- Optional
+- Environment Variable: `DB2_ENTITLEMENT_KEY`
+- Default: None
+
+### db2_dbname
 Name of the database within the instance.
 
+- Optional
 - Environment Variable: `DB2_DBNAME`
 - Default: `BLUDB`
 
-### [optional] db2_version
+### db2_version
 Version of the DB2U operator instance to be created.
 
+- Optional
 - Environment Variable: `DB2_VERSION`
 - Default: `11.5.7.0-cn2`
 
-### [optional] db2_4k_device_support
+### db2_4k_device_support
 Whether 4K device support is turned on or not.
 
+- Optional
 - Environment Variable: `DB2_4K_DEVICE_SUPPORT`
 - Default: `ON`
 
-### [optional] db2_table_org
+### db2_workload
+The workload profile of the db2 instance, possible values are `PUREDATA_OLAP` or `ANALYTICS`.
+
+- Optional
+- Environment Variable: `DB2_WORKLOAD`
+- Default: `ANALYTICS`
+
+### db2_table_org
 The way database tables will be organized. It can be set to either `ROW` or `COLUMN`.
 
+- Optional
 - Environment Variable: `DB2_TABLE_ORG`
 - Default: `ROW`
 
-### [required] db2_meta_storage_class
+
+Role Variables - Storage
+------------------------
+### db2_meta_storage_class
 Storage class used for metadata. This must support ReadWriteMany
 
+- **Required**
 - Environment Variable: `DB2_META_STORAGE_CLASS`
 - Default: Defaults to `ibmc-file-gold` if the storage class is available in the cluster.
 
-### [optional] db2_meta_storage_size
+### db2_meta_storage_size
 Size of the metadata persistent volume, in gigabytes
 
+- Optional
 - Environment Variable: `DB2_META_STORAGE_SIZE`
 - Default: `20Gb`
 
-### [required] db2_data_storage_class
+### db2_data_storage_class
 Storage class used for user data. This must support ReadWriteOnce
 
+- **Required**
 - Environment Variable: `DB2_USER_STORAGE_CLASS`
 - Default: Defaults to `ibmc-block-gold` if the storage class is available in the cluster.
 
-### [optional] db2_data_storage_size
+### db2_data_storage_size
 Size of data persistent volume.
 
+- Optional
 - Environment Variable: `DB2_DATA_STORAGE_SIZE`
 - Default: `100Gb`
 
-### [optional] db2_backup_storage_class
+### db2_backup_storage_class
 Storage class used for backup. This must support ReadWriteMany
 
+- Optional
 - Environment Variable: `DB2_BACKUP_STORAGE_CLASS`
 - Default: Defaults to `ibmc-file-gold` if the storage class is available in the cluster.
 
-### [optional] db2_backup_storage_size
+### db2_backup_storage_size
 Size of backup persistent volume.
 
+- Optional
 - Environment Variable: `DB2_BACKUP_STORAGE_SIZE`
 - Default: `100Gb`
 
-### [optional] db2_logs_storage_class
+### db2_logs_storage_class
 Storage class used for transaction logs. This must support ReadWriteOnce
 
+- Optional
 - Environment Variable: `DB2_LOGS_STORAGE_CLASS`
 - Default: Defaults to `ibmc-block-gold` if the storage class is available in the cluster.
 
-### [optional] db2_logs_storage_size
+### db2_logs_storage_size
 Size of transaction logs persistent volume.
 
+- Optional
 - Environment Variable: `DB2_LOGS_STORAGE_SIZE`
 - Default: `100Gb`
 
-### [optional] db2_temp_storage_class
+### db2_temp_storage_class
 Storage class used for temporary data. This must support ReadWriteOnce
 
+- Optional
 - Environment Variable: `DB2_TEMP_STORAGE_CLASS`
 - Default: Defaults to `ibmc-block-gold` if the storage class is available in the cluster.
 
-### [optional] db2_temp_storage_size
+### db2_temp_storage_size
 Size of temporary persistent volume.
 
+- Optional
 - Environment Variable: `DB2_TEMP_STORAGE_SIZE`
 - Default: `100Gb`
 
-### [optional] db2_cpu_requests
+
+Role Variables - Resource Requests
+----------------------------------
+### db2_cpu_requests
 Define the Kubernetes CPU request for the Db2 pod.
 
+- Optional
 - Environment Variable: `DB2_CPU_REQUESTS`
 - Default: `2000m`
 
-### [optional] db2_cpu_limits
+### db2_cpu_limits
 Define the Kubernetes CPU limit for the Db2 pod.
 
+- Optional
 - Environment Variable: `DB2_CPU_LIMITS`
 - Default: `4000m`
 
-### [optional] db2_memory_requests
+### db2_memory_requests
 Define the Kubernetes memory request for the Db2 pod.
 
+- Optional
 - Environment Variable: `DB2_MEMORY_REQUESTS`
 - Default: `6Gi`
 
-### [optional] db2_memory_limits
+### db2_memory_limits
 Define the Kubernetes memory limit for the Db2 pod.
 
+- Optional
 - Environment Variable: `DB2_MEMORY_LIMITS`
 - Default: `12Gi`
 
-### [required] entitlement_key
-Required.  This is the entitlement key used to install the Db2u Operator and Db2 images. Holds your IBM Entitlement key.
 
-- Environment Variable: `ENTITLEMENT_KEY`
-- Default: None
-
-### [optional] mas_instance_id
-Providing this and `mas_config_dir` will instruct the role to generate a JdbcCfg template that can be used to configure MAS to connect to this database.
-
-- Environment Variable: `MAS_INSTANCE_ID`
-- Default: None
-
-### [optional] mas_config_dir
-Providing this and `mas_instance_id` will instruct the role to generate a JdbcCfg template that can be used to configure MAS to connect to this database.
-
-- Environment Variable: `MAS_CONFIG_DIR`
-- Default: None
-
-### [optional] mas_config_scope
-Supported values are `system`, `ws`, `app`, or `wsapp`, this is only used when both `mas_config_dir` and `mas_instance_id` are set.
-
-- Environment Variable: `MAS_CONFIG_SCOPE`
-- Default: `system`
-
-### [optional] mas_workspace_id
-This is only used when both `mas_config_dir` and `mas_instance_id` are set, and `mas_config_scope` is set to either `ws` or `wsapp`
-
-- Environment Variable: `MAS_WORKSPACE_ID`
-- Default: None
-
-### [optional] mas_application_id
-This is only used when both `mas_config_dir` and `mas_instance_id` are set, and `mas_config_scope` is set to either `app` or `wsapp`
-
-- Environment Variable: `'MAS_APP_ID`
-- Default: None
-
-### [optional] db2_workload
-The workload profile of the db2 instance, possible values are 'PUREDATA_OLAP' or 'ANALYTICS'
-
-- Environment Variable: `'DB2_WORKLOAD`
-- Default: 'ANALYTICS'
-
+Role Variables - Node Affinity
+----------------------------------
 ### db2_node_label
 The label used to specify node affinity and tolerations in the db2ucluster CR.
 
+- Optional
 - Environment Variable: `'DB2_NODE_LABEL`
 - Default: None
 
 ### db2_dedicated_node
-The name of the worker node to apply the {{ db2_node_label }} taint and label to.
+The name of the worker node to apply the `{{ db2_node_label }}` taint and label to.
 
+- Optional
 - Environment Variable: `'DB2_DEDICATED_NODE`
 - Default: None
 
-### db2_mln_count
-The number of logical nodes (i.e. database partitions to create). Note: ensure that the application using this DB2 can support DB2 MPP (which is created when DB2_MLN_COUNT is > 1). As of MAS 8.7 no MAS application supports MPP.
 
+Role Variables - MPP System
+---------------------------
+### db2_mln_count
+The number of logical nodes (i.e. database partitions to create). Note: ensure that the application using this Db2 can support Db2 MPP (which is created when `DB2_MLN_COUNT` is greater than 1). **As of MAS 8.7 no MAS application supports MPP**.
+
+- Optional
 - Environment Variable: `'DB2_MLN_COUNT`
 - Default: 1
 
 ### db2_num_pods
 The number of Db2 pods to create in the instance. Note that `db2_num_pods` must be less than or equal to `db2_mln_count`.  A single db2u pod can contain multiple logical nodes. So be sure to avoid specifying a large number for `db2_mln_count` while specifying a small number for `db2_num_pods`. If in doubt, make `db2_mln_count = db2_num_pods`. For more information refer to the [Db2 documentation](https://www.ibm.com/docs/en/db2-warehouse?topic=SSCJDQ/com.ibm.swg.im.dashdb.ucontainer.doc/doc/db2w-mempernode-new.html).
 
+- Optional
 - Environment Variable: `'DB2_NUM_PODS`
 - Default: 1
+
+
+Role Variables - MAS Configuration
+----------------------------------
+### mas_instance_id
+Providing this and `mas_config_dir` will instruct the role to generate a JdbcCfg template that can be used to configure MAS to connect to this database.
+
+- Optional
+- Environment Variable: `MAS_INSTANCE_ID`
+- Default: None
+
+### mas_config_dir
+Providing this and `mas_instance_id` will instruct the role to generate a JdbcCfg template that can be used to configure MAS to connect to this database.
+
+- Optional
+- Environment Variable: `MAS_CONFIG_DIR`
+- Default: None
+
+### mas_config_scope
+Supported values are `system`, `ws`, `app`, or `wsapp`, this is only used when both `mas_config_dir` and `mas_instance_id` are set.
+
+- Optional
+- Environment Variable: `MAS_CONFIG_SCOPE`
+- Default: `system`
+
+### mas_workspace_id
+This is only used when both `mas_config_dir` and `mas_instance_id` are set, and `mas_config_scope` is set to either `ws` or `wsapp`
+
+- Optional
+- Environment Variable: `MAS_WORKSPACE_ID`
+- Default: None
+
+### mas_application_id
+This is only used when both `mas_config_dir` and `mas_instance_id` are set, and `mas_config_scope` is set to either `app` or `wsapp`
+
+- Optional
+- Environment Variable: `'MAS_APP_ID`
+- Default: None
+
 
 Example Playbook
 ----------------
@@ -208,6 +261,8 @@ Example Playbook
 - hosts: localhost
   any_errors_fatal: true
   vars:
+    ibm_entitlement_key: xxxxx
+
     # Configuration for the Db2 cluster
     db2_version: 11.5.7.0-cn2
     db2_instance_name: db2u-db01
@@ -219,13 +274,11 @@ Example Playbook
     db2_logs_storage_class: "ibmc-block-gold"
     db2_temp_storage_class: "ibmc-block-gold"
 
-    entitlement_key: "{{ lookup('env', 'ENTITLEMENT_KEY') }}"
-
     # Create the MAS JdbcCfg & Secret resource definitions
-    mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
-    mas_config_dir: "{{ lookup('env', 'MAS_CONFIG_DIR') }}"
+    mas_instance_id: inst1
+    mas_config_dir: /home/david/masconfig
   roles:
-    - ibm.mas_devops.db2u
+    - ibm.mas_devops.db2
 ```
 
 License

--- a/ibm/mas_devops/roles/db2/defaults/main.yml
+++ b/ibm/mas_devops/roles/db2/defaults/main.yml
@@ -50,13 +50,18 @@ mas_config_scope: "{{ lookup('env', 'MAS_CONFIG_SCOPE') | default('system', true
 mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') }}" # Necessary for ws and wsapp scopes
 mas_application_id: "{{ lookup('env', 'MAS_APP_ID') }}" # Necessary for app and wsapp scopes
 
-# request/limit defaults
+# Request/limit defaults
 # -----------------------------------------------------------------------------------------------------------------
 db2_cpu_requests: "{{ lookup('env', 'DB2_CPU_REQUESTS')  | default('2000m', true) }}"
 db2_cpu_limits: "{{ lookup('env', 'DB2_CPU_LIMITS')  | default('4000m', true) }}"
 db2_memory_requests: "{{ lookup('env', 'DB2_MEMORY_REQUESTS')  | default('6Gi', true) }}"
 db2_memory_limits: "{{ lookup('env', 'DB2_MEMORY_LIMITS')  | default('12Gi', true) }}"
 
+# Entitlement
+# -----------------------------------------------------------------------------------------------------------------
 registry: cp.icr.io
 registry_user: cp
-entitlement_key: "{{ lookup('env', 'ENTITLEMENT_KEY') }}"
+
+ibm_entitlement_key: "{{ lookup('env', 'IBM_ENTITLEMENT_KEY') }}"
+# We support ENTITLEMENT_KEY for backwards compatability with previous releases
+db2_entitlement_key: "{{ lookup('env', 'DB2_ENTITLEMENT_KEY') | default(ibm_entitlement_key, true) | default(lookup('env', 'ENTITLEMENT_KEY'), true) }}"

--- a/ibm/mas_devops/roles/db2/tasks/main.yml
+++ b/ibm/mas_devops/roles/db2/tasks/main.yml
@@ -47,10 +47,10 @@
 
 - name: Set 'ibm-registry' secret content
   vars:
-    entitledAuthStr: "{{ registry_user }}:{{ entitlement_key }}"
+    entitledAuthStr: "{{ registry_user }}:{{ db2_entitlement_key }}"
     entitledAuth: "{{ entitledAuthStr | b64encode }}"
     content:
-      - "{\"auths\":{\"{{ registry }}/cp/cpd\":{\"username\":\"{{ registry_user }}\",\"password\":\"{{ entitlement_key }}\",\"email\":\"{{ registry_user }}\",\"auth\":\"{{ entitledAuth }}\"}"
+      - "{\"auths\":{\"{{ registry }}/cp/cpd\":{\"username\":\"{{ registry_user }}\",\"password\":\"{{ db2_entitlement_key }}\",\"email\":\"{{ registry_user }}\",\"auth\":\"{{ entitledAuth }}\"}"
       - "}"
       - "}"
   set_fact:

--- a/ibm/mas_devops/roles/db2/tasks/main.yml
+++ b/ibm/mas_devops/roles/db2/tasks/main.yml
@@ -1,15 +1,13 @@
 ---
 # 1. Fail if required parameters are not set
 # -----------------------------------------------------------------------------
-- name: "Fail if db2_instance_name has not been provided"
+- name: "Fail if required properties have not been provided"
   assert:
-    that: db2_instance_name is defined and db2_instance_name != ""
-    fail_msg: "db2_instance_name property has not been set"
+    that:
+      - db2_instance_name is defined and db2_instance_name != ""
+      - db2_entitlement_key is defined and db2_entitlement_key != ""
+    fail_msg: "One or more required properties have not been set"
 
-- name: "Fail if ENTITLEMENT_KEY has not been provided"
-  assert:
-    that: entitlement_key is defined and entitlement_key != ""
-    fail_msg: "ENTITLEMENT_KEY property has not been set"
 
 # 2. Load default storage classes (if not provided by the user)
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/db2/tasks/setup_norootsquash.yml
+++ b/ibm/mas_devops/roles/db2/tasks/setup_norootsquash.yml
@@ -6,10 +6,10 @@
 # -----------------------------------------------------------------------------
 - name: Set 'ibm-registry' secret content
   vars:
-    entitledAuthStr: "{{ registry_user }}:{{ entitlement_key }}"
+    entitledAuthStr: "{{ registry_user }}:{{ db2_entitlement_key }}"
     entitledAuth: "{{ entitledAuthStr | b64encode }}"
     content:
-      - "{\"auths\":{\"{{ registry }}/cp/cpd\":{\"username\":\"{{ registry_user }}\",\"password\":\"{{ entitlement_key }}\",\"email\":\"{{ registry_user }}\",\"auth\":\"{{ entitledAuth }}\"}"
+      - "{\"auths\":{\"{{ registry }}/cp/cpd\":{\"username\":\"{{ registry_user }}\",\"password\":\"{{ db2_entitlement_key }}\",\"email\":\"{{ registry_user }}\",\"auth\":\"{{ entitledAuth }}\"}"
       - "}"
       - "}"
   set_fact:

--- a/ibm/mas_devops/roles/sls/README.md
+++ b/ibm/mas_devops/roles/sls/README.md
@@ -9,11 +9,18 @@ Role Variables - Installation
 -----------------------------
 If `sls_url` is set then the role will skip the installation of an SLS instance and simply generate the SLSCfg resource for the SLS instance defined.
 
-### sls_entitlement_key
-API Key for entitled registry. This password will be used to create the image pull secret.
+### ibm_entitlement_key
+Provide your [IBM entitlement key](https://myibm.ibm.com/products-services/containerlibrary).
 
-- **Required** (unless `sls_url` is provided)
-- Environment Variable: `SLS_ENTITLEMENT_KEY` or `IBM_ENTITLEMENT_KEY`
+- **Required** unless `sls_url` is provided
+- Environment Variable: `IBM_ENTITLEMENT_KEY`
+- Default: None
+
+### sls_entitlement_key
+An IBM entitlement key specific for SLS installation, primarily used to override `ibm_entitlement_key` in development.
+
+- Optional
+- Environment Variable: `SLS_ENTITLEMENT_KEY`
 - Default: None
 
 ### sls_catalog_source
@@ -202,15 +209,15 @@ Example Playbook
 - hosts: localhost
   any_errors_fatal: true
   vars:
+    ibm_entitlement_key: xxxx
     mas_instance_id: inst1
     mas_config_dir: /home/me/masconfig
-    sls_entitlement_key: "{{ lookup('env', 'SLS_ENTITLEMENT_KEY') }}"
     sls_mongodb_cfg_file: "/etc/mas/mongodb.yml"
 
     bootstrap:
       license_id: "aa78dd65ef10"
       license_file: "/etc/mas/entitlement.lic"
-      registration_key: "{{ lookup('env', 'SLS_REGISTRATION_KEY') }}"
+      registration_key: xxxx
 
   roles:
     - ibm.mas_devops.sls

--- a/ibm/mas_devops/roles/sls/defaults/main.yml
+++ b/ibm/mas_devops/roles/sls/defaults/main.yml
@@ -13,7 +13,8 @@ sls_icr_cpopen: "{{ lookup('env', 'SLS_ICR_CPOPEN') | default('icr.io/cpopen', t
 # IBM entitlement key for SLS
 # Default to re-using the IBM entitlement key if we do not provide a specific one for SLS
 sls_entitlement_username: "{{ lookup('env', 'SLS_ENTITLEMENT_USERNAME') | default('cp', true) }}"
-sls_entitlement_key: "{{ lookup('env', 'SLS_ENTITLEMENT_KEY') | default(lookup('env', 'IBM_ENTITLEMENT_KEY'), true) }}"
+ibm_entitlement_key: "{{ lookup('env', 'IBM_ENTITLEMENT_KEY') }}"
+sls_entitlement_key: "{{ lookup('env', 'SLS_ENTITLEMENT_KEY') | default(ibm_entitlement_key, true) }}"
 
 # SLS settings
 sls_mongo_configdb: "admin"

--- a/ibm/mas_devops/roles/sls/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/sls/tasks/install/main.yml
@@ -2,11 +2,6 @@
 
 # 1. Check for missing properties that do not have defaults
 # -----------------------------------------------------------------------------
-- name: "Fail if sls_entitlement_username has not been provided"
-  assert:
-    that: sls_entitlement_username is defined and sls_entitlement_username != ""
-    fail_msg: "sls_entitlement_username property has not been set"
-
 - name: "Fail if sls_entitlement_key has not been provided"
   assert:
     that: sls_entitlement_key is defined and sls_entitlement_key != ""

--- a/ibm/mas_devops/roles/suite_app_install/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_app_install/defaults/main.yml
@@ -15,7 +15,8 @@ mas_icr_cp: "{{ lookup('env', 'MAS_ICR_CP') | default('cp.icr.io/cp', true) }}"
 
 # MAS configuration - Entitlement
 mas_entitlement_username: "{{ lookup('env', 'MAS_ENTITLEMENT_USERNAME') | default('cp', true) }}"
-mas_entitlement_key: "{{ lookup('env', 'MAS_ENTITLEMENT_KEY') }}"
+ibm_entitlement_key: "{{ lookup('env', 'IBM_ENTITLEMENT_KEY') }}"
+mas_entitlement_key: "{{ lookup('env', 'MAS_ENTITLEMENT_KEY') | default(ibm_entitlement_key, true) }}"
 
 # MAS application configuration
 mas_app_id: "{{ lookup('env', 'MAS_APP_ID') }}"

--- a/ibm/mas_devops/roles/suite_install/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_install/defaults/main.yml
@@ -30,7 +30,8 @@ mas_icr_cpopen: "{{ lookup('env', 'MAS_ICR_CPOPEN') | default('icr.io/cpopen', t
 # MAS Entitlement
 # -----------------------------------------------------------------------------
 mas_entitlement_username: "{{ lookup('env', 'MAS_ENTITLEMENT_USERNAME') | default('cp', true) }}"
-mas_entitlement_key: "{{ lookup('env', 'MAS_ENTITLEMENT_KEY') }}"
+ibm_entitlement_key: "{{ lookup('env', 'IBM_ENTITLEMENT_KEY') }}"
+mas_entitlement_key: "{{ lookup('env', 'MAS_ENTITLEMENT_KEY') | default(ibm_entitlement_key, true) }}"
 
 
 # Manual upgrade support

--- a/image/ansible-devops/Dockerfile
+++ b/image/ansible-devops/Dockerfile
@@ -15,8 +15,8 @@ ENV ANSIBLE_COLLECTIONS_PATH=/opt/app-root/lib64/python3.9/site-packages/ansible
     ANSIBLE_CONFIG=/opt/app-root/src/ansible.cfg
 
 # 1. Upgrade system packages
-RUN dnf update -y &&\
-    dnf upgrade -y &&\
+RUN dnf update -y --skip-broken --nobest &&\
+    dnf upgrade -y --skip-broken --nobest &&\
     dnf install nano -y &&\
     dnf clean all
 

--- a/pipelines/tasks/cp4d.yaml
+++ b/pipelines/tasks/cp4d.yaml
@@ -21,6 +21,14 @@ spec:
       type: string
       default: ""
 
+    # Entitlement
+    - name: ibm_entitlement_key
+      type: string
+    - name: cpd_entitlement_key
+      type: string
+      default: ""
+      description: "Optional CP4D-specific override for the IBM entitlement key"
+
     # Optional support built into the ansible-devops image
     # for saving task execution results to a MongoDb instance
     - name: mas_instance_id
@@ -51,6 +59,12 @@ spec:
         value: $(params.cpd_primary_storage_class)
       - name: CPD_METADATA_STORAGE_CLASS
         value: $(params.cpd_metadata_storage_class)
+
+      # Entitlement
+      - name: IBM_ENTITLEMENT_KEY
+        value: $(params.ibm_entitlement_key)
+      - name: CPD_ENTITLEMENT_KEY
+        value: $(params.cpd_entitlement_key)
 
       # Optional support built into the ansible-devops image
       # for saving task execution results to a MongoDb instance

--- a/pipelines/tasks/cp4d_service.yaml
+++ b/pipelines/tasks/cp4d_service.yaml
@@ -17,6 +17,10 @@ spec:
     - name: cpd_service_name
       type: string
 
+    # CPD product Version (Required)
+    - name: cpd_product_version
+      type: string
+
     # CPD Storage class (Optional, defaults built into Ansible role)
     - name: cpd_service_storage_class
       type: string
@@ -60,6 +64,8 @@ spec:
       - name: CPD_INSTANCE_NAMESPACE
         value: $(params.cpd_instance_namespace)
 
+      - name: CPD_PRODUCT_VERSION
+        value: $(params.cpd_product_version)
       - name: CPD_SERVICE_NAME
         value: $(params.cpd_service_name)
       - name: CPD_SERVICE_STORAGE_CLASS

--- a/pipelines/tasks/db2.yaml
+++ b/pipelines/tasks/db2.yaml
@@ -49,9 +49,12 @@ spec:
       default: ""
 
     # Entitlement
-    - name: entitlement_key
+    - name: ibm_entitlement_key
+      type: string
+    - name: db2_entitlement_key
       type: string
       default: ""
+      description: "Optional Db2-specific override for the IBM entitlement key"
 
     # Optional support built into the ansible-devops image
     # for saving task execution results to a MongoDb instance
@@ -101,10 +104,12 @@ spec:
         value: $(params.db2_logs_storage_size)
       - name: DB2_TEMP_STORAGE_SIZE
         value: $(params.db2_temp_storage_size)
-      
+
       # Entitlement
-      - name: ENTITLEMENT_KEY
-        value: $(params.entitlement_key)
+      - name: IBM_ENTITLEMENT_KEY
+        value: $(params.ibm_entitlement_key)
+      - name: DB2_ENTITLEMENT_KEY
+        value: $(params.db2_entitlement_key)
 
       # Optional support built into the ansible-devops image
       # for saving task execution results to a MongoDb instance

--- a/pipelines/tasks/sls.yaml
+++ b/pipelines/tasks/sls.yaml
@@ -22,11 +22,17 @@ spec:
     - name: sls_icr_cpopen
       type: string
       default: ""
+
+    # Entitlement
     - name: sls_entitlement_username
       type: string
       default: ""
+    - name: ibm_entitlement_key
+      type: string
     - name: sls_entitlement_key
       type: string
+      default: ""
+      description: "Optional SLS-specific override for the IBM entitlement key"
 
     - name: artifactory_username
       default: ''
@@ -80,6 +86,8 @@ spec:
         value: $(params.sls_icr_cpopen)
       - name: SLS_ENTITLEMENT_USERNAME
         value: $(params.sls_entitlement_username)
+      - name: IBM_ENTITLEMENT_KEY
+        value: $(params.ibm_entitlement_key)
       - name: SLS_ENTITLEMENT_KEY
         value: $(params.sls_entitlement_key)
 

--- a/pipelines/tasks/suite-app-install.yaml
+++ b/pipelines/tasks/suite-app-install.yaml
@@ -36,14 +36,18 @@ spec:
     - name: mas_entitlement_username
       type: string
       default: ""
+    - name: ibm_entitlement_key
+      type: string
     - name: mas_entitlement_key
       type: string
+      default: ""
+      description: "Optional MAS-specific override for the IBM entitlement key"
 
     - name: mas_app_spec
       default: ""
       type: string
       description: Application specifications such as binding, settings, etc
-    
+
     - name: mas_app_plan
       type: string
       description: Application installation plan
@@ -79,6 +83,8 @@ spec:
 
       - name: MAS_ENTITLEMENT_USERNAME
         value: $(params.mas_entitlement_username)
+      - name: IBM_ENTITLEMENT_KEY
+        value: $(params.ibm_entitlement_key)
       - name: MAS_ENTITLEMENT_KEY
         value: $(params.mas_entitlement_key)
 

--- a/pipelines/tasks/suite-install.yaml
+++ b/pipelines/tasks/suite-install.yaml
@@ -23,8 +23,12 @@ spec:
     - name: mas_entitlement_username
       type: string
       default: ""
+    - name: ibm_entitlement_key
+      type: string
     - name: mas_entitlement_key
       type: string
+      default: ""
+      description: "Optional MAS-specific override for the IBM entitlement key"
 
     - name: artifactory_username
       default: ''
@@ -90,6 +94,8 @@ spec:
 
       - name: MAS_ENTITLEMENT_USERNAME
         value: $(params.mas_entitlement_username)
+      - name: IBM_ENTITLEMENT_KEY
+        value: $(params.ibm_entitlement_key)
       - name: MAS_ENTITLEMENT_KEY
         value: $(params.mas_entitlement_key)
       - name: MAS_ANNOTATIONS


### PR DESCRIPTION
## Entitlement handling cleanup
Most users won't care about `SLS_ENTITLEMENT_KEY` vs `DB2_ENTITLEMENT_KEY` vs `MAS_ENTITLEMENT_KEY` etc ... they just want to provide `IBM_ENTITLEMENT_KEY`.

This update makes `IBM_ENTITELEMENT_KEY` a required property across the various roles that use require IBM entitlement in the install pipeline today:
- `sls`
- `db2`
- `suite_install`
- `suite_app_install`

The additional properties are still supported, but are now optional overrides for the default `ibm_entitlement_key` which will really only see use internally for development purposes.

## CP4D fixes
- When we set `spec.version` we also have to set `spec.ccs_operand_version` and `spec.datarefinery_operand_version` otherwise the inconsistency between the operand version we directly control and the operand version of the CP4D internals create incompatabilities (because CP4D patch versions can contain breaking changes).  With this update we can directly control the version of Watson Studio, CCS, and the Data Refinery.
- Missing `cpd_product_version` has been put into the Tekton tasks
- Standalone CP4D playbook has been added to the collection `ibm.mas_devops.cp4d`
- `ibm-entitlement-key` secret is installed in the CP4D instance namespace and the CP4D service accounts are patched to use it.  This removes the need to install a cluster-wide entitlement secret ([CPD-Quality#3478](https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/3478)).
- Watson Discovery reports a false install failure, updated automation to not exit early when Failure status is reported ([CPD-Quality#3480](https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/3480))

## Makefile
Added a simple makefile support the docker image and ansible collection to make it easier to do local development.