### PR TITLE
[patch] Fix App Connect version management

### DIFF
--- a/ibm/mas_devops/roles/appconnect/README.md
+++ b/ibm/mas_devops/roles/appconnect/README.md
@@ -68,6 +68,13 @@ AppConnect dashboard instance name. Defaults to `dashboard-12040r2` as a referen
 - Environment Variable: `APPCONNECT_DASHBOARD_NAME`
 - Default Value: `dashboard-12040r2`
 
+### appconnect_dashboard_version
+AppConnect dashboard version, this must align with the License ID used.
+
+- Optional
+- Environment Variable: `APPCONNECT_DASHBOARD_VERSION`
+- Default Value: `12.0.4.0-r2`
+
 ### appconnect_license_id
 AppConnect license ID.
 

--- a/ibm/mas_devops/roles/appconnect/defaults/main.yml
+++ b/ibm/mas_devops/roles/appconnect/defaults/main.yml
@@ -1,24 +1,28 @@
 ---
 # We don't actually use this dictionary today, but in a future release we should simply pass in the version
 # of HP Utilities and key off this instead.
-appconnect_defaults:
+appconnect_defaults: # Based on HP Utilities version
   8.4.x:
     channel: v5.2
     license: L-APEH-C9NCK6
     dashboard: dashboard-12040r2
+    dashboard_version: 12.0.4.0-r2
   8.3.x:
     channel: v4.2
     license: L-KSBM-C87FU2
     dashboard: dashboard-12020r2
+    dashboard_version: 12.0.2.0-r2
   8.2.x:
     channel: v3.1
     license: L-KSBM-C37J2R
     dashboard: dashboard-12010r2
+    dashboard_version: 12.0.1.0-r2
 
 # Define where AppConnect will be installed, the default values below
 appconnect_namespace: "{{ lookup('env', 'APPCONNECT_NAMESPACE') | default('ibm-app-connect', true) }}"
 appconnect_channel: "{{ lookup('env', 'APPCONNECT_CHANNEL') | default('v5.2', true) }}"
 appconnect_dashboard_name: "{{ lookup('env', 'APPCONNECT_DASHBOARD_NAME') | default('dashboard-12040r2', true) }}"
+appconnect_dashboard_version: "{{ lookup('env', 'APPCONNECT_DASHBOARD_VERSION') | default('12.0.4.0-r2', true) }}"
 appconnect_license_id: "{{ lookup('env', 'APPCONNECT_LICENSE_ID') | default('L-APEH-C9NCK6', true) }}"
 appconnect_storage_class: "{{ lookup('env', 'APPCONNECT_STORAGE_CLASS') }}"
 

--- a/ibm/mas_devops/roles/appconnect/tasks/main.yml
+++ b/ibm/mas_devops/roles/appconnect/tasks/main.yml
@@ -75,6 +75,7 @@
     kind: Namespace
     name: '{{ appconnect_namespace }}'
 
+
 # 5. Create ibm-entitlement for AppConnect
 # -----------------------------------------------------------------------------
 - name: "Create ibm-entitlement-key secret in AppConnect namespace"
@@ -95,6 +96,7 @@
         namespace: "{{ appconnect_namespace }}"
       stringData:
         .dockerconfigjson: "{{ content | join('') | string }}"
+
 
 # 6. Deploy AppConnect subscription and Operator Group
 # -----------------------------------------------------------------------------
@@ -131,13 +133,35 @@
     - appconnect_crd_info.resources is defined
     - appconnect_crd_info.resources | length > 0
 
-# 7. Create AppConnect Dashboard
+
+# 7. Wait until AppConnect Operator is ready
+# -----------------------------------------------------------------------------
+- name: "Wait for ibm-appconnect-operator to be ready (60s delay)"
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    name: ibm-appconnect-operator
+    namespace: "{{ appconnect_namespace }}"
+    kind: Deployment
+  register: appconnect_operator_deployment
+  until:
+    - appconnect_operator_deployment.resources is defined
+    - appconnect_operator_deployment.resources | length > 0
+    - appconnect_operator_deployment.resources[0].status is defined
+    - appconnect_operator_deployment.resources[0].status.replicas is defined
+    - appconnect_operator_deployment.resources[0].status.readyReplicas is defined
+    - appconnect_operator_deployment.resources[0].status.readyReplicas == appconnect_operator_deployment.resources[0].status.replicas
+  retries: 30 # Approximately 1/2 hour before we give up
+  delay: 60 # 1 minute
+
+
+# 8. Create AppConnect Dashboard
 # -----------------------------------------------------------------------------
 - name: "Create AppConnect Dashboard"
   kubernetes.core.k8s:
     definition: "{{ lookup('template', 'templates/dashboard.yaml') }}"
 
-# 8. Wait AppConnect Dashboard to be complete
+
+# 9. Wait AppConnect Dashboard to be complete
 # -----------------------------------------------------------------------------
 - name: "Wait for AppConnect Dashboard to be ready (60s delay)"
   kubernetes.core.k8s_info:
@@ -154,7 +178,8 @@
   retries: 45 # approx 45 minutes before we give up
   delay: 60 # 1 minute
 
-# 9. Retrieve AppConnect dashboard route
+
+# 10. Retrieve AppConnect dashboard route
 # -----------------------------------------------------------------------------
 - name: "Retrieve AppConnect dashboard Route:"
   kubernetes.core.k8s_info:
@@ -175,7 +200,7 @@
     msg:
       - "AppConnect Dashboard Route ................. {{ appconnect_url }}"
 
-# 10. MAS Config
+# 11. MAS Config
 # -----------------------------------------------------------------------------
 - include_tasks: tasks/appconnectcfg.yml
   when:
@@ -186,7 +211,8 @@
     - appconnect_url is defined
     - appconnect_url != ""
 
-# 11. AppConnect deployment details
+
+# 12. AppConnect deployment details
 # -----------------------------------------------------------------------------
 - name: "AppConnect Deployment details"
   debug:

--- a/ibm/mas_devops/roles/appconnect/templates/dashboard.yaml
+++ b/ibm/mas_devops/roles/appconnect/templates/dashboard.yaml
@@ -30,7 +30,7 @@ spec:
             cpu: 50m
             memory: 125Mi
   useCommonServices: false
-  version: '12.0'
+  version: "{{ appconnect_dashboard_version }}"
   storage:
     class: "{{ appconnect_storage_class }}"
     size: 5Gi


### PR DESCRIPTION
The updates to the `appconnect` role do not work:

- The version set to `12.0` resolves to an inccorect version (the latest available `12.0`) that does not match the license (and does not match the version that HP Utilities claims to support.
- The role does not wait for the App Connect operator deployment to be ready, thus the admission controller webhook can not be reached when the dashboard is attempted to be created.