### PR TITLE
[patch] Fix auto-generation of mas_domain

### DIFF
--- a/ibm/mas_devops/roles/suite_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_install/tasks/main.yml
@@ -20,7 +20,7 @@
 - name: "Configure domain if not set"
   when: mas_domain == ""
   set_fact:
-    mas_domain: "{{ mas_instance_id }}. {{ _cluster_subdomain.resources[0].spec.domain }} }}"
+    mas_domain: "{{ mas_instance_id }}.{{ _cluster_subdomain.resources[0].spec.domain }}"
 
 
 # 3. Determine version of cert-manager in use on the cluster


### PR DESCRIPTION
During MAS install, if `mas_domain` is not set the code to generate a default domain based on the cluster's ingress is broken.  This fixes the regression introduced in #349 