### PR TITLE
[patch] Correct support versions of IBM App Connect

### DIFF
--- a/ibm/mas_devops/roles/appconnect/README.md
+++ b/ibm/mas_devops/roles/appconnect/README.md
@@ -14,31 +14,31 @@ Optional - Defines the targetted cluster namespace/project where AppConnect will
 - Default Value: `ibm-app-connect`
 
 ### appconnect_channel
-Optional - AppConnect subscription channel to be installed. For MAS 8.7, default `v3.0` channel is used. Ensure the supported dashboard version and license ID according to the AppConnect operator/channel version.
+Optional - AppConnect subscription channel to be installed.
+Ensure the supported dashboard version and license ID according to the AppConnect operator/channel version.
 
-- MAS 8.4 uses AppConnect channel subscription v1.4 and license id = L-APEH-BSVCHU
-- MAS 8.5 uses AppConnect channel subscription v2.0 and license id = L-KSBM-BZWEAT
 - MAS 8.6 uses AppConnect channel subscription v2.0 and license id = L-KSBM-C37J2R
 - MAS 8.7 uses AppConnect channel subscription v3.0 and license id = L-KSBM-C87FU2
+- MAS 8.8 uses AppConnect channel subscription v4.2 and license id = L-APEH-C9NCK6
 
 For more details: https://www.ibm.com/support/knowledgecenter/SSTTDS_11.0.0/com.ibm.ace.icp.doc/certc_licensingreference.html
 
 - Environment Variable: `APPCONNECT_CHANNEL`
-- Default Value: `v3.0`
+- Default Value: `v4.2`
 
 ### appconnect_dashboard_name
-Optional - AppConnect Dashboard instance name. Default to `dashboard-12020r2` as a reference to AppConnect Dashboard version `12.0.2.0-r2` that is compatible with AppConnect Channel subscription `v3.0` and license ID `L-KSBM-C87FU2` (MAS 8.7 compatible)
+Optional - AppConnect Dashboard instance name. Default to `dashboard-12040r2` as a reference to AppConnect Dashboard version `12.0.4.0-r2` that is compatible with AppConnect Channel subscription `v4.2` and license ID `L-APEH-C9NCK6` (MAS 8.8 compatible)
 
 For More details: https://www.ibm.com/docs/en/app-connect/containers_cd?topic=resources-licensing-reference-app-connect-operator
 
 - Environment Variable: `APPCONNECT_DASHBOARD_NAME`
-- Default Value: `dashboard-12020r2`
+- Default Value: `dashboard-12040r2`
 
 ### appconnect_license_id
 Optional - AppConnect license ID.
 
 - Environment Variable: `APPCONNECT_LICENSE_ID`
