### PR TITLE
[patch] Use OperatorConditions to determine digest version

### DIFF
--- a/ibm/mas_devops/roles/sls/tasks/install/install_digest_cm.yml
+++ b/ibm/mas_devops/roles/sls/tasks/install/install_digest_cm.yml
@@ -1,17 +1,86 @@
 ---
 
+# 1. Determine the version of the SLS operator that is running
+# -----------------------------------------------------------------------------
+- name: "Lookup Application operator version"
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v2
+    kind: OperatorCondition
+    namespace: "{{ sls_namespace }}"
+    label_selectors:
+      - "operators.coreos.com/ibm-sls.{{ sls_namespace }}"
+  register: sls_opcon
+
+
+# 2. Fail if we can't find the OperatorCondition for SLS
+# -----------------------------------------------------------------------------
+- name: "Check that the OperatorCondition was found"
+  assert:
+    that:
+      - sls_opcon.resources is defined
+      - sls_opcon.resources | length == 1
+      - sls_opcon.resources[0].metadata.name is defined
+
+
+# 3. Set the SLS operator version
+# -----------------------------------------------------------------------------
+# OperatorCondition names are in the format {packageName}.{packageVersion}
+# We want to strip off the "v" prefix from the version while we do this
+- name: "Lookup operator version"
+  set_fact:
+    sls_operator_version: "{{ sls_opcon.resources[0].metadata.name.split('.v')[1] }}"
+
+- name: Debug
+  debug:
+    msg:
+      - "SLS operator condition ......... {{ sls_opcon.resources[0].metadata.name }}"
+      - "SLS operator version ........... {{ sls_operator_version }}"
+
+
+# 4. Create the Image Digest Map
+# -----------------------------------------------------------------------------
 - name: "Create ibm-sls Image Digest Map"
   include_role:
     name: ibm.mas_airgap.install_digest_cm
   vars:
     digest_image_map_namespace: "{{ sls_namespace }}"
     case_name: ibm-sls
-    case_version: "3.4.0" # TODO: Look this up from OperatorCondition
+    case_version: "{{ sls_operator_version }}"
 
+
+# 5. Lookup the OperatorCondition for Truststore Manager
+# -----------------------------------------------------------------------------
+- name: "Lookup Truststore Manager operator version"
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v2
+    kind: OperatorCondition
+    namespace: "{{ sls_namespace }}"
+    label_selectors:
+      - "operators.coreos.com/ibm-truststore-mgr.{{ sls_namespace }}"
+  register: tsm_opcon
+
+
+# 6. If TSM is installed, determine at which version
+# -----------------------------------------------------------------------------
+- name: "Lookup Truststore Manager operator version"
+  when:
+    - tsm_opcon.resources is defined
+    - tsm_opcon.resources | length == 1
+    - tsm_opcon.resources[0].metadata.name is defined
+  set_fact:
+    tsm_operator_version: "{{ tsm_opcon.resources[0].metadata.name.split('.v')[1] }}"
+
+
+# 7. If TSM is installed, install it's digest map
+# -----------------------------------------------------------------------------
 - name: "Create ibm-truststore-mgr Image Digest Map"
+  when:
+    - tsm_opcon.resources is defined
+    - tsm_opcon.resources | length == 1
+    - tsm_opcon.resources[0].metadata.name is defined
   include_role:
     name: ibm.mas_airgap.install_digest_cm
   vars:
     digest_image_map_namespace: "{{ sls_namespace }}"
     case_name: ibm-truststore-mgr
-    case_version: "1.3.0" # TODO: Look this up from OperatorCondition
+    case_version: "{{ tsm_operator_version }}"

--- a/ibm/mas_devops/roles/suite_app_install/tasks/install_digest_cm.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/install_digest_cm.yml
@@ -1,17 +1,86 @@
 ---
 
+# 1. Determine the version of the application operator that is running
+# -----------------------------------------------------------------------------
+- name: "Lookup Application operator version"
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v2
+    kind: OperatorCondition
+    namespace: "{{ mas_app_namespace }}"
+    label_selectors:
+      - "operators.coreos.com/ibm-mas-{{ mas_app_id }}.{{ mas_app_namespace }}"
+  register: app_opcon
+
+
+# 2. Fail if we can't find the OperatorCondition for the application
+# -----------------------------------------------------------------------------
+- name: "Check that the OperatorCondition was found"
+  assert:
+    that:
+      - app_opcon.resources is defined
+      - app_opcon.resources | length == 1
+      - app_opcon.resources[0].metadata.name is defined
+
+
+# 3. Set the application operator version
+# -----------------------------------------------------------------------------
+# OperatorCondition names are in the format {packageName}.{packageVersion}
+# We want to strip off the "v" prefix from the version while we do this
+- name: "Lookup operator version"
+  set_fact:
+    mas_app_operator_version: "{{ app_opcon.resources[0].metadata.name.split('.v')[1] }}"
+
+- name: Debug
+  debug:
+    msg:
+      - "Application operator condition ......... {{ app_opcon.resources[0].metadata.name }}"
+      - "Application operator version ........... {{ mas_app_operator_version }}"
+
+
+# 4. Create the Image Digest Map
+# -----------------------------------------------------------------------------
 - name: "Create ibm-mas-{{ mas_app_id }} Image Digest Map"
   include_role:
     name: ibm.mas_airgap.install_digest_cm
   vars:
     digest_image_map_namespace: "{{ mas_app_namespace }}"
     case_name: "ibm-mas-{{ mas_app_id }}"
-    case_version: "8.5.0" # TODO: Look this up from OperatorCondition (will only work for IoT at the moment)
+    case_version: "{{ mas_app_operator_version }}"
 
+
+# 5. Lookup the OperatorCondition for Truststore Manager
+# -----------------------------------------------------------------------------
+- name: "Lookup Truststore Manager operator version"
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v2
+    kind: OperatorCondition
+    namespace: "{{ mas_app_namespace }}"
+    label_selectors:
+      - "operators.coreos.com/ibm-truststore-mgr.{{ mas_app_namespace }}"
+  register: tsm_opcon
+
+
+# 6. If TSM is installed, determine at which version
+# -----------------------------------------------------------------------------
+- name: "Lookup Truststore Manager operator version"
+  when:
+    - tsm_opcon.resources is defined
+    - tsm_opcon.resources | length == 1
+    - tsm_opcon.resources[0].metadata.name is defined
+  set_fact:
+    tsm_operator_version: "{{ tsm_opcon.resources[0].metadata.name.split('.v')[1] }}"
+
+
+# 7. If TSM is installed, install it's digest map
+# -----------------------------------------------------------------------------
 - name: "Create ibm-truststore-mgr Image Digest Map"
+  when:
+    - tsm_opcon.resources is defined
+    - tsm_opcon.resources | length == 1
+    - tsm_opcon.resources[0].metadata.name is defined
   include_role:
     name: ibm.mas_airgap.install_digest_cm
   vars:
     digest_image_map_namespace: "{{ mas_app_namespace }}"
     case_name: ibm-truststore-mgr
-    case_version: "1.3.0" # TODO: Look this up from OperatorCondition
+    case_version: "{{ tsm_operator_version }}"

--- a/ibm/mas_devops/roles/suite_install/tasks/install_digest_cm.yml
+++ b/ibm/mas_devops/roles/suite_install/tasks/install_digest_cm.yml
@@ -1,17 +1,85 @@
 ---
+# 1. Determine the version of the application operator that is running
+# -----------------------------------------------------------------------------
+- name: "Lookup Application operator version"
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v2
+    kind: OperatorCondition
+    namespace: "{{ mas_namespace }}"
+    label_selectors:
+      - "operators.coreos.com/ibm-mas.{{ mas_namespace }}"
+  register: mas_opcon
 
+
+# 2. Fail if we can't find the OperatorCondition for the application
+# -----------------------------------------------------------------------------
+- name: "Check that the OperatorCondition was found"
+  assert:
+    that:
+      - mas_opcon.resources is defined
+      - mas_opcon.resources | length == 1
+      - mas_opcon.resources[0].metadata.name is defined
+
+
+# 3. Set the application operator version
+# -----------------------------------------------------------------------------
+# OperatorCondition names are in the format {packageName}.{packageVersion}
+# We want to strip off the "v" prefix from the version while we do this
+- name: "Lookup operator version"
+  set_fact:
+    mas_operator_version: "{{ mas_opcon.resources[0].metadata.name.split('.v')[1] }}"
+
+- name: Debug
+  debug:
+    msg:
+      - "MAS operator condition ................. {{ mas_opcon.resources[0].metadata.name }}"
+      - "MAS operator version ................... {{ mas_operator_version }}"
+
+
+# 4. Create the Image Digest Map
+# -----------------------------------------------------------------------------
 - name: "Create ibm-mas Image Digest Map"
   include_role:
     name: ibm.mas_airgap.install_digest_cm
   vars:
     digest_image_map_namespace: "{{ mas_namespace }}"
     case_name: ibm-mas
-    case_version: "8.8.0" # TODO: Look this up from OperatorCondition
+    case_version: "{{ mas_operator_version }}"
 
+
+# 5. Lookup the OperatorCondition for Truststore Manager
+# -----------------------------------------------------------------------------
+- name: "Lookup Truststore Manager operator version"
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v2
+    kind: OperatorCondition
+    namespace: "{{ mas_namespace }}"
+    label_selectors:
+      - "operators.coreos.com/ibm-truststore-mgr.{{ mas_namespace }}"
+  register: tsm_opcon
+
+
+# 6. If TSM is installed, determine at which version
+# -----------------------------------------------------------------------------
+- name: "Lookup Truststore Manager operator version"
+  when:
+    - tsm_opcon.resources is defined
+    - tsm_opcon.resources | length == 1
+    - tsm_opcon.resources[0].metadata.name is defined
+  set_fact:
+    tsm_operator_version: "{{ tsm_opcon.resources[0].metadata.name.split('.v')[1] }}"
+
+
+# 7. If TSM is installed, install it's digest map
+# -----------------------------------------------------------------------------
 - name: "Create ibm-truststore-mgr Image Digest Map"
+  when:
+    - tsm_opcon.resources is defined
+    - tsm_opcon.resources | length == 1
+    - tsm_opcon.resources[0].metadata.name is defined
   include_role:
     name: ibm.mas_airgap.install_digest_cm
   vars:
     digest_image_map_namespace: "{{ mas_namespace }}"
     case_name: ibm-truststore-mgr
-    case_version: "1.3.0" # TODO: Look this up from OperatorCondition
+    case_version: "{{ tsm_operator_version }}"


### PR DESCRIPTION
To move beyond supporting a single specific version of MAS in an offline/air gap/private registry installation we need to take advantage of the `OperatorCondition` resource to dynamically determine the version of the Operator that is installed, so that we can lay down the correct version of the image digest map that current MAS versions rely on for such support.  Future releases of MAS will eventaully no longer need this additional configmap to the installed, but until then this is essential to enable offline installations.