### PR TITLE
[patch] fix for wd instance name

### DIFF
--- a/ibm/mas_devops/roles/cp4d_service/defaults/main.yml
+++ b/ibm/mas_devops/roles/cp4d_service/defaults/main.yml
@@ -61,7 +61,8 @@ cpd_wsl_project_storage_guid: "{{ 1000 | random | to_uuid | lower }}"
 # ---------------------------------------------------------------------------------------------------------------------
 # A Watson Discovery instance will be set up for Assist per MAS instance
 # Note: This is only used when mas_instance_id and mas_config_dir are not empty string
-cpd_wd_instance_name: "{{ lookup('env', 'CPD_WD_INSTANCE_NAME') | default('wd-mas-{{ mas_instance_id }}-assist', true) }}"
+cpd_default_wd_instance_name: "wd-mas-{{ mas_instance_id }}-assist"
+cpd_wd_instance_name: "{{ lookup('env', 'CPD_WD_INSTANCE_NAME') | default(cpd_default_wd_instance_name, true) }}"
 
 # CPD Service Information
 # ---------------------------------------------------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/db2/defaults/main.yml
+++ b/ibm/mas_devops/roles/db2/defaults/main.yml
@@ -5,7 +5,7 @@ db2_namespace: db2u
 
 db2_instance_name: "{{ lookup('env', 'DB2_INSTANCE_NAME') }}" # e.g. db2u-iot or db2u-manage
 db2_dbname: "{{ lookup('env', 'DB2_DBNAME') | default('BLUDB', true) }}"
-db2_version: "{{ lookup('env', 'DB2_VERSION') | default('11.5.7.0-cn2', true)}}"
+db2_version: "{{ lookup('env', 'DB2_VERSION') | default('11.5.7.0-cn4', true)}}"
 db2_jdbc_username: db2inst1
 
 db2_table_org: "{{ lookup('env', 'DB2_TABLE_ORG') | default('ROW', true) }}" # e.g ROW or COLUMN


### PR DESCRIPTION
this is to fix a minor issue with the default name used for the provisioned wd instance:

<img width="344" alt="image" src="https://user-images.githubusercontent.com/31037381/183434354-49a098a9-1ce7-456b-b7bb-34e9a2e07b12.png">

also, updating the default db2 instance version to latest available