-- Default Value: `L-KSBM-C87FU2` (Which is compatible with AppConnect `v3.0` operator/channel)
+- Default Value: `L-KSBM-C9NCK6` (Which is compatible with AppConnect `v4.2` operator/channel)
 
 ### appconnect_storage_class
 Required - Storage class where AppConnect will be installed - for IBM Cloud clusters, `ibmc-file-gold-gid` must be used as per [documentation](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=resources-dashboard-reference#storage).

--- a/ibm/mas_devops/roles/appconnect/README.md
+++ b/ibm/mas_devops/roles/appconnect/README.md
@@ -1,77 +1,97 @@
 appconnect
-==========
+===============================================================================
 
-Installs **IBM AppConnect** on IBM Cloud Openshift Clusters (ROKS) and generates configuration that can be directly applied to IBM Maximo Application Suite.
-This dependency is required by HP Utilities application.
+Installs **IBM AppConnect** and generates configuration that can be directly applied to IBM Maximo Application Suite.
 
-Role Variables
---------------
+This dependency is required by the Health and Predict Utilities application:
+
+- HP Utilities v8.4 requires support for `12.0.4.0-r2` AppConnect dashboards (License ID `L-APEH-C9NCK6`)
+- HP Utilities v8.3 requires support for `12.0.2.0-r2` AppConnect dashboards (License ID `L-KSBM-C87FU2`)
+- HP Utilities v8.2 requires support for `12.0.1.0-r2` AppConnect dashboards (license ID `L-KSBM-C37J2R`)
+
+| HP Utilities | AppConnect   | License       | Dashboard Versions       |
+| ------------ | ------------ | ------------- | ------------------------ |
+| v8.4         | v4.1 - v5.2  | L-APEH-C9NCK6 | 12.0.4.0-r1, 12.0.4.0-r2 |
+| v8.3         | v3.0 - v4.2  | L-KSBM-C87FU2 | 12.0.2.0-r2              |
+| v8.2         | v1.5 - v3.1  | L-KSBM-C37J2R | 12.0.1.0-r1, 12.0.1.0-r2 |
+
+All defaults in this role are currently set for compatability with HP Utilities version 8.4.  For more information review the [licensing reference for IBM App Connect Operator](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=resources-licensing-reference-app-connect-operator).
+
+
+Role Variables - Installation
+-------------------------------------------------------------------------------
+### ibm_entitlement_key
+Provide your [IBM entitlement key](https://myibm.ibm.com/products-services/containerlibrary).
+
+- **Required**
+- Environment Variable: `IBM_ENTITLEMENT_KEY`
+- Default: None
+
+### appconnect_entitlement_username
+An IBM entitlement key specific for AppConnect installation, primarily used to override `ibm_entitlement_key` in development.
+
+- Optional
+- Environment Variable: `APPCONNECT_ENTITLEMENT_USERNAME`
+- Default: None
 
 ### appconnect_namespace
-Optional - Defines the targetted cluster namespace/project where AppConnect will be installed. If not provided, default AppConnect namespace will be `ibm-app-connect`.
+Defines the targetted cluster namespace/project where AppConnect will be installed. If not provided, default AppConnect namespace will be `ibm-app-connect`.
 
+- Optional
 - Environment Variable: `APPCONNECT_NAMESPACE`
 - Default Value: `ibm-app-connect`
 
 ### appconnect_channel
-Optional - AppConnect subscription channel to be installed.
-Ensure the supported dashboard version and license ID according to the AppConnect operator/channel version.
+Subscription channel, this must align with the version of HP Utilities (see table above).
 
-- MAS 8.6 uses AppConnect channel subscription v2.0 and license id = L-KSBM-C37J2R
-- MAS 8.7 uses AppConnect channel subscription v3.0 and license id = L-KSBM-C87FU2
-- MAS 8.8 uses AppConnect channel subscription v4.2 and license id = L-APEH-C9NCK6
-
-For more details: https://www.ibm.com/support/knowledgecenter/SSTTDS_11.0.0/com.ibm.ace.icp.doc/certc_licensingreference.html
-
+- Optional
 - Environment Variable: `APPCONNECT_CHANNEL`
-- Default Value: `v4.2`
+- Default Value: `v5.2`
+
+
+Role Variables - Configuration
+-------------------------------------------------------------------------------
+### appconnect_storage_class
+Storage class where AppConnect will be installed - for IBM Cloud clusters, `ibmc-file-gold-gid` must be used as per [documentation](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=resources-dashboard-reference#storage).
+
+- **Required**
+- Environment Variable: `APPCONNECT_STORAGE_CLASS`
+- Default Value: None
 
 ### appconnect_dashboard_name
-Optional - AppConnect Dashboard instance name. Default to `dashboard-12040r2` as a reference to AppConnect Dashboard version `12.0.4.0-r2` that is compatible with AppConnect Channel subscription `v4.2` and license ID `L-APEH-C9NCK6` (MAS 8.8 compatible)
+AppConnect dashboard instance name. Defaults to `dashboard-12040r2` as a reference to AppConnect Dashboard version `12.0.4.0-r2` that is compatible with the default subscription channel and license ID.
 
-For More details: https://www.ibm.com/docs/en/app-connect/containers_cd?topic=resources-licensing-reference-app-connect-operator
-
+- Optional
 - Environment Variable: `APPCONNECT_DASHBOARD_NAME`
 - Default Value: `dashboard-12040r2`
 
 ### appconnect_license_id
-Optional - AppConnect license ID.
+AppConnect license ID.
 
+- Optional
 - Environment Variable: `APPCONNECT_LICENSE_ID`
-- Default Value: `L-KSBM-C9NCK6` (Which is compatible with AppConnect `v4.2` operator/channel)
+- Default Value: `L-KSBM-C37J2R`
 
-### appconnect_storage_class
-Required - Storage class where AppConnect will be installed - for IBM Cloud clusters, `ibmc-file-gold-gid` must be used as per [documentation](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=resources-dashboard-reference#storage).
 
-- Environment Variable: `APPCONNECT_STORAGE_CLASS`
-- Default Value: None
-
-### appconnect_entitlement_username
-Optional - Holds your IBM Entitlement username.
-
-- Environment Variable: `APPCONNECT_ENTITLEMENT_USERNAME`
-- Default Value: `cp`
-
-### appconnect_entitlement_key
-Required - Holds your IBM Entitlement key.
-
-- Environment Variable: `APPCONNECT_ENTITLEMENT_KEY`
-- Default Value: None
-
+Role Variables - MAS Configuration
+-------------------------------------------------------------------------------
 ### mas_instance_id
-Optional - The instance ID of Maximo Application Suite that the AppConnect configuration will target.  If this or `mas_config_dir` are not set then the role will not generate an AppConnect template.
+The instance ID of Maximo Application Suite that the AppConnect configuration will target.  If this or `mas_config_dir` are not set then the role will not generate an AppConnect template.
 
+- Optional
 - Environment Variable: `MAS_INSTANCE_ID`
 - Default Value: None
 
 ### mas_config_dir
-Optional - Local directory to save the generated AppConnect resource definition.  This can be used to manually configure a MAS instance to connect to AppConnect instance, or used as an input to the [suite_config](suite_config.md) role. If this or `mas_instance_id` are not set then the role will not generate an AppConnect template.
+Local directory to save the generated AppConnect resource definition.  This can be used to manually configure a MAS instance to connect to AppConnect instance, or used as an input to the [suite_config](suite_config.md) role. If this or `mas_instance_id` are not set then the role will not generate an AppConnect template.
 
+- Optional
 - Environment Variable: `MAS_CONFIG_DIR`
 - Default Value: None
 
+
 Example Playbook
-----------------
+-------------------------------------------------------------------------------
 
 ```yaml
 - hosts: localhost
@@ -81,6 +101,6 @@ Example Playbook
 ```
 
 License
--------
+-------------------------------------------------------------------------------
 
 EPL-2.0

--- a/ibm/mas_devops/roles/appconnect/README.md
+++ b/ibm/mas_devops/roles/appconnect/README.md
@@ -15,7 +15,10 @@ This dependency is required by the Health and Predict Utilities application:
 | v8.3         | v3.0 - v4.2  | L-KSBM-C87FU2 | 12.0.2.0-r2              |
 | v8.2         | v1.5 - v3.1  | L-KSBM-C37J2R | 12.0.1.0-r1, 12.0.1.0-r2 |
 
-All defaults in this role are currently set for compatability with HP Utilities version 8.4.  For more information review the [licensing reference for IBM App Connect Operator](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=resources-licensing-reference-app-connect-operator).
+For more information review the [licensing reference for IBM App Connect Operator](https://www.ibm.com/docs/en/app-connect/containers_cd?topic=resources-licensing-reference-app-connect-operator).
+
+!!! important
+    All defaults in this role are currently set for compatability with HP Utilities version 8.4.  If you are installing App Connect for use with older release of HP Utilities then you must set the `appconnect_channel` and `appconnect_license_id` variables (and it would be sensible to customize `appconnect_dashboard_name` as well).
 
 
 Role Variables - Installation
@@ -90,14 +93,31 @@ Local directory to save the generated AppConnect resource definition.  This can 
 - Default Value: None
 
 
-Example Playbook
+Example Playbooks
 -------------------------------------------------------------------------------
-
+### Install IBM App Connect for the latest release of HP Utilties (v8.4)
 ```yaml
 - hosts: localhost
   any_errors_fatal: true
+  vars:
+    ibm_entitlement_key: xxx
   roles:
-  - ibm.mas_devops.appconnect
+    - ibm.mas_devops.ibm_catalogs
+    - ibm.mas_devops.appconnect
+```
+
+### Install IBM App Connect for HP Utilties v8.3
+```yaml
+- hosts: localhost
+  any_errors_fatal: true
+  vars:
+    ibm_entitlement_key: xxx
+    appconnect_channel: v4.2
+    appconnect_license_id: L-KSBM-C87FU2
+    appconnect_dashboard_name: dashboard-12020r2
+  roles:
+    - ibm.mas_devops.ibm_catalogs
+    - ibm.mas_devops.appconnect
 ```
 
 License

--- a/ibm/mas_devops/roles/appconnect/defaults/main.yml
+++ b/ibm/mas_devops/roles/appconnect/defaults/main.yml
@@ -7,7 +7,7 @@
 appconnect_namespace: "{{ lookup('env', 'APPCONNECT_NAMESPACE') | default('ibm-app-connect', true) }}"
 appconnect_channel: "{{ lookup('env', 'APPCONNECT_CHANNEL') | default('v4.2', true) }}"
 appconnect_dashboard_name: "{{ lookup('env', 'APPCONNECT_DASHBOARD_NAME') | default('dashboard-12040r2', true) }}"
-appconnect_license_id: "{{ lookup('env', 'APPCONNECT_DASHBOARD_NAME') | default('L-APEH-C9NCK6', true) }}"
+appconnect_license_id: "{{ lookup('env', 'APPCONNECT_LICENSE_ID') | default('L-APEH-C9NCK6', true) }}"
 appconnect_storage_class: "{{ lookup('env', 'APPCONNECT_STORAGE_CLASS') }}"
 
 # IBM entitlement key for AppConnect

--- a/ibm/mas_devops/roles/appconnect/defaults/main.yml
+++ b/ibm/mas_devops/roles/appconnect/defaults/main.yml
@@ -1,15 +1,13 @@
 ---
-# MAS 8.4 uses AppConnect channel subscription v1.4 and license id = L-APEH-BSVCHU
-# MAS 8.5 uses AppConnect channel subscription v2.0 and license id = L-KSBM-BZWEAT
 # MAS 8.6 uses AppConnect channel subscription v2.0 and license id = L-KSBM-C37J2R
 # MAS 8.7 uses AppConnect channel subscription v3.0 and license id = L-KSBM-C87FU2
+# MAS 8.8 uses AppConnect channel subscription v4.2 and license id = L-APEH-C9NCK6
 
-# Define where AppConnect will be installed
+# Define where AppConnect will be installed, the default values below
 appconnect_namespace: "{{ lookup('env', 'APPCONNECT_NAMESPACE') | default('ibm-app-connect', true) }}"
-# v3.0 channel is used in MAS 8.7, v2.0 channel is used in older MAS versions
-appconnect_channel: "{{ lookup('env', 'APPCONNECT_CHANNEL') | default('v3.0', true) }}"
-appconnect_dashboard_name: "{{ lookup('env', 'APPCONNECT_DASHBOARD_NAME') | default('dashboard-12020r2', true) }}"
-appconnect_license_id: "{{ lookup('env', 'APPCONNECT_DASHBOARD_NAME') | default('L-KSBM-C87FU2', true) }}"
+appconnect_channel: "{{ lookup('env', 'APPCONNECT_CHANNEL') | default('v4.2', true) }}"
+appconnect_dashboard_name: "{{ lookup('env', 'APPCONNECT_DASHBOARD_NAME') | default('dashboard-12040r2', true) }}"
+appconnect_license_id: "{{ lookup('env', 'APPCONNECT_DASHBOARD_NAME') | default('L-APEH-C9NCK6', true) }}"
 appconnect_storage_class: "{{ lookup('env', 'APPCONNECT_STORAGE_CLASS') }}"
 
 # IBM entitlement key for AppConnect

--- a/ibm/mas_devops/roles/appconnect/defaults/main.yml
+++ b/ibm/mas_devops/roles/appconnect/defaults/main.yml
@@ -1,11 +1,23 @@
 ---
-# MAS 8.6 uses AppConnect channel subscription v2.0 and license id = L-KSBM-C37J2R
-# MAS 8.7 uses AppConnect channel subscription v3.0 and license id = L-KSBM-C87FU2
-# MAS 8.8 uses AppConnect channel subscription v4.2 and license id = L-APEH-C9NCK6
+# We don't actually use this dictionary today, but in a future release we should simply pass in the version
+# of HP Utilities and key off this instead.
+appconnect_defaults:
+  8.4.x:
+    channel: v5.2
+    license: L-APEH-C9NCK6
+    dashboard: dashboard-12040r2
+  8.3.x:
+    channel: v4.2
+    license: L-KSBM-C87FU2
+    dashboard: dashboard-12020r2
+  8.2.x:
+    channel: v3.1
+    license: L-KSBM-C37J2R
+    dashboard: dashboard-12010r2
 
 # Define where AppConnect will be installed, the default values below
 appconnect_namespace: "{{ lookup('env', 'APPCONNECT_NAMESPACE') | default('ibm-app-connect', true) }}"
-appconnect_channel: "{{ lookup('env', 'APPCONNECT_CHANNEL') | default('v4.2', true) }}"
+appconnect_channel: "{{ lookup('env', 'APPCONNECT_CHANNEL') | default('v5.2', true) }}"
 appconnect_dashboard_name: "{{ lookup('env', 'APPCONNECT_DASHBOARD_NAME') | default('dashboard-12040r2', true) }}"
 appconnect_license_id: "{{ lookup('env', 'APPCONNECT_LICENSE_ID') | default('L-APEH-C9NCK6', true) }}"
 appconnect_storage_class: "{{ lookup('env', 'APPCONNECT_STORAGE_CLASS') }}"


### PR DESCRIPTION
Current default version of App Connect is quite old now, and does not support OCP 4.10.  v4.2 is the latest version that offers support for all levels of OCP required in MAS.