### PR TITLE
[patch] Fix LDAP user create to not fail if user already exists

### DIFF
--- a/ibm/mas_devops/roles/db2/tasks/create_ldap_user.yml
+++ b/ibm/mas_devops/roles/db2/tasks/create_ldap_user.yml
@@ -52,7 +52,7 @@
   shell: |
     oc exec -it {{ db2_manage_pod_name }} -n {{ db2_namespace }} -c db2u -- su -lc "db2 connect to bludb user {{ db2_ldap_username }} using {{ db2_ldap_password }}" db2inst1
   register: db2_connect_result
-  retries: 5
-  delay: 5
+  retries: 6
+  delay: 20
   until: db2_connect_result.rc == 0
 


### PR DESCRIPTION
This PR contains changes to remove the task that fails `db2` role if the ldap user we are going to create in ldap, already exist.

It also adds a retry to the task that test the db2 connection with the newly db2 user created. To give it some time to reconcile the user with the db2 database.