### PR TITLE
[patch] Increase install timeout for UDS

### DIFF
--- a/ibm/mas_devops/roles/uds/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/uds/tasks/install/main.yml
@@ -71,7 +71,7 @@
     - uds_ap_cr_lookup.resources[0].status is defined
     - uds_ap_cr_lookup.resources[0].status.phase is defined
     - uds_ap_cr_lookup.resources[0].status.phase == 'Ready'
-  retries: 20 # approx 40 minutes before we give up waiting for status.phase to be Ready
+  retries: 30 # approx 1 hour (!!) before we give up waiting for status.phase to be Ready
   delay: 120 # 2 minutes
 
 


### PR DESCRIPTION
We've seen a significant increase in UDS install time causing the existing 40 minute timeout for UDS install to be hit on multiple occasions in testing.  This update increases the timeout while we wait for UDS to be ready to use following initial install so that the pipeline is more resiliant to these longer installs.  We now give UDS up to 1 hour to complete it's installation before considering it a failed installation.