### PR TITLE
[patch] Fix default catalog version/tag

### DIFF
--- a/ibm/mas_devops/roles/ibm_catalogs/defaults/main.yml
+++ b/ibm/mas_devops/roles/ibm_catalogs/defaults/main.yml
@@ -5,7 +5,7 @@
 artifactory_username: "{{ lookup('env', 'ARTIFACTORY_USERNAME') | lower }}"
 artifactory_apikey: "{{ lookup('env', 'ARTIFACTORY_APIKEY') }}"
 
-mas_catalog_version: "{{ lookup('env', 'MAS_CATALOG_VERSION') | default ('v8', True) }}"
+mas_catalog_version: "{{ lookup('env', 'MAS_CATALOG_VERSION') | default ('v8-amd64', True) }}"
 mas_catalog_digests:
   # 2022-07-17
   v8-220717: sha256:1222697802a54640bbfd5e5cc86716319ef5c440902da8227599c9a5fe28d7b8


### PR DESCRIPTION
We were still defaulting to the catalog with the `-amd64` arch suffix.