### PR TITLE
[patch] Fix certificate secret check for ROSA

### DIFF
--- a/ibm/mas_devops/common_tasks/get_ingress_cert.yml
+++ b/ibm/mas_devops/common_tasks/get_ingress_cert.yml
@@ -1,0 +1,113 @@
+---
+# 1. Lookup for router-certs-default secret
+# -----------------------------------------------------------------------------
+- name: Lookup for router-certs-default secret
+  no_log: true
+  k8s_info:
+    api_version: v1
+    kind: Secret
+    name: router-certs-default
+    namespace: openshift-ingress
+  register: router_certs_default_secret
+
+- name: "Record that we have found the router default cert secret"
+  when:
+    - router_certs_default_secret is defined
+    - router_certs_default_secret.resources | length > 0
+  set_fact:
+    found_router_default_secret: true
+    cluster_ingress_secret_name: router-certs-default
+    cluster_ingress_tls_crt: "{{ router_certs_default_secret.data['tls.crt'] | b64decode }}"
+
+
+# 2. Lookup for secret named after cluster ingress
+# -----------------------------------------------------------------------------
+- name: Get cluster subdomain
+  when: found_router_default_secret is not defined
+  kubernetes.core.k8s_info:
+    api_version: config.openshift.io/v1
+    kind: Ingress
+    name: cluster
+  register: cluster_subdomain
+
+- name: Lookup for cluster ingress secret
+  when:
+    - found_router_default_secret is not defined
+    - cluster_subdomain.resources is defined
+    - cluster_subdomain.resources | length > 0
+  no_log: true
+  k8s_info:
+    api_version: v1
+    kind: Secret
+    name: "{{ cluster_subdomain.resources[0].spec.domain | regex_search('[^.]*')  }}"
+    namespace: openshift-ingress
+  register: cluster_ingress_secret
+
+- name: "Record that we have found the cluster ingress cert secret"
+  when:
+    - found_router_default_secret is not defined
+    - cluster_ingress_secret is defined
+    - cluster_ingress_secret.resources | length > 0
+  set_fact:
+    found_cluster_ingress_secret: true
+    cluster_ingress_secret_name: "{{ cluster_subdomain.resources[0].spec.domain | regex_search('[^.]*')  }}"
+    cluster_ingress_tls_crt: "{{ cluster_ingress_secret.data['tls.crt'] | b64decode }}"
+
+
+# 3. Lookup for secret based on the cluster name
+# -----------------------------------------------------------------------------
+# ROSA uses this convention
+- name: Get all TLS secrets
+  when:
+    - found_router_default_secret is not defined
+    - found_cluster_ingress_secret is not defined
+  k8s_info:
+    api_version: v1
+    kind: Secret
+    namespace: openshift-ingress
+    field_selectors:
+      - type=kubernetes.io/tls
+  register: cluster_primary_secrets
+
+- name: "Find Cluster Primary Secret"
+  when:
+    - found_router_default_secret is not defined
+    - found_cluster_ingress_secret is not defined
+    - cluster_primary_secrets is defined
+    - cluster_primary_secrets.resources is defined
+    - cluster_primary_secrets.resources | length > 0
+    - item.metadata.name.endswith("-primary-cert-bundle-secret")
+  set_fact:
+    found_cluster_primary_secret: true
+    cluster_ingress_secret_name: "{{ item.metadata.name }}"
+    cluster_ingress_tls_crt: "{{ item.data['tls.crt'] | b64decode }}"
+  with_items:
+    - "{{ cluster_primary_secrets.resources }}"
+  loop_control:
+    label: "{{ item.metadata.name }}"
+
+
+# 4. Log which (if any) secret was found
+# -----------------------------------------------------------------------------
+# If at least one of the secrets exist, then all good.  If none of the
+# secrets are found, then fail with a message
+
+- name: "Debug cluster certificate secret search"
+  debug:
+    msg:
+       - "Found Router Default Secret ........... {{ found_router_default_secret | default(False, True) }}"
+       - "Found Cluster Ingress Secret .......... {{ found_cluster_ingress_secret | default(False, True) }}"
+       - "Found Cluster Primary Secret .......... {{ found_cluster_primary_secret | default(False, True) }}"
+       - "Cluster Ingress Cert Secret Name ...... {{ cluster_ingress_secret_name | default('missing', True) }}"
+       - "Cluster Ingress Cert .................. {{ cluster_ingress_tls_crt | default('missing', True) }}"
+
+
+# COS and UDS roles both require one of these secrets ... can we fix it so that
+# they don't, not sure why they can't create their own certs and need to
+# piggyback off the cluster cert tbh.
+- name: Fail if one of the cluster required secrets does not exist
+  assert:
+    that:
+      - cluster_ingress_secret_name is defined
+      - cluster_ingress_tls_crt is defined
+    fail_msg: "This cluster does not contain any of the secrets known to contain the TLS certificate for the cluster ingress."

