### PR TITLE
[patch] Fix Assist playbook & IBM COS resource creation

### DIFF
--- a/ibm/mas_devops/playbooks/oneclick_add_assist.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_assist.yml
@@ -15,7 +15,7 @@
 
     # Application Installation
     mas_app_id: assist
-    mas_app_channel: 8.4.x
+    mas_app_channel: "{{ lookup('env', 'MAS_APP_CHANNEL') | default('8.4.x', true) }}"
 
     mas_app_spec:
       bindings:
@@ -25,7 +25,7 @@
         watsondiscovery: application
 
     # Application Configuration
-    mas_workspace_id: masdev
+    mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') | default('masdev', true) }}"
 
   pre_tasks:
     # For the full set of supported environment variables refer to the playbook documentation

--- a/ibm/mas_devops/roles/cos/tasks/providers/ibm.yml
+++ b/ibm/mas_devops/roles/cos/tasks/providers/ibm.yml
@@ -59,6 +59,7 @@
 - name: "ibm : Create a cos instance"
   ibm.cloudcollection.ibm_resource_instance:
     name: "{{ ibmcos_instance_name }}"
+    resource_group_id: "{{ resourceGID }}"
     service: "cloud-object-storage"
     plan: "{{ ibmcos_plan_type }}"
     location: "{{ ibmcos_location_info }}"


### PR DESCRIPTION
- fixing default workspace_id to the set by variable just like other one click playbooks
- fixing cos creation to accept resource group param otherwise it will fail to lookup by resource group