### PR TITLE
[patch] removed SLS_ENTITLEMENT_FILE

### DIFF
--- a/docs/playbooks/oneclick-core.md
+++ b/docs/playbooks/oneclick-core.md
@@ -82,7 +82,6 @@ export MAS_CONFIG_DIR=~/masconfig
 export SLS_LICENSE_ID=xxx
 export SLS_LICENSE_FILE=/path/to/entitlement.lic
 export SLS_ENTITLEMENT_KEY=xxx
-export SLS_ENTITLEMENT_FILE=xxx
 export UDS_CONTACT_EMAIL=xxx@xxx.com
 export UDS_CONTACT_FIRSTNAME=xxx
 export UDS_CONTACT_LASTNAME=xxx


### PR DESCRIPTION
SLS_ENTITLEMENT_FILE was changed to SLS_LICENSE_FILE but the export was not taken out of the docs