--- a/ibm/mas_devops/roles/cos/tasks/providers/ocs.yml
+++ b/ibm/mas_devops/roles/cos/tasks/providers/ocs.yml
@@ -1,5 +1,5 @@
 ---
-# 0. Check if the ocs is installed
+# 1. Check if the ocs is installed
 # ----------------------------------------------------------------------------
 - name: "Get OCS cluster "
   kubernetes.core.k8s_info:
@@ -23,7 +23,8 @@
     msg:
       - "OCS Cluster is available .... {{ ocsavailable }}"
 
-# 1. Create the object store
+
+# 2. Create the object store
 # -----------------------------------------------------------------------------
 - name: "ocs/objectstorage : Create objectstore in OSC Cluster"
   when: ocsavailable is defined and ocsavailable
@@ -31,7 +32,8 @@
     apply: yes
     definition: "{{ lookup('template', 'templates/ocs/object.yaml') }}"
 
-# 2. Create the object User
+
+# 3. Create the object User
 # -----------------------------------------------------------------------------
 - name: "ocs/objectstorage : Create objectstore User"
   when: ocsavailable is defined and ocsavailable
@@ -50,7 +52,8 @@
   retries: 10 # Approximately 10 minutes before we give up
   delay: 60 # 1 minute
 
-# 3. Set up the domain name for object storage route
+
+# 4. Set up the domain name for object storage route
 # -----------------------------------------------------------------------------
 - name: "ocs/objectstorage :Get cluster subdomain"
   when: ocsavailable is defined and ocsavailable
@@ -65,7 +68,8 @@
   set_fact:
     cos_domain: "rgw-openshift-storage.{{ _cluster_subdomain.resources[0].spec.domain }}"
 
-# 4. Create route for cos
+
+# 5. Create route for cos
 # -----------------------------------------------------------------------------
 - name: "ocs/objectstorage : Create objectstore route"
   when: ocsavailable is defined and ocsavailable
@@ -73,8 +77,9 @@
     apply: yes
     definition: "{{ lookup('template', 'templates/ocs/rgw.yaml') }}"
 
-## 4. Query the object User crdential
-## -----------------------------------------------------------------------------
+
+# 6. Query the object User crdential
+# -----------------------------------------------------------------------------
 - name: "ocs/objectstorage :Lookup if cos user secret is there"
   when: ocsavailable is defined and ocsavailable
   kubernetes.core.k8s_info:
@@ -85,30 +90,29 @@
   register: objectuserSecret
 
 
-## 5. Query the tls for object route
-## -----------------------------------------------------------------------------
-- name: "ocs/objectstorage :Lookup cos route tls secret"
-  when: ocsavailable is defined and ocsavailable
-  kubernetes.core.k8s_info:
-    api_version: v1
-    kind: Secret
-    name: "router-certs-default"
-    namespace: "openshift-ingress"
-  register: objectrouteSecret
+# 7. Query the tls for object route
+# -----------------------------------------------------------------------------
+- name: "ocs/objectstorage : Lookup the default cluster ingress secret"
+  include_tasks: "{{ role_path }}/../../common_tasks/get_ingress_cert.yml"
+
+# Not sure why we do this manipulation on the certificate content, whoever wrote
+# this originally should really have put a comment in here explaining why this
+# is necessary :)
+- name: "ocs/objectstorage : Set COS cert variable"
+  set_fact:
+    ocscos_certs: "{{ cluster_ingress_tls_crt | regex_findall('(-----BEGIN .+?-----(?s).+?-----END .+?-----)', multiline=True, ignorecase=True) }}"
 
 - name: "ocs/objectstorage :Query cos secret based on existing secret/cm"
   when:
     - ocsavailable is defined and ocsavailable
     - objectuserSecret.resources| length != 0
