### PR TITLE
[patch] Cope with custom_cluster_issuer being None

### DIFF
--- a/ibm/mas_devops/roles/suite_dns/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/main.yml
@@ -29,6 +29,7 @@
   when:
     - custom_domain != ""
     - custom_cluster_issuer != ""
+    - custom_cluster_issuer != None
     - cis_crn is defined
     - cis_email is defined
     - cis_apikey is defined
@@ -40,3 +41,4 @@
     - configure_suite_cp4d_route
     - custom_domain != ''
     - custom_cluster_issuer != ''
+    - custom_cluster_issuer != None

--- a/ibm/mas_devops/roles/suite_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_install/tasks/main.yml
@@ -137,7 +137,7 @@
     suite_cr: "{{ lookup('template', 'templates/core_v1_suite.yml.j2') }}"
     certificate_block: "{{ lookup('template', 'templates/certificate.yml.j2') }}"
   set_fact:
-    cr_definition: "{{ (custom_cluster_issuer != '') | ternary (suite_cr + certificate_block, suite_cr) }}"
+    cr_definition: "{{ (custom_cluster_issuer != '' and custom_cluster_issuer != None) | ternary (suite_cr + certificate_block, suite_cr) }}"
 
 - name: "Add Annotation block to CR"
   vars:


### PR DESCRIPTION
In issue https://github.com/ibm-mas/ansible-devops/issues/63 it is seen that when no cluster issuer is  set then the custom_cluster_issuer gets set to None rather than an empty string. Even when using the same ansible levels I wasn't able to reproduce this. The change is to cope with the value being None and treat it the same as empty string