### PR TITLE
[patch] Fix ansible-publish github workflow

### DIFF
--- a/.github/workflows/ansible-publish.yml
+++ b/.github/workflows/ansible-publish.yml
@@ -44,7 +44,7 @@ jobs:
           ansible-galaxy collection publish ${{ github.workspace }}/ibm/mas_devops/ibm-mas_devops-${{ env.VERSION }}.tar.gz --token=${{ secrets.ANSIBLE_GALAXY_TOKEN }}
 
       - name: Install the Ansible collection in the container image
-        run: cp $GITHUB_WORKSPACE/ibm/mas_devops/ibm-mas_devops-${{ env.VERSION }}.tar.gz $GITHUB_WORKSPACE/image/ansible-devops/ibm-mas_devops.tar.gz
+        run: cp $GITHUB_WORKSPACE/ibm/mas_devops/ibm-mas_devops-${{ env.VERSION }}.tar.gz $GITHUB_WORKSPACE/image/ansible-devops/app-root/ibm-mas_devops.tar.gz
 
       # Docker build
       - name: Build the docker image


### PR DESCRIPTION
Only the `ansible` workflow was updated to reference the changes to the Dockerfile in 10.1.0 ... this fix applies the same changes to `ansible-release`.

Additionally, the 10.1.0 container image has been manually pushed to quay.io to complete the 10.1.0 release.