### PR TITLE
[patch] Wait for Db2 pod to be ready

### DIFF
--- a/ibm/mas_devops/roles/suite_db2_setup_for_manage/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_manage/tasks/main.yml
@@ -41,6 +41,12 @@
     label_selectors:
       - type=engine
       - app={{ db2_instance_name }}
+    wait: yes
+    wait_sleep: 30
+    wait_timeout: 300 # 5 mins until we give up waiting for the pod to get into the expected state
+    wait_condition:
+      type: Ready
+      status: "True"
   register: db2_pod
 
 - name: Configure facts


### PR DESCRIPTION
Sometimes, when we run the `suite_db2_setup_for_manage` role, the Db2 pod is not yet ready so the attempt to copy the setup script into the pod fails.  Add `wait` to the `k8s_info` call to query the pod name so that hopefully the pod is always ready by the time we attempt to copy the file into the container.