### PR TITLE
[patch] fixing jdbccfg template to consider scope

### DIFF
--- a/ibm/mas_devops/roles/db2/templates/suite_jdbccfg.yml.j2
+++ b/ibm/mas_devops/roles/db2/templates/suite_jdbccfg.yml.j2
@@ -4,7 +4,7 @@ kind: Secret
 type: Opaque
 metadata:
   name: "jdbc-{{ db2_instance_name | lower }}-credentials"
-  namespace: "mas-{{mas_instance_id}}-core"
+  namespace: "mas-{{ mas_instance_id }}-core"
 stringData:
   username: "{{db2_jdbc_username}}"
   password: "{{jdbc_instance_password}}"
@@ -12,13 +12,11 @@ stringData:
 apiVersion: config.mas.ibm.com/v1
 kind: JdbcCfg
 metadata:
-  name: "{{mas_instance_id}}-jdbc-system"
-  namespace: "mas-{{mas_instance_id}}-core"
-  labels:
-    mas.ibm.com/configScope: system
-    mas.ibm.com/instanceId: "{{mas_instance_id}}"
+  name: "{{ suite_jdbccfg_name }}"
+  namespace: "mas-{{ mas_instance_id }}-core"
+  labels: {{ suite_jdbccfg_labels }}
 spec:
-  displayName: "{{ db2_instance_name | lower }} on CP4D"
+  displayName: "{{ suite_jdbccfg_name }}"
   config:
     url: "{{ jdbc_url }}"
     sslEnabled: true


### PR DESCRIPTION
This PR contains changes to build the jdbccfg in the db2 role respecting the `mas_config_scope` provided.