### PR TITLE
[patch] Fix DD support for development installs

### DIFF
--- a/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
+++ b/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
@@ -14,3 +14,8 @@ spec:
     icr:
       cp: "{{ mas_icr_cp }}"
       cpopen: "{{ mas_icr_cpopen }}"
+{% if mas_catalog_source is defined and mas_catalog_source == 'ibm-mas-operators' %}
+    datadictionary:
+      catalog: ibm-data-dictionary-operators
+      channel: stable
+{% endif %}


### PR DESCRIPTION
Data dictionary should install from development catalog if we are installing MAS from development catalogs.