### PR TITLE
[minor] Support OCP on ROSA

### DIFF
--- a/ibm/mas_devops/playbooks/ocp_rosa_deprovision.yml
+++ b/ibm/mas_devops/playbooks/ocp_rosa_deprovision.yml
@@ -1,0 +1,16 @@
+---
+- hosts: localhost
+  vars:
+    cluster_type: rosa
+
+  pre_tasks:
+    # For the full set of supported environment variables refer to the playbook documentation
+    - name: Check for required environment variables
+      assert:
+        that:
+          - lookup('env', 'ROSA_TOKEN') != ""
+          - lookup('env', 'CLUSTER_NAME') != ""
+        fail_msg: "One or more required environment variables are not defined"
+
+  roles:
+    - ibm.mas_devops.ocp_deprovision

--- a/ibm/mas_devops/playbooks/ocp_rosa_provision.yml
+++ b/ibm/mas_devops/playbooks/ocp_rosa_provision.yml
@@ -1,0 +1,28 @@
+---
+- hosts: localhost
+  vars:
+    cluster_type: rosa
+    ocp_version: "{{ lookup('env', 'OCP_VERSION') | default('4.10.18', True) }}"
+
+  pre_tasks:
+    # For the full set of supported environment variables refer to the playbook documentation
+    - name: Check for required environment variables
+      assert:
+        that:
+          - lookup('env', 'ROSA_TOKEN') != ""
+          - lookup('env', 'ROSA_CLUSTER_ADMIN_PASSWORD') != ""
+          - lookup('env', 'ROSA_COMPUTE_NODES') != ""
+          - lookup('env', 'CLUSTER_NAME') != ""
+        fail_msg: "One or more required environment variables are not defined"
+
+  roles:
+    # 1. Provision the ROSA cluster
+    - ibm.mas_devops.ocp_provision
+
+    # 2. Login and verify the cluster is ready
+    - ibm.mas_devops.ocp_login
+    - ibm.mas_devops.ocp_verify
+
+    # 3. Set up storage classes
+    # ROSA doesn't come with a RWX storage class, we need to automate the process of adding EFS storage class to the cluster
+

--- a/ibm/mas_devops/roles/ocp_deprovision/README.md
+++ b/ibm/mas_devops/roles/ocp_deprovision/README.md
@@ -1,48 +1,58 @@
 ocp_deprovision
 ===============
 
-Deprovision OCP cluster in Fyre and IBM Cloud
+Deprovision OCP cluster in Fyre, IBM Cloud, & ROSA.
 
 Role Variables
 --------------
-
 ### cluster_type
 Required.  Specify the cluster type, supported values are `roks` and `quickburn`.
 
+- **Required**
 - Environment Variable: `CLUSTER_TYPE`
 - Default Value: None
 
 ### cluster_name
 Required.  Specify the name of the cluster
 
+- **Required**
 - Environment Variable: `CLUSTER_NAME`
 - Default Value: None
 
 
 Role Variables - ROKS
 ---------------------
-The following variables are only used when `cluster_type = roks`.
-
 ### ibmcloud_apikey
-Required if `cluster_type = roks`.  The APIKey to be used by ibmcloud login comand.
+The APIKey to be used by ibmcloud login comand.
 
+- **Required** if `cluster_type = roks`
 - Environment Variable: `IBMCLOUD_APIKEY`
+- Default Value: None
+
+
+Role Variables - ROSA
+---------------------
+### rosa_token
+The Token used to authenticate with the ROSA service.
+
+- **Required** if `cluster_type = rosa`
+- Environment Variable: `ROSA_TOKEN`
 - Default Value: None
 
 
 Role Variables - Quickburn
 --------------------------
-The following variables are only used when `cluster_type = quickburn`.
+### fyre_username
+Username to authenticate with the Fyre API.
 
-### username
-Required if `cluster_type = quickburn`.  IBM Cloud zone where the cluster should be provisioned.
-
+- **Required** if `cluster_type = quickburn`.
 - Environment Variable: `FYRE_USERNAME`
 - Default Value: None
 
-### password
-Required if `cluster_type = quickburn`.  IBM Cloud zone where the cluster should be provisioned.
+### fyre_apikey
+API key to authenticate with the Fyre API.
 
+- **Required** if `cluster_type = quickburn`.
 - Environment Variable: `FYRE_APIKEY`
 - Default Value: None
 
@@ -52,6 +62,11 @@ Example Playbook
 
 ```yaml
 - hosts: localhost
+  vars:
+    cluster_name: mycluster
+    cluster_type: roks
+
+    ibmcloud_apikey: xxxxx
   roles:
     - ibm.mas_devops.ocp_deprovision
 ```