-    - objectrouteSecret.resources| length != 0
   set_fact:
     ocscos_url: "https://{{ cos_domain }}"
     ocscos_username: "{{ objectuserSecret.resources[0]['data']['AccessKey']| b64decode }}"
     ocscos_password: "{{ objectuserSecret.resources[0]['data']['SecretKey']| b64decode }}"
-    ocscos_certs: "{{ objectrouteSecret.resources[0]['data']['tls.crt'] | b64decode | regex_findall('(-----BEGIN .+?-----(?s).+?-----END .+?-----)', multiline=True, ignorecase=True)  }}"
 
 
-# 6. Provide debug information and create coscfg.yml
+# 8. Provide debug information and create coscfg.yml
 # -----------------------------------------------------------------------------
 - name: "ocs/objectstorage : Debug information"
   block:
@@ -124,7 +128,7 @@
         msg: "we didn't get the cos info xhere in ocs cluster."
 
 
-# 7. Write ObjectStorageCfg to disk
+# 9. Write ObjectStorageCfg to disk
 # -----------------------------------------------------------------------------
 - name: "ocs/objectstorage : Copy objectstorageCfg to filesytem"
   when:

--- a/ibm/mas_devops/roles/cos/tasks/providers/ocs.yml
+++ b/ibm/mas_devops/roles/cos/tasks/providers/ocs.yml
@@ -125,7 +125,7 @@
   rescue:
     - name: Fail as we didn't get the cos info in ocs cluster.
       fail:
-        msg: "we didn't get the cos info xhere in ocs cluster."
+        msg: "we didn't get the cos info here in ocs cluster."
 
 
 # 9. Write ObjectStorageCfg to disk

--- a/ibm/mas_devops/roles/ocp_verify/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_verify/tasks/main.yml
@@ -2,8 +2,7 @@
 # 1. Check for the Red Hat Catalog Source
 # -----------------------------------------------------------------------------
 # In IBMCloud ROKS we have seen delays of over an hour before the catalog is
-# ready to use.  This will cause attempts to install e.g. SBO from OperatorHub
-# to fail
+# ready to use.
 - name: Check if Red Hat Catalog is ready
   kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
@@ -22,88 +21,5 @@
 
 # 2. Check for router and ingress secrets
 # -----------------------------------------------------------------------------
