### PR TITLE
[patch] Add missing namespace to StorageCluster lookup

### DIFF
--- a/ibm/mas_devops/roles/ocs/tasks/storage.yml
+++ b/ibm/mas_devops/roles/ocs/tasks/storage.yml
@@ -56,6 +56,7 @@
     api_version: ocs.openshift.io/v1
     kind: StorageCluster
     name:  ocs-storagecluster
+    namespace: openshift-storage
   register: storagecluster_info
   retries: 30 # 1 hour
   delay: 120 # 2 minutes


### PR DESCRIPTION
This role only works if you happen to already be set to the `openshift-storage` namespace as the default.