--- a/ibm/mas_devops/roles/ocp_deprovision/README.md
+++ b/ibm/mas_devops/roles/ocp_deprovision/README.md
@@ -1,6 +1,5 @@
 ocp_deprovision
 ===============
-
 Deprovision OCP cluster in Fyre, IBM Cloud, & ROSA.
 
 Role Variables

--- a/ibm/mas_devops/roles/ocp_deprovision/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_deprovision/defaults/main.yml
@@ -10,10 +10,14 @@ cluster_type: "{{ lookup('env', 'CLUSTER_TYPE')}}"
 supported_cluster_types:
   - roks
   - quickburn
+  - rosa
 
-# ROKS defaults
+# ROKS
 ibmcloud_apikey: "{{ lookup('env', 'IBMCLOUD_APIKEY') }}"
 
-# Quickburn defaults
-username: "{{ lookup('env', 'FYRE_USERNAME') }}"
-password: "{{ lookup('env', 'FYRE_APIKEY') }}"
+# ROSA
+rosa_token: "{{ lookup('env', 'ROSA_TOKEN') }}"
+
+# Fyre
+fyre_username: "{{ lookup('env', 'FYRE_USERNAME') }}"
+fyre_apikey: "{{ lookup('env', 'FYRE_APIKEY') }}"

--- a/ibm/mas_devops/roles/ocp_deprovision/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_deprovision/tasks/main.yml
@@ -1,20 +1,17 @@
 ---
 # 1. Check for undefined properties that do not have a default
 # -----------------------------------------------------------------------------
-- name: "Fail if cluster_type is not provided"
+- name: "Fail if cluster_type and cluster_name are not provided"
   assert:
-    that: cluster_type is defined and cluster_type != ""
-    fail_msg: "cluster_type property is required"
+    that:
+      - cluster_type is defined and cluster_type != ""
+      - cluster_name is defined and cluster_name != ""
+    fail_msg: "cluster_type & cluster_name properties are required"
 
 - name: "Fail if cluster_type is not supported"
   assert:
     that: cluster_type is in supported_cluster_types
     fail_msg: "cluster_type '{{ cluster_type }}' property is not supported by this role"
-
-- name: "Fail if no cluster name is provided"
-  assert:
-    that: cluster_name is defined and cluster_name != ""
-    fail_msg: "cluster_name is required"
 
 
 # 2. Run the deprovision

--- a/ibm/mas_devops/roles/ocp_deprovision/tasks/providers/quickburn.yml
+++ b/ibm/mas_devops/roles/ocp_deprovision/tasks/providers/quickburn.yml
@@ -1,14 +1,11 @@
 ---
 
-- name: "quickburn : Fail if username is not provided"
+- name: "quickburn : Fail if fyre_user and fyre_apikey are not provided"
   assert:
-    that: username is defined and username != ""
-    fail_msg: "username property is required"
-
-- name: "quickburn : Fail if password is not provided"
-  assert:
-    that: password is defined and password != ""
-    fail_msg: "password property is required"
+    that:
+      - fyre_username is defined and fyre_username != ""
+      - fyre_apikey is defined and fyre_apikey != ""
+    fail_msg: "fyre_username & fyre_apikey properties are required"
 
 
 # 1. Debug Info
@@ -17,7 +14,7 @@
   debug:
     msg:
       - "Cluster name ................. {{ cluster_name }}"
-      - "Username ..................... {{ username }}"
+      - "Username ..................... {{ fyre_username }}"
       - "Password ..................... *****************"
 
 # 2. Deprovision
@@ -25,8 +22,8 @@
 - name: "quickburn : Deprovision quick burn cluster"
   uri:
     url: "https://ocpapi.svl.ibm.com/v1/ocp/{{cluster_name}}"
-    user: "{{username}}"
-    password: "{{password}}"
+    user: "{{ fyre_username }}"
+    password: "{{ fyre_apikey }}"
     method: DELETE
     status_code:
       - 200

