### PR TITLE
[patch] Support OCP_INGRESS_TLS_SECRET_NAME

### DIFF
--- a/ibm/mas_devops/common_tasks/get_ingress_cert.yml
+++ b/ibm/mas_devops/common_tasks/get_ingress_cert.yml
@@ -1,12 +1,16 @@
 ---
 # 1. Lookup for router-certs-default secret
 # -----------------------------------------------------------------------------
+- name: set ocp ingress tls secret
+  set_fact:
+    ocp_ingress_tls_secret: "{{ lookup('env', 'OCP_INGRESS_TLS_SECRET') | default('router-certs-default', True) }}"
+
 - name: Lookup for router-certs-default secret
   no_log: true
   k8s_info:
     api_version: v1
     kind: Secret
-    name: router-certs-default
+    name: "{{ ocp_ingress_tls_secret }}"
     namespace: openshift-ingress
   register: router_certs_default_secret
 
@@ -16,7 +20,7 @@
     - router_certs_default_secret.resources | length > 0
   set_fact:
     found_router_default_secret: true
-    cluster_ingress_secret_name: router-certs-default
+    cluster_ingress_secret_name: "{{ ocp_ingress_tls_secret }}"
     cluster_ingress_tls_crt: "{{ router_certs_default_secret.data['tls.crt'] | b64decode }}"
 
 

--- a/ibm/mas_devops/common_tasks/get_ingress_cert.yml
+++ b/ibm/mas_devops/common_tasks/get_ingress_cert.yml
@@ -3,14 +3,16 @@
 # -----------------------------------------------------------------------------
 - name: set ocp ingress tls secret
   set_fact:
-    ocp_ingress_tls_secret: "{{ lookup('env', 'OCP_INGRESS_TLS_SECRET') | default('router-certs-default', True) }}"
+    ocp_ingress_tls_secret_name: "{{ lookup('env', 'OCP_INGRESS_TLS_SECRET_NAME') | default('router-certs-default', True) }}"
+  when:
+    ocp_ingress_tls_secret_name is not defined
 
 - name: Lookup for router-certs-default secret
   no_log: true
   k8s_info:
     api_version: v1
     kind: Secret
-    name: "{{ ocp_ingress_tls_secret }}"
+    name: "{{ ocp_ingress_tls_secret_name }}"
     namespace: openshift-ingress
   register: router_certs_default_secret
 
@@ -20,7 +22,7 @@
     - router_certs_default_secret.resources | length > 0
   set_fact:
     found_router_default_secret: true
-    cluster_ingress_secret_name: "{{ ocp_ingress_tls_secret }}"
+    cluster_ingress_secret_name: "{{ ocp_ingress_tls_secret_name }}"
     cluster_ingress_tls_crt: "{{ router_certs_default_secret.data['tls.crt'] | b64decode }}"
 
 

--- a/ibm/mas_devops/roles/cos/README.md
+++ b/ibm/mas_devops/roles/cos/README.md
@@ -47,11 +47,11 @@ Local directory to save the generated ObjectStorageCfg resource definition.  Thi
 - Environment Variable: `MAS_CONFIG_DIR`
 - Default Value: None
 
-### cluster ingres tls secret 
+### cluster ingres tls secret name
 Specify the name of the cluster's ingres tls secret which contains the default router certificate.
 
 - Optional
-- Environment Variable: `OCP_INGRESS_TLS_SECRET`
+- Environment Variable: `OCP_INGRESS_TLS_SECRET_NAME`
 - Default Value: router-certs-default
 
 

--- a/ibm/mas_devops/roles/cos/README.md
+++ b/ibm/mas_devops/roles/cos/README.md
@@ -47,6 +47,13 @@ Local directory to save the generated ObjectStorageCfg resource definition.  Thi
 - Environment Variable: `MAS_CONFIG_DIR`
 - Default Value: None
 
+### cluster ingres tls secret 
+Specify the name of the cluster's ingres tls secret which contains the default router certificate.
+
+- Optional
+- Environment Variable: `OCP_INGRESS_TLS_SECRET`
+- Default Value: router-certs-default
+
 
 Example Playbook
 ----------------

--- a/ibm/mas_devops/roles/ocp_verify/README.md
+++ b/ibm/mas_devops/roles/ocp_verify/README.md
@@ -16,11 +16,11 @@ Specify the name of the cluster, in some cluster setups this name is required to
 - Environment Variable: `CLUSTER_NAME`
 - Default Value: None
 
-### cluster ingres tls secret 
+### cluster ingres tls secret name
 Specify the name of the cluster's ingres tls secret which contains the default router certificate.
 
 - Optional
-- Environment Variable: `OCP_INGRESS_TLS_SECRET`
+- Environment Variable: `OCP_INGRESS_TLS_SECRET_NAME`
 - Default Value: router-certs-default
 
 

--- a/ibm/mas_devops/roles/ocp_verify/README.md
+++ b/ibm/mas_devops/roles/ocp_verify/README.md
@@ -16,6 +16,13 @@ Specify the name of the cluster, in some cluster setups this name is required to
 - Environment Variable: `CLUSTER_NAME`
 - Default Value: None
 
+### cluster ingres tls secret 
+Specify the name of the cluster's ingres tls secret which contains the default router certificate.
+
+- Optional
+- Environment Variable: `OCP_INGRESS_TLS_SECRET`
+- Default Value: router-certs-default
+
 
 Example Playbook
 ----------------

--- a/ibm/mas_devops/roles/uds/README.md
+++ b/ibm/mas_devops/roles/uds/README.md
@@ -24,6 +24,13 @@ Defines the frequency that BAS will collect event data. The value can be set fol
 - Environment Variable: `UDS_EVENT_SCHEDULER_FREQUENCY`
 - Default Value: `@daily`
 
+### cluster ingres tls secret 
+Specify the name of the cluster's ingres tls secret which contains the default router certificate.
+
+- Optional
+- Environment Variable: `OCP_INGRESS_TLS_SECRET`
+- Default Value: router-certs-default
+
 
 Role Variables - BASCfg Generation
 ----------------------------------

--- a/ibm/mas_devops/roles/uds/README.md
+++ b/ibm/mas_devops/roles/uds/README.md
@@ -24,11 +24,11 @@ Defines the frequency that BAS will collect event data. The value can be set fol
 - Environment Variable: `UDS_EVENT_SCHEDULER_FREQUENCY`
 - Default Value: `@daily`
 
-### cluster ingres tls secret 
+### cluster ingres tls secret name
 Specify the name of the cluster's ingres tls secret which contains the default router certificate.
 
 - Optional
-- Environment Variable: `OCP_INGRESS_TLS_SECRET`
+- Environment Variable: `OCP_INGRESS_TLS_SECRET_NAME`
 - Default Value: router-certs-default
 
 


### PR DESCRIPTION
Add support for optional `OCP_INGRESS_TLS_SECRET_NAME` environment variable which will allow the user to explcitly control the name of the secret containing the OCP default ingress TLS certificate.  This is only required when the secret name does not match any of the known patterns that are supported out of the box by the collection.