-# We don't know why but sometimes the name of the secret will be
-# "router-certs-default" and sometimes it will be named after the cluster's ingress
-# cluster must have at least one of these secrets to run the playbooks from this collection
-
-# 2.1 First lookup for router-certs-default secret
-- name: Lookup for router-certs-default secret
-  no_log: true
-  k8s_info:
-    api_version: v1
-    kind: Secret
-    name: router-certs-default
-    namespace: openshift-ingress
-  register: router_certs_default_secret
-
-- name: "Record that we have found the router default cert secret"
-  when:
-    - router_certs_default_secret is defined
-    - router_certs_default_secret.resources | length > 0
-  set_fact:
-    found_router_default_secret: true
-
-# 2.2. If router-certs-default does not exist, lookup for secret named after cluster ingress
-- name: Get cluster subdomain
-  when: found_router_default_secret is not defined
-  kubernetes.core.k8s_info:
-    api_version: config.openshift.io/v1
-    kind: Ingress
-    name: cluster
-  register: cluster_subdomain
-
-- name: Lookup for cluster ingress secret
-  when:
-    - found_router_default_secret is not defined
-    - cluster_subdomain.resources is defined
-    - cluster_subdomain.resources | length > 0
-  no_log: true
-  k8s_info:
-    api_version: v1
-    kind: Secret
-    name: "{{ cluster_subdomain.resources[0].spec.domain | regex_search('[^.]*')  }}"
-    namespace: openshift-ingress
-  register: cluster_ingress_secret
-
-- name: "Record that we have found the cluster ingress cert secret"
-  when:
-    - found_router_default_secret is not defined
-    - cluster_ingress_secret is defined
-    - cluster_ingress_secret.resources | length > 0
-  set_fact:
-    found_cluster_ingress_secret: true
-
-# 2.3.  If that does not exist either, lookup for secret based on the cluster name
-- name: Get cluster subdomain
-  when:
-    - found_router_default_secret is not defined
-    - found_cluster_ingress_secret is not defined
-    - cluster_name is defined and cluster_name != ""
-  k8s_info:
-    api_version: v1
-    kind: Secret
-    name: "{{ cluster_name }}-primary-cert-bundle-secret"
-    namespace: openshift-ingress
-  register: cluster_primary_secret
-
-- name: "Record that we have found the cluster primary cert secret"
-  when:
-    - found_router_default_secret is not defined
-    - found_cluster_ingress_secret is not defined
-    - cluster_primary_secret is defined
-    - cluster_primary_secret.resources | length > 0
-  set_fact:
-    found_cluster_primary_secret: true
-
-# 3. Determine which secret was found
-# -----------------------------------------------------------------------------
-# If at least one of the secrets exist, then all good.  If neither of the
-# secrets are found, then fail with a message
-
-# COS and UDS roles both require one of these secrets ... can we fix it so that
-# they don't, not sure why they can't create their own certs and need to
-# piggyback off the cluster cert tbh.
-- name: Fail if one of the cluster required secrets does not exist
-  assert:
-    that: found_router_default_secret is defined or found_cluster_ingress_secret is defined or found_cluster_primary_secret is defined
-    fail_msg: "This cluster does not contain any of the secrets known to contain the TLS certificate for the cluster ingress."
+- name: "Lookup the default cluster ingress secret"
+  include_tasks: "{{ role_path }}/../../common_tasks/get_ingress_cert.yml"

--- a/ibm/mas_devops/roles/uds/tasks/install/udscfg.yml
+++ b/ibm/mas_devops/roles/uds/tasks/install/udscfg.yml
@@ -53,82 +53,18 @@
 
 # 4. Lookup the certificates
 # -----------------------------------------------------------------------------
-# We don't know why but sometimes the name of the secret will be
-# "router-certs-default" and sometimes it will be named after the domain of
-# the cluster (e.g. fvtstable-6f1620198115433da1cac8216c06779b-0000)
+- name: "udscfg : Lookup the default cluster ingress secret"
+  include_tasks: "{{ role_path }}/../../common_tasks/get_ingress_cert.yml"
 
-# 4.1 First, attempt to get the router-certs-default secret
-- name: "udscfg : Lookup Certificate for UDS (default)"
-  no_log: true
-  k8s_info:
-    api_version: v1
-    kind: Secret
-    name: router-certs-default
-    namespace: openshift-ingress
-  register: uds_certificate_lookup
-
-# 4.2 If it does exist, then use it
-- name: "udscfg : Generate router secret name from the cluster subdomain"
-  when:
-    - uds_certificate_lookup.resources is defined
-    - uds_certificate_lookup.resources | length == 1
+# Not sure why we do this manipulation on the certificate content, whoever wrote
+# this originally should really have put a comment in here explaining why this
+# is necessary :)
+- name: "udscfg : Set UDS cert variable"
   set_fact:
-    uds_tls_crt: "{{ uds_certificate_lookup.resources[0].data['tls.crt'] | b64decode | regex_findall('(-----BEGIN .+?-----(?s).+?-----END .+?-----)', multiline=True, ignorecase=True) }}"
-
-# 4.3 If it does not exist, then perform a second lookup for the custom secret
-- name: "udscfg : Get cluster subdomain"
-  kubernetes.core.k8s_info:
-    api_version: config.openshift.io/v1
-    kind: Ingress
-    name: cluster
-  register: cluster_subdomain
-
-- name: "udscfg : Lookup Certificate for UDS (custom)"
-  no_log: true
-  k8s_info:
-    api_version: v1
-    kind: Secret
-    name: "{{ cluster_subdomain.resources[0].spec.domain | regex_search('[^.]*')  }}"
-    namespace: openshift-ingress
-  register: uds_certificate_lookup
-
-- name: "udscfg : Debug cert lookup result"
-  debug:
-    msg:
-      - "UDS Certificate Lookup ................. {{ uds_certificate_lookup }}"
-
-# 4.4 If it does exist, then use it
-- name: "udscfg : Generate router secret name from the cluster subdomain"
-  when:
-    - uds_certificate_lookup.resources is defined
-    - uds_certificate_lookup.resources | length == 1
-  set_fact:
-    uds_tls_crt: "{{ uds_certificate_lookup.resources[0].data['tls.crt'] | b64decode | regex_findall('(-----BEGIN .+?-----(?s).+?-----END .+?-----)', multiline=True, ignorecase=True) }}"
-
-- name: "udscfg : Lookup Certificate for UDS (ROSA)"
-  k8s_info:
-    api_version: v1
-    kind: Secret
-    name: "{{ cluster_name }}-primary-cert-bundle-secret"
-    namespace: openshift-ingress
-  register: uds_certificate_lookup
-
-# 4.5 If we have a lookup result (last step wasn't skipped) and we haven't already set the crt variable, then set it now
-- name: "udscfg : Generate router secret name from the cluster subdomain"
-  when:
-    - uds_certificate_lookup.resources is defined
-    - uds_certificate_lookup.resources | length == 1
-  set_fact:
-    uds_tls_crt: "{{ uds_certificate_lookup.resources[0].data['tls.crt'] | b64decode | regex_findall('(-----BEGIN .+?-----(?s).+?-----END .+?-----)', multiline=True, ignorecase=True) }}"
-
-# 4.6 If uds_tls_crt is still unset, then we've failed
-- name: "udscfg : Fail if we can't find the secret containing the UDS certificates"
-  assert:
-    that: uds_tls_crt is defined
-    fail_msg: "Failed looking up secret containing UDS certificates from the default or custom router certificates secret"
+    uds_tls_crt: "{{ cluster_ingress_tls_crt | regex_findall('(-----BEGIN .+?-----(?s).+?-----END .+?-----)', multiline=True, ignorecase=True) }}"
 
 
-# 5 Debug
+# 5. Debug
 # -----------------------------------------------------------------------------
 - name: "udscfg : Debug generated config"
   debug:


### PR DESCRIPTION
The cluster ingress certificate lookup doesn't work on ROSA.  This PR fixes that while centralizing the fixed logic for looking up the ingress cert secret.

```
TASK [ocp_verify : Debug cluster certificate secret search] *****************************************************************************************************************************************************************************************************************Friday 19 August 2022  12:47:16 +0100 (0:00:00.057)       0:00:04.883 *********
ok: [localhost] => {
    "msg": [
        "Found Router Default Secret ........... False",
        "Found Cluster Ingress Secret .......... False",
        "Found Cluster Primary Secret .......... True",
        "Cluster Ingress Cert Secret Name ...... djprosa1-primary-cert-bundle-secret",
        "Cluster Ingress Cert .................. -----BEGIN CERTIFICATE-----\nMIIFqzCCBJOgAwIBAgISBMPMPNhD/sT1qATKfhG46oSRMA0GCSqGSIb3DQEBCwUA\nMDIxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MQswCQYDVQQD\nEwJSMzAeFw0yMjA4MDQwOTQ<snip>d5JW1zbVWEkLNxE7GJThEUG3szgBVGP7pSWTUTsqX\nnLRbwHOoq7hHwg==\n-----END CERTIFICATE-----\n"
    ]
}

TASK [ocp_verify : Fail if one of the cluster required secrets does not exist] **********************************************************************************************************************************************************************************************Friday 19 August 2022  12:47:16 +0100 (0:00:00.040)       0:00:04.924 *********
ok: [localhost] => {
    "changed": false,
    "msg": "All assertions passed"
}
```