### PR TITLE
[patch] Reference norootsquash image by digest

### DIFF
--- a/ibm/mas_devops/roles/db2/templates/norootsquash_daemonset.yml.j2
+++ b/ibm/mas_devops/roles/db2/templates/norootsquash_daemonset.yml.j2
@@ -24,7 +24,8 @@ spec:
             requests:
               cpu: 0.01
           name: systemdutil01
-          image: cp.icr.io/cp/cpd/norootsquash:3.0-amd64
+          # cp.icr.io/cp/cpd/norootsquash:3.0-amd64
+          image: cp.icr.io/cp/cpd/norootsquash@sha256:5dbe9310d15cbe452f6099017defd411eeb6eebb2fecea5d99463227e2518574
           imagePullPolicy: Always
           args: ["-option", "restart", "-service", "nfs-idmapd.service"]
           volumeMounts:


### PR DESCRIPTION
Required for private mirror registry support, otherwise the `ImageContentSourcePolicy` will not be used.