### PR TITLE
[patch] Fix settings.datadictionary to camelCase

### DIFF
--- a/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
+++ b/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
@@ -15,7 +15,7 @@ spec:
       cp: "{{ mas_icr_cp }}"
       cpopen: "{{ mas_icr_cpopen }}"
 {% if mas_catalog_source is defined and mas_catalog_source == 'ibm-mas-operators' %}
-    datadictionary:
+    dataDictionary:
       catalog: ibm-data-dictionary-operators
       channel: stable
 {% endif %}


### PR DESCRIPTION
This change will fix dataDictionary installation in our automated environment.
The Camel Case has been introduced to follow the standards.