--- a/ibm/mas_devops/roles/ocp_deprovision/tasks/providers/rosa.yml
+++ b/ibm/mas_devops/roles/ocp_deprovision/tasks/providers/rosa.yml
@@ -1,0 +1,82 @@
+---
+# 1. Failure conditions
+# -----------------------------------------------------------------------------
+- name: "roks : Fail if rosa_token is not provided"
+  assert:
+    that: rosa_token is defined and rosa_token != ""
+    fail_msg: "rosa_token property is required"
+
+
+# 2. Debug Info
+# -----------------------------------------------------------------------------
+- name: "roks : Debug information"
+  debug:
+    msg:
+      - "Cluster name ................. {{ cluster_name }}"
+      - "ROSA token ................... ********************"
+
+
+# 3. Check for required software
+# -----------------------------------------------------------------------------
+- name: "Test if rosa is installed"
+  shell: rosa version
+  register: rosa_version
+  ignore_errors: true
+
+- name: "Fail if rosa is not installed"
+  assert:
+    that: ( rosa_version.rc == 0 )
+    fail_msg: "rosa CLI must be installed (https://console.redhat.com/openshift/create/rosa/welcome)"
+
+
+# 4. Login
+# -----------------------------------------------------------------------------
+- name: "rosa : Login"
+  shell: rosa login --token {{ rosa_token }}
+
+- name: "rosa : Validate login"
+  shell: rosa whoami
+  register: rosa_whoami_result
+
+- name: "rosa : Debug login"
+  debug:
+    msg: "{{ rosa_whoami_result }}"
+
+
+# 5. Check if the cluster is already provisioned
+# -----------------------------------------------------------------------------
+# State: pending -> installing -> ready
+- name: "rosa : Lookup Cluster"
+  shell: rosa describe cluster -c {{ cluster_name }} -o json
+  register: rosa_cluster_lookup_result
+  failed_when: "rosa_cluster_lookup_result.rc > 1"
+
+
+# 6. Delete cluster
+# -----------------------------------------------------------------------------
+- name: "rosa : Delete ROSA cluster"
+  when: rosa_cluster_lookup_result.rc != 1
+  shell: >
+    rosa delete cluster \
+      --cluster-name {{ cluster_name }} \
+      --yes
+
+
+# 7. Watch cluster deprovisioning progress
+# -----------------------------------------------------------------------------
+- name: "rosa : Wait for cluster to be deprovisioned"
+  shell: rosa describe cluster -c {{ cluster_name }} -o json
+  register: cluster_lookup
+  failed_when: "cluster_lookup.rc > 1"
+  retries: 60
+  delay: 60 # 60s * 60 retries = 1 hour
+  until: cluster_lookup.rc == 1
+
+
+# 8. Clean up other AWS resources related to the cluster
+# -----------------------------------------------------------------------------
+- name: "rosa : Clean up operator roles"
+  shell: "rosa delete operator-roles -c {{ (rosa_cluster_lookup_result.stdout | from_json).id }} -m auto --yes"
+
+- name: "rosa : Clean up OIDC provider"
+  shell: "rosa delete oidc-provider -c {{ (rosa_cluster_lookup_result.stdout | from_json).id }} -m auto --yes"

--- a/ibm/mas_devops/roles/ocp_deprovision/tasks/providers/rosa.yml
+++ b/ibm/mas_devops/roles/ocp_deprovision/tasks/providers/rosa.yml
@@ -58,7 +58,7 @@
   when: rosa_cluster_lookup_result.rc != 1
   shell: >
     rosa delete cluster \
-      --cluster-name {{ cluster_name }} \
+      --cluster {{ cluster_name }} \
       --yes
 
 

--- a/ibm/mas_devops/roles/ocp_login/README.md
+++ b/ibm/mas_devops/roles/ocp_login/README.md
@@ -1,25 +1,82 @@
 ocp_login
 =========
 
-This role provides support to login to a cluster using the `oc cli`. If you set `ocp_server` and `ocp_token` then a non cluster type specific login is attempted rather than using the cluster_type specific facts (apikey or username/password).
+This role provides support to login to a cluster using the `oc cli` by looking up cluster information from the infrastructure provider's APIs. Also supports setting `ocp_server` and `ocp_token` directly to support login to any Kubernetes cluster.
 
 
 Role Variables
 --------------
 
-- `cluster_name` Gives a name for the provisioning cluster
-- `cluster_type` quickburn | roks
+### cluster_name
+The name of the cluster to login to.  This will be used to lookup the actual login credentials of the system.
 
-#### ROKS specific facts
-- `ibmcloud_apikey` APIKey to be used by ibmcloud login comand
+- **Required** unless `ocp_server` and `ocp_token` are set
+- Environment Variable: `CLUSTER_NAME`
+- Default: None
 
-#### Fyre specific facts
-- `username` Required when cluster type is quickburn
-- `password` Required when cluster type is quickburn
+###
+The type of cluster to login to (`roks`, `quickburn`, or `rosa`)
 
