### PR TITLE
[patch] Use correct env var for mas_channel

### DIFF
--- a/ibm/mas_devops/playbooks/oneclick_core.yml
+++ b/ibm/mas_devops/playbooks/oneclick_core.yml
@@ -11,7 +11,7 @@
     sls_mongodb_cfg_file: "{{ mas_config_dir }}/mongo-{{ mongodb_namespace }}.yml"
 
     # Core Services Configuration
-    mas_channel: "{{ lookup('env', 'MAS_APP_CHANNEL') | default('8.7.x', true) }}"
+    mas_channel: "{{ lookup('env', 'MAS_CHANNEL') | default('8.7.x', true) }}"
 
     # Workspace Configuration
     mas_workspace_name: "{{ lookup('env', 'MAS_WORKSPACE_NAME') | default('MAS Development', true) }}"


### PR DESCRIPTION
When environment variable support was added to the oneclick playbooks, the `mas_channel` property was incorrectly linked to the `MAS_APP_CHANNEL` env var instead of `MAS_CHANNEL`