### PR TITLE
[patch] Add wsrt_operand_version to Watson Studio spec

### DIFF
--- a/ibm/mas_devops/roles/cp4d_service/templates/services/wsl.yml.j2
+++ b/ibm/mas_devops/roles/cp4d_service/templates/services/wsl.yml.j2
@@ -14,3 +14,4 @@ spec:
   version: "{{ cpd_product_version }}"
   ccs_operand_version: "{{ cpd_product_version }}"
   datarefinery_operand_version: "{{ cpd_product_version }}"
+  wsrt_operand_version: "{{ cpd_product_version }}"


### PR DESCRIPTION
This is the final piece in being able to lock down the product version of Cloud Pak for data independant from the operator version.  With this update the `NotebookRuntimes` will be configured at the same product version that Watson Studio is deployed at.  This ensures that the breaking changes introduced in patch levels of the CP4D product do not break the installation.