### PR TITLE
[patch] Improve catalog & CP4D installation checks

### DIFF
--- a/ibm/mas_devops/roles/cp4d/tasks/install-cp4d.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/install-cp4d.yml
@@ -75,14 +75,9 @@
   register: ibmcpd_lookup
   until:
     - ibmcpd_lookup.resources[0].status.controlPlaneStatus is defined
-    - ibmcpd_lookup.resources[0].status.controlPlaneStatus == "Completed" or ibmcpd_lookup.resources[0].status.controlPlaneStatus == "Failed"
+    - ibmcpd_lookup.resources[0].status.controlPlaneStatus == "Completed"
   retries: 60 # Approximately 2 hours before we give up
   delay: 120 # 2 minutes
-
-- name: "install-cp4d : Check that the controlPlaneStatus is 'Completed'"
-  assert:
-    that: ibmcpd_lookup.resources[0].status.controlPlaneStatus == "Completed"
-    fail_msg: "IBM CloudPak for Data install failed (controlPlaneStatus)"
 
 
 # 4. Wait for zenStatus

--- a/ibm/mas_devops/roles/ibm_catalogs/tasks/main.yml
+++ b/ibm/mas_devops/roles/ibm_catalogs/tasks/main.yml
@@ -16,6 +16,27 @@
   kubernetes.core.k8s:
     definition: "{{ lookup('template', 'templates/ibm-catalogs.yml') }}"
 
+- name: "Wait till IBM Catalogs are Ready"
+  when:
+    - not airgap_install
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: CatalogSource
+    name: "{{ item }}"
+    namespace: openshift-marketplace
+  register: ibm_catalog_lookup
+  retries: 5 # Up to 5 min
+  delay: 60 # Every minute
+  until:
+    - ibm_catalog_lookup.resources is defined
+    - ibm_catalog_lookup.resources | length == 1
+    - ibm_catalog_lookup.resources[0].status is defined
+    - ibm_catalog_lookup.resources[0].status.connectionState is defined
+    - ibm_catalog_lookup.resources[0].status.connectionState.lastObservedState is defined
+    - ibm_catalog_lookup.resources[0].status.connectionState.lastObservedState == "READY"
+  with_items:
+    - ibm-operator-catalog
+    - opencloud-operators
 
 # 3. Install development (pre-release) catalogs
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
- [x] Wait till ibm-catalogs are READY

Test evidence:

<img width="886" alt="image" src="https://user-images.githubusercontent.com/15021471/177433751-db954856-7812-439b-b022-b806e1025642.png">

-----

- [x] A `Failed` status in cpd installation can revert back to in progress and then complete.

Experienced that scenario in `fvt-dev` during cp4d task:

**Update**: `fvt-release` had the same behavior

```
FAILED - RETRYING: [localhost]: install-cp4d : Wait for controlPlaneStatus to be 'Completed' (2m delay) (38 retries left).
FAILED - RETRYING: [localhost]: install-cp4d : Wait for controlPlaneStatus to be 'Completed' (2m delay) (37 retries left).
ok: [localhost] => {"api_found": true, "attempts": 25, "changed": false, "resources": [{"apiVersion": "cpd.ibm.com/v1", "kind": "Ibmcpd", "metadata": {"annotations": {"kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"cpd.ibm.com/v1\",\"kind\":\"Ibmcpd\",\"metadata\":{\"csNamespace\":\"ibm-common-services\",\"name\":\"ibmcpd\",\"namespace\":\"ibm-cpd\"},\"spec\":{\"license\":{\"accept\":true,\"license\":\"Standard\"},\"storageClass\":\"ibmc-file-gold-gid\",\"zenCoreMetadbStorageClass\":\"ibmc-block-gold\"}}"}, "creationTimestamp": "2022-06-30T23:02:58Z", "generation": 1, "managedFields": [{"apiVersion": "cpd.ibm.com/v1", "fieldsType": "FieldsV1", "fieldsV1": {"f:status": {".": {}, "f:conditions": {}}}, "manager": "ansible-operator", "operation": "Update", "time": "2022-06-30T23:02:58Z"}, {"apiVersion": "cpd.ibm.com/v1", "fieldsType": "FieldsV1", "fieldsV1": {"f:metadata": {"f:annotations": {".": {}, "f:kubectl.kubernetes.io/last-applied-configuration": {}}}, "f:spec": {".": {}, "f:license": {".": {}, "f:accept": {}, "f:license": {}}, "f:storageClass": {}, "f:zenCoreMetadbStorageClass": {}}, "f:status": {"f:controlPlaneStatus": {}, "f:lastReconcileEnd": {}, "f:lastReconcileStart": {}}}, "manager": "OpenAPI-Generator", "operation": "Update", "time": "2022-06-30T23:56:16Z"}], "name": "ibmcpd", "namespace": "ibm-cpd", "resourceVersion": "163148", "uid": "f5559461-b124-4c95-8609-dedf009f8362"}, "spec": {"license": {"accept": true, "license": "Standard"}, "storageClass": "ibmc-file-gold-gid", "zenCoreMetadbStorageClass": "ibmc-block-gold"}, "status": {"conditions": [{"lastTransitionTime": "2022-06-30T23:56:17Z", "message": "", "reason": "", "status": "False", "type": "Successful"}, {"ansibleResult": {"changed": 7, "completion": "2022-06-30T23:56:17.352033", "failures": 1, "ok": 21, "skipped": 5}, "lastTransitionTime": "2022-06-30T23:56:17Z", "message": "unknown playbook failure\nzen service installation has failed", "reason": "Failed", "status": "False", "type": "Failure"}, {"lastTransitionTime": "2022-06-30T23:56:17Z", "message": "Running reconciliation", "reason": "Running", "status": "True", "type": "Running"}], "controlPlaneStatus": "Failed", "lastReconcileEnd": "2022-06-30_23:56:13", "lastReconcileStart": "2022-06-30_23:03:12"}}]}

TASK [ibm.mas_devops.cp4d : install-cp4d : Check that the controlPlaneStatus is 'Completed'] ***
Thursday 30 June 2022  23:56:25 +0000 (0:48:20.717)       0:55:40.501 ********* 
fatal: [localhost]: FAILED! => {
    "assertion": "ibmcpd_lookup.resources[0].status.controlPlaneStatus == \"Completed\"",
    "changed": false,
    "evaluated_to": false,
    "msg": "IBM CloudPak for Data install failed (controlPlaneStatus)"
}
```

Looking at the `ibmcpd` CR, however, after some time:

```
status:
  conditions:
    - lastTransitionTime: '2022-06-30T23:56:17Z'
      message: ''
      reason: ''
      status: 'False'
      type: Failure
    - ansibleResult:
        changed: 6
        completion: '2022-07-01T00:32:54.459793'
        failures: 0
        ok: 39
        skipped: 14
      lastTransitionTime: '2022-06-30T23:56:17Z'
      message: Awaiting next reconciliation
      reason: Successful
      status: 'True'
      type: Running
    - lastTransitionTime: '2022-07-01T00:32:54Z'
      message: Last reconciliation succeeded
      reason: Successful
      status: 'True'
      type: Successful
  controlPlaneStatus: Completed
  lastReconcileEnd: '2022-07-01_00:32:51'
  lastReconcileStart: '2022-07-01_00:29:39'
```