-#### Non cluster_type specific facts
-- `ocp_server` The OCP server address to perform oc login against
-- `ocp_token` The login token to use for oc login
+- **Required** unless `ocp_server` and `ocp_token` are set
+- Environment Variable: `CLUSTER_TYPE`
+- Default: None
+
+### ocp_server
+The OCP server address to perform oc login against
+
+- **Required** unless `cluster_name` and `cluster_type` are set
+- Environment Variable: `OCP_SERVER`
+- Default: None
+
+### ocp_token
+The login token to use for oc login
+
+- **Required** unless `cluster_name` and `cluster_type` are set
+- Environment Variable: `OCP_TOKEN`
+- Default: None
+
+
+Role Variables - IBMCloud ROKS
+------------------------------
+### ibmcloud_apikey
+APIKey to be used by ibmcloud login comand
+
+- **Required** when `cluster_type` is `roks`
+- Environment Variable: `IBMCLOUD_APIKEY`
+- Default: None
+
+
+Role Variables - IBM DevIT Fyre
+------------------------------
+### fyre_username
+Your FYRE username
+
+- **Required** when `cluster_type` is `quickburn`
+- Environment Variable: `FYRE_APIKEY`
+- Default: None
+
+### fyre_apikey
+Your FYRE API Key
+- **Required** when `cluster_type` is `quickburn`
+- Environment Variable: `FYRE_APIKEY`
+- Default: None
+
+
+Role Variables - AWS ROSA
+-------------------------
+### rosa_token
+Your ROSA secure token.
+
+- **Required** when `cluster_type` is `rosa`
+- Environment Variable: `ROSA_TOKEN`
+- Default: None
+
+### rosa_cluster_admin_password
+The password for the `cluster-admin` account (created when the cluster was provisioned).
+
+- **Required** when `cluster_type` is `rosa`
+- Environment Variable: `ROSA_CLUSTER_ADMIN_PASSWORD`
+- Default: None
 
 
 Example Playbook
@@ -28,10 +85,10 @@ Example Playbook
 ```yaml
 - hosts: localhost
   vars:
-    cluster_name: "{{ lookup('env', 'CLUSTER_NAME')}}"
+    cluster_name: mycluster
     cluster_type: roks
-    ibmcloud_apikey: "{{ lookup('env', 'IBMCLOUD_APIKEY') }}"
-    ibmcloud_resourcegroup: "{{ lookup('env', 'IBMCLOUD_RESOURCEGROUP') | default('Default', true) }}"
+    ibmcloud_apikey: xxxxx
+    ibmcloud_resourcegroup: mygroup
   roles:
     - ibm.mas_devops.ocp_login
 ```

--- a/ibm/mas_devops/roles/ocp_login/README.md
+++ b/ibm/mas_devops/roles/ocp_login/README.md
@@ -1,7 +1,7 @@
 ocp_login
 =========
 
-This role provides support to login to a cluster using the `oc cli` by looking up cluster information from the infrastructure provider's APIs. Also supports setting `ocp_server` and `ocp_token` directly to support login to any Kubernetes cluster.
+This role provides support to login to a cluster using the `oc` CLI by looking up cluster information from the infrastructure provider's APIs, it also supports setting `ocp_server` and `ocp_token` directly to support login to any Kubernetes cluster.
 
 
 Role Variables
@@ -79,9 +79,20 @@ The password for the `cluster-admin` account (created when the cluster was provi
 - Default: None
 
 
-Example Playbook
+Example Playbooks
 ----------------
 
+### Direct Login
+```yaml
+- hosts: localhost
+  vars:
+    ocp_server: xxxxx
+    ocp_token: xxxxx
+  roles:
+    - ibm.mas_devops.ocp_login
+```
+
+### IBMCloud ROKS
 ```yaml
 - hosts: localhost
   vars:
@@ -89,6 +100,30 @@ Example Playbook
     cluster_type: roks
     ibmcloud_apikey: xxxxx
     ibmcloud_resourcegroup: mygroup
+  roles:
+    - ibm.mas_devops.ocp_login
+```
+
+### AWS ROSA
+```yaml
+- hosts: localhost
+  vars:
+    cluster_name: mycluster
+    cluster_type: rosa
+    rosa_token: xxxxx
+    rosa_cluster_admin_password: xxxxx
+  roles:
+    - ibm.mas_devops.ocp_login
+```
+
+### IBM DevIT Fyre
+```yaml
+- hosts: localhost
+  vars:
+    cluster_name: mycluster
+    cluster_type: quickburn
+    fyre_username: xxxxx
+    fyre_password: xxxxx
   roles:
     - ibm.mas_devops.ocp_login
 ```

--- a/ibm/mas_devops/roles/ocp_login/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_login/defaults/main.yml
@@ -11,13 +11,18 @@ ocp_server: "{{ lookup('env', 'OCP_SERVER') }}"
 ibmcloud_apikey: "{{ lookup('env', 'IBMCLOUD_APIKEY') }}"
 
 # Fyre username/password - used when cluster_type == "quickburn"
-username: "{{ lookup('env', 'FYRE_USERNAME') }}"
-password: "{{ lookup('env', 'FYRE_APIKEY') }}"
+fyre_username: "{{ lookup('env', 'FYRE_USERNAME') }}"
+fyre_apikey: "{{ lookup('env', 'FYRE_APIKEY') }}"
+
+# Rosa token & cluster-admin password
+rosa_token:  "{{ lookup('env', 'ROSA_TOKEN') }}"
+rosa_cluster_admin_password: "{{ lookup('env', 'ROSA_CLUSTER_ADMIN_PASSWORD') }}"
 
 # What cluster types does this role support
 supported_cluster_types:
   - roks
   - quickburn
+  - rosa
   - in-cluster
   - aws
 

--- a/ibm/mas_devops/roles/ocp_login/tasks/login-quickburn.yml
+++ b/ibm/mas_devops/roles/ocp_login/tasks/login-quickburn.yml
@@ -1,21 +1,18 @@
 ---
 # 1. Fyre Login
 # -----------------------------------------------------------------------------
-- name: "login-quickburn : Fail if username is not provided"
+- name: "login-quickburn : Fail if fyre_username and fyre_apikey are not provided"
   assert:
-    that: username is defined and username != ""
-    fail_msg: "username property is required"
-
-- name: "login-quickburn : Fail if password is not provided"
-  assert:
-    that: password is defined and password != ""
-    fail_msg: "password property is required"
+    that:
+      - fyre_username is defined and fyre_username != ""
+      - fyre_apikey is defined and fyre_apikey != ""
+    fail_msg: "fyre_username and fyre_apikey properties are required"
 
 - name: "login-quickburn : Get Cluster Details"
   uri:
     url: https://ocpapi.svl.ibm.com/v1/ocp/{{ cluster_name }}
-    user: "{{ username }}"
-    password: "{{ password }}"
+    user: "{{ fyre_username }}"
+    password: "{{ fyre_apikey }}"
     method: GET
     force_basic_auth: yes
     validate_certs: false
@@ -25,7 +22,7 @@
     api_host: "api.{{ cluster_name }}.cp.fyre.ibm.com"
     _this_cluster: "{{ _cluster_details.json.clusters | selectattr('cluster_name', '==', cluster_name) | last }}"
 
-- name: "login-quickburn : Oc Login the created cluster"
+- name: "login-quickburn : Login to the created cluster"
   vars:
     login_password: "{{ _this_cluster.kubeadmin_password }}"
     login_server: "https://{{ api_host }}:6443"

--- a/ibm/mas_devops/roles/ocp_login/tasks/login-roks.yml
+++ b/ibm/mas_devops/roles/ocp_login/tasks/login-roks.yml
@@ -5,17 +5,18 @@
 
 # 1. Check that we have an IBM Cloud API key defined
 # -----------------------------------------------------------------------------
-- name: "login-roks : Fail if ibmcloud_apikey is not provided"
+- name: "login-roks : Fail if ibmcloud_apikey & cluster_name are not provided"
   assert:
-    that: ibmcloud_apikey is defined and ibmcloud_apikey != ""
-    fail_msg: "ibmcloud_apikey property is required"
+    that:
+      - ibmcloud_apikey is defined and ibmcloud_apikey != ""
+      - cluster_name is defined and cluster_name != ""
+    fail_msg: "ibmcloud_apikey are cluster_name properties is required"
 
 
 # 2. Login to IBM Cloud
 # -----------------------------------------------------------------------------
 - name: "login-roks : Login to IBM Cloud"
-  shell: |
-    ibmcloud login --apikey "{{ ibmcloud_apikey }}" -q --no-region
+  shell: ibmcloud login --apikey "{{ ibmcloud_apikey }}" -q --no-region
   register: login_result
   retries: 10
   delay: 30
@@ -25,8 +26,7 @@
 # 3. Configure for the selected cluster
 # -----------------------------------------------------------------------------
 - name: "login-roks : Set the target cluster"
-  shell: |
-    ibmcloud oc cluster config -c {{ cluster_name }} --admin
+  shell: ibmcloud oc cluster config -c {{ cluster_name }} --admin
   register: config_result
   retries: 10
   delay: 30

--- a/ibm/mas_devops/roles/ocp_login/tasks/login-rosa.yml
+++ b/ibm/mas_devops/roles/ocp_login/tasks/login-rosa.yml
@@ -1,0 +1,50 @@
+---
+# 1. Check that we have a ROSA token defined
+# -----------------------------------------------------------------------------
+- name: "login-rosa : Fail if rosa_token is not provided"
+  assert:
+    that:
+      - rosa_token is defined and rosa_token != ""
+      - cluster_name is defined and cluster_name != ""
+      - rosa_cluster_admin_password is defined and rosa_cluster_admin_password != ""
+
+
+# 2. Check for required software
+# -----------------------------------------------------------------------------
+- name: "Test if rosa is installed"
+  shell: rosa version
+  register: rosa_version
+  ignore_errors: true
+
+- name: "Fail if rosa is not installed"
+  assert:
+    that: ( rosa_version.rc == 0 )
+    fail_msg: "rosa CLI must be installed (https://console.redhat.com/openshift/create/rosa/welcome)"
+
+
+# 3. Login to Rosa
+# -----------------------------------------------------------------------------
+- name: "login-rosa : Login"
+  shell: rosa login --token {{ rosa_token }}
+
+- name: "login-rosa : Validate login"
+  shell: rosa whoami
+  register: rosa_whoami_result
+
+- name: "login-rosa : Debug login"
+  debug:
+    msg: "{{ rosa_whoami_result }}"
+
+
+# 4. Configure for the selected cluster
+# -----------------------------------------------------------------------------
+- name: "login-rosa : Lookup Cluster"
+  shell: rosa describe cluster -c {{ cluster_name }} -o json
+  register: rosa_cluster_lookup_result
+
+- name: "login-rosa : Debug status"
+  debug:
+    msg: "Cluster API URL ....................... {{ (rosa_cluster_lookup_result.stdout | from_json).api.url }}"
+
+- name: "login-rosa : Login to the cluster"
+  shell: "oc login {{ (rosa_cluster_lookup_result.stdout | from_json).api.url }} --username cluster-admin --password {{ rosa_cluster_admin_password }} --insecure-skip-tls-verify"

--- a/ibm/mas_devops/roles/ocp_login/tasks/login.yml
+++ b/ibm/mas_devops/roles/ocp_login/tasks/login.yml
@@ -1,26 +1,23 @@
 ---
 # 1. Check that we have the ocp vars defined
 # -----------------------------------------------------------------------------
-- name: "login : Fail if ocp_token is not provided"
+- name: "login : Fail if ocp_server or ocp_token are not provided"
   assert:
-    that: ocp_token is defined and ocp_token != ""
-    fail_msg: "ocp_token property is required"
-
-- name: "login : Fail if ocp_server is not provided"
-  assert:
-    that: ocp_server is defined and ocp_server != ""
-    fail_msg: "ocp_server property is required"
+    that:
+      - ocp_token is defined and ocp_token != ""
+      - ocp_server is defined and ocp_server != ""
+    fail_msg: "ocp_server and ocp_token must be provided together"
 
 
 # 2. Login to OCP
 # -----------------------------------------------------------------------------
 - name: "login : Login to OCP"
-  shell: |
-    oc login --token={{ ocp_token }} --server={{ ocp_server }}
+  shell: oc login --token={{ ocp_token }} --server={{ ocp_server }}
   register: login_result
   retries: 5
   delay: 10
   until: login_result.rc == 0
 
-- debug:
+- name: "login : Debug OCP login"
+  debug:
     msg: "{{ login_result.stdout_lines }}"

--- a/ibm/mas_devops/roles/ocp_login/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_login/tasks/main.yml
@@ -3,25 +3,17 @@
 # -----------------------------------------------------------------------------
 - name: "Fail if type is not provided"
   assert:
-    that: cluster_type is defined and cluster_type != ""
-    fail_msg: "cluster_type property is required"
+    that: (cluster_type is defined and cluster_type != "" and cluster_name is defined and cluster_name != "") or (ocp_token is defined and ocp_token != "" and  ocp_server is defined and ocp_server != "")
+    fail_msg: "cluster_type & cluster_name, or ocp_token and ocp_server properties must be provided"
 
-# Allow for different cluster_types if the ocp_token and ocp_server have been set
-- name: "Fail if cluster_type is not supported and no ocp_token or ocp_server has been set"
-  assert:
-    that:
-      - ocp_token is defined and ocp_token != ""
-      - ocp_server is defined and ocp_server != ""
-    fail_msg: "cluster_type '{{ cluster_type }}' property is not supported by this role if you haven't set ocp_server or ocp_token properties"
-  when: cluster_type is not in supported_cluster_types
 
 # 2. Provide debug info
 # -----------------------------------------------------------------------------
 - debug:
     msg:
-      - "Cluster name ................. {{ cluster_name }}"
-      - "Cluster type ................. {{ cluster_type }}"
-      - "OCP server ................... {{ ocp_server }}"
+      - "Cluster name ................. {{ cluster_name | default('<undefined>', true) }}"
+      - "Cluster type ................. {{ cluster_type | default('<undefined>', true) }}"
+      - "OCP server ................... {{ ocp_server | default('<undefined>', true) }}"
 
 
 # 3. Perform login using cluster specific login

--- a/ibm/mas_devops/roles/ocp_provision/README.md
+++ b/ibm/mas_devops/roles/ocp_provision/README.md
@@ -25,6 +25,9 @@ Required.  Specify the version of OCP to install.  The exact format of this will
 - Environment Variable: `OCP_VERSION`
 - Default Value: None
 
+
+Role Variables - GPU Node Support
+---------------------------------
 ### ocp_provision_gpu
 Flag that determines if GPU worker nodes should be added during cluster creation (eg. needed for MVI application). This is currently only set up for ROKS clusters.
 
@@ -32,7 +35,7 @@ Flag that determines if GPU worker nodes should be added during cluster creation
 - Default Value: `false`
 
 ### gpu_workerpool_name
-The name of the gpu worker pool to added to or modify in the cluster. If already existing, use the existing name to avoid recreating another gpu worker pool unless that is the goal. 
+The name of the gpu worker pool to added to or modify in the cluster. If already existing, use the existing name to avoid recreating another gpu worker pool unless that is the goal.
 
 - Environment Variable: `GPU_WORKERPOOL_NAME`
 - Default Value: `gpu`
@@ -85,6 +88,32 @@ Can be used to specify additional parameters for the cluster creation
 - Default Value: None
 
 
+Role Variables - ROSA
+---------------------
+The following variables are only used when `cluster_type = rosa`.
+
+### roso_token
+Token to authenticate to the ROSA service
+
+- **Required** if `cluster_type = rosa`.
+- Environment Variable: `ROSA_TOKEN`
+- Default Value: None
+
+### roso_cluster_admin_password
+Password to set up for the `cluster-admin` user account on the OCP instance.  You will need this to log onto the cluster after it is provisioned.
+
+- **Required** if `cluster_type = rosa`.
+- Environment Variable: `ROSA_CLUSTER_ADMIN_PASSWORD`
+- Default Value: None
+
+### rosa_compute_nodes
+Number of compute nodes to deploy in the cluster.
+
+- Optional
+- Environment Variable: `ROSA_COMPUTE_NODES`
+- Default Value: `3`
+
+
 Role Variables - Quickburn
 --------------------------
 The following variables are only used when `cluster_type = quickburn`.
@@ -120,6 +149,12 @@ Example Playbook
 
 ```yaml
 - hosts: localhost
+  vars:
+    cluster_type: roks
+    cluster_name: mycluster
+    ocp_version: 4.10
+
+    ibmcloud_apikey: xxxxx
   roles:
     - ibm.mas_devops.ocp_provision
 ```

--- a/ibm/mas_devops/roles/ocp_provision/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/defaults/main.yml
@@ -23,6 +23,7 @@ gpu_workerpool_name: "{{ lookup('env', 'GPU_WORKERPOOL_NAME') | default('gpu', t
 supported_cluster_types:
   - roks
   - quickburn
+  - rosa
 
 # ROKS defaults
 ibmcloud_apikey: "{{ lookup('env', 'IBMCLOUD_APIKEY') }}"
@@ -39,3 +40,8 @@ fyre_password: "{{ lookup('env', 'FYRE_APIKEY') }}"
 
 fyre_cluster_size: "{{ lookup('env', 'FYRE_CLUSTER_SIZE') | default('large', true) }}"
 fyre_product_id: "{{ lookup('env', 'FYRE_PRODUCT_ID') }}"
+
+# ROSA defaults
+rosa_token: "{{ lookup('env', 'ROSA_TOKEN') }}"
+rosa_cluster_admin_password: "{{ lookup('env', 'ROSA_CLUSTER_ADMIN_PASSWORD') }}"
+rosa_compute_nodes: "{{ lookup('env', 'ROSA_COMPUTE_NODES') | default('3', true) }}"

--- a/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
@@ -1,10 +1,12 @@
 ---
 # 1. Check for undefined properties that do not have a default
 # -----------------------------------------------------------------------------
-- name: "Fail if cluster type is not provided"
+- name: "Fail if cluster name & type is not provided"
   assert:
-    that: cluster_type is defined and cluster_type != ""
-    fail_msg: "cluster_type property is required"
+    that:
+      - cluster_type is defined and cluster_type != ""
+      - cluster_name is defined and cluster_name != ""
+    fail_msg: "cluster_type and cluster_name properties are required"
 
 - name: "Fail if cluster type is not supported"
   assert:

--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/rosa.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/rosa.yml
@@ -97,3 +97,11 @@
   shell: rosa create admin --cluster {{ cluster_name }} --password {{ rosa_cluster_admin_password }}
   register: rosa_cluster_completion
   failed_when: "rosa_cluster_completion.rc > 1"
+
+# We want to try to ensure the account is ready to use by the time the
+# script completes, so we will delay for 5 minutes if the return code
+# indicates that the account was created when we ran the previous command.
+- name: Pause for 5 minutes while the cluster-admin account is created
+  when: rosa_cluster_completion.rc == 0
+  pause:
+    minutes: 5

--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/rosa.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/rosa.yml
@@ -1,0 +1,103 @@
+---
+# 1. Failure conditions
+# -----------------------------------------------------------------------------
+- name: "roks : Fail if rosa_token is not provided"
+  assert:
+    that: rosa_token is defined and rosa_token != ""
+    fail_msg: "rosa_token property is required"
+
+
+# 2. Debug Info
+# -----------------------------------------------------------------------------
+- name: "roks : Debug information"
+  debug:
+    msg:
+      - "Cluster name ................. {{ cluster_name }}"
+      - "OCP version .................. {{ ocp_version }}"
+      - "ROSA compute nodes ........... {{ rosa_compute_nodes }}"
+      - "ROSA token ................... ********************"
+
+
+# 3. Check for required software
+# -----------------------------------------------------------------------------
+- name: "Test if rosa is installed"
+  shell: rosa version
+  register: rosa_version
+  ignore_errors: true
+
+- name: "Fail if rosa is not installed"
+  assert:
+    that: ( rosa_version.rc == 0 )
+    fail_msg: "rosa CLI must be installed (https://console.redhat.com/openshift/create/rosa/welcome)"
+
+
+# 4. Login
+# -----------------------------------------------------------------------------
+- name: "rosa : Login"
+  shell: rosa login --token {{ rosa_token }}
+
+- name: "rosa : Validate login"
+  shell: rosa whoami
+  register: rosa_whoami_result
+
+- name: "rosa : Debug login"
+  debug:
+    msg: "{{ rosa_whoami_result }}"
+
+
+# 5. Check if the cluster is already provisioned
+# -----------------------------------------------------------------------------
+# State: pending -> installing -> ready
+- name: "rosa : Lookup Cluster"
+  shell: rosa describe cluster -c {{ cluster_name }} -o json
+  register: rosa_cluster_lookup_result
+  failed_when: "rosa_cluster_lookup_result.rc > 1"
+
+- name: "rosa : Debug status"
+  when: rosa_cluster_lookup_result.rc == 0
+  debug:
+    msg: "Cluster state ......................... {{ (rosa_cluster_lookup_result.stdout | from_json).state }}"
+
+
+# 6. Create cluster
+# -----------------------------------------------------------------------------
+- name: "rosa : Create ROSA cluster"
+  when: rosa_cluster_lookup_result.rc == 1
+  shell: >
+    rosa create cluster \
+      --cluster-name {{ cluster_name }} \
+      --version {{ ocp_version }} \
+      --compute-nodes {{ rosa_compute_nodes }} \
+      --sts \
+      --mode auto \
+      --yes
+
+
+# 7. Watch cluster provisioning progress
+# -----------------------------------------------------------------------------
+- name: "rosa : Wait until the ROSA cluster is deployed"
+  shell: rosa describe cluster -c {{ cluster_name }} -o json
+  register: rosa_cluster_completion
+  until:
+    - rosa_cluster_completion.rc == 0
+    - (rosa_cluster_completion.stdout | from_json).state == 'ready'
+  retries: 60
+  delay: 60
+
+- name: "rosa: Debug final cluster state"
+  debug:
+    msg: "{{ rosa_cluster_completion.stdout | from_json }}"
+
+
+# 8. Set up cluster-admin user
+# -----------------------------------------------------------------------------
+# If the user already exists this will fail, but there's no way to see if the
+# user exists already (that I know of)
+- name: "rosa : Create cluster-admin user"
+  shell: rosa create admin --cluster {{ cluster_name }} --password {{ rosa_cluster_admin_password }}
+  register: rosa_cluster_completion
+  failed_when: "rosa_cluster_completion.rc > 1"
+
+
+# TODO: We need to set up EFS storage class too, otherwise we can only use RWO PVCs/storage classes (EBS)
+

--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/rosa.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/rosa.yml
@@ -97,7 +97,3 @@
   shell: rosa create admin --cluster {{ cluster_name }} --password {{ rosa_cluster_admin_password }}
   register: rosa_cluster_completion
   failed_when: "rosa_cluster_completion.rc > 1"
-
-
-# TODO: We need to set up EFS storage class too, otherwise we can only use RWO PVCs/storage classes (EBS)
-


### PR DESCRIPTION
New playbooks:
- `ibm.mas_devops.provision_rosa`
- `ibm.mas_devops.deprovision_rosa`

Updates to roles (including documenation) to add support for `cluster_type` = `rosa`
- `ibm.mas_devops.ocp_provision`
- `ibm.mas_devops.ocp_deprovision`
- `ibm.mas_devops.ocp_login`

There is still more work to do to support MAS on ROSA (e.g. enabling EFS storage class), this is just the starting point