### PR TITLE
[patch] db2ucluster lookup verification fix

### DIFF
--- a/ibm/mas_devops/roles/db2/tasks/main.yml
+++ b/ibm/mas_devops/roles/db2/tasks/main.yml
@@ -180,6 +180,7 @@
     kind: Db2uCluster
   register: db2_cluster_lookup
   until:
+    - db2_cluster_lookup.resources is defined
     - db2_cluster_lookup.resources | length == 1
     - db2_cluster_lookup.resources[0].status is defined
     - db2_cluster_lookup.resources[0].status.state is defined


### PR DESCRIPTION
Added the check for a defined resource field before the check for resource length