### PR TITLE
[minor] Catalog update for IoT airgap support fix

### DIFF
--- a/ibm/mas_devops/roles/ibm_catalogs/defaults/main.yml
+++ b/ibm/mas_devops/roles/ibm_catalogs/defaults/main.yml
@@ -7,5 +7,11 @@ artifactory_apikey: "{{ lookup('env', 'ARTIFACTORY_APIKEY') }}"
 
 mas_catalog_version: "{{ lookup('env', 'MAS_CATALOG_VERSION') | default ('v8', True) }}"
 mas_catalog_digests:
+  # 2022-07-17
   v8-220717: sha256:1222697802a54640bbfd5e5cc86716319ef5c440902da8227599c9a5fe28d7b8
   v8.8-220717: sha256:97163f6bb25658ef308fb5843406b779d03c09e520cc240ba2fcd13411189043
+  v8-220717-amd64: sha256:02db98338386f874dead37fb9a0b956fe59b851db09440e5523b634f7341e4bf
+  v8.8-220717-amd64: sha256:b126228c4ae7fc498e77386522c891a4449838ef256ca8571e750edd83e9958f
+  # 2022-08-05
+  v8-220805-amd64: sha256:012839d2dd801863b5a1f35de3d1e1e39d8e4a3e707f894beee091608c09aca4
+  v8.8-220805-amd64: sha256:1ad7d8e0bb826e77ced362cf99cf7e317d9acde58ebfcd3d0dd715b4644563c4


### PR DESCRIPTION
This update introduces the 220805 catalog source which provides bug fixes and security updates for `ibm-sls` and `ibm-mas-iot`.  The most significant update is that IoT should now be useable in an airgap environment with the 8.5.1 release.