### PR TITLE
[patch] configure_suite_cp4d_route should default to false

### DIFF
--- a/ibm/mas_devops/roles/suite_dns/defaults/main.yaml
+++ b/ibm/mas_devops/roles/suite_dns/defaults/main.yaml
@@ -79,7 +79,7 @@ custom_domain: "{{ lookup('env', 'MAS_DOMAIN') | default(None)}}"
 
 # CP4D Intergration
 # -----------------------------------------------------------------------------
-cpd_services_namespace: "{{ lookup('env', 'CPD_SERVICES_NAMESPACE') | default('cpd-services', true) }}"
+cpd_instance_namespace: "{{ lookup('env', 'CPD_INSTANCE_NAMESPACE') | default('ibm-cpd', true) }}"
 # Note: the suite version of the cp4d web client route is only configured if you use a custom domain regardless
 # as to the below setting
-configure_suite_cp4d_route: "{{ lookup('env', 'CONFIGURE_SUITE_CP4D_ROUTE') | default('True', true) | bool }}"
+configure_suite_cp4d_route: "{{ lookup('env', 'CONFIGURE_SUITE_CP4D_ROUTE') | default('False', true) | bool }}"

--- a/ibm/mas_devops/roles/suite_dns/templates/cp4d/cp4d-certificate.yml.j2
+++ b/ibm/mas_devops/roles/suite_dns/templates/cp4d/cp4d-certificate.yml.j2
@@ -2,7 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "suite-cp4d-certificate"
-  namespace: "{{ cpd_services_namespace }}"
+  namespace: "{{ cpd_instance_namespace }}"
 spec:
   dnsNames:
     - "cp4d.{{ custom_domain }}"

--- a/ibm/mas_devops/roles/suite_dns/templates/cp4d/cp4d-route.yml.j2
+++ b/ibm/mas_devops/roles/suite_dns/templates/cp4d/cp4d-route.yml.j2
@@ -2,7 +2,7 @@ kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
   name: suite-cp4d-route
-  namespace: "{{ cpd_services_namespace }}"
+  namespace: "{{ cpd_instance_namespace }}"
   annotations:
     haproxy.router.openshift.io/balance=roundrobin
 spec:


### PR DESCRIPTION
Also updates the naming convention for the CP4D namespace variable to match what we have in v10.