### PR TITLE
[patch] Create "prod-cred" secret sometimes used by Discovery

### DIFF
--- a/ibm/mas_devops/roles/cp4d/tasks/entitlement.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/entitlement.yml
@@ -23,3 +23,27 @@
   with_items:
     - "ibm-common-services"
     - "{{ cpd_instance_namespace }}"
+
+
+# Watson Discovery - for some unkown reason - creates ONE POD that references an ImagePullSecret named "prod-cred".  Unless this secret is created
+# that pod will not be able to start up reliably, Kubernetes will sometimes ignore the image pull secrets assigned the service account that owns the pod.
+# It doesn't make any sense why it sometimes works and sometimes doesn't, but this is CP4D after-all:)
+- name: "entitlement : Create prod-cred secret in {{ cpd_instance_namespace }} namespace (for Watson Discovery)"
+  vars:
+    entitledAuthStr: "{{ cpd_entitlement_username }}:{{ cpd_entitlement_key }}"
+    entitledAuth: "{{ entitledAuthStr | b64encode }}"
+    content:
+      - '{"auths":{"cp.icr.io/cp": {"username":"{{ cpd_entitlement_username }}","password":"{{ cpd_entitlement_key }}","auth":"{{ entitledAuth }}"}'
+      - '}'
+      - '}'
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: v1
+      kind: Secret
+      type: kubernetes.io/dockerconfigjson
+      metadata:
+        name: "prod-cred"
+        namespace: "{{ cpd_instance_namespace }}"
+      stringData:
+        # Only way I could get three consecutive "}" into a string :)
+        .dockerconfigjson: "{{ content | join('') | string }}"


### PR DESCRIPTION
The `wd-minio-discovery-update-label` job pod will fail with image pull errors **sometimes** if the `prod-cred` secret referenced in it's deployment template is not present.  This update creates that secret.

```
      "containers": [
        {
          "command": [
            "/bin/bash",
            "-c",
            "kubectl label --overwrite pvc --selector app.kubernetes.io/instance=$MINIO_RELEASENAME,helm.sh/chart=ibm-minio velero.io/exclude-from-backup=$MINIO_EXCLUDE_FROM_BACKUP icpdsupport/empty-on-nd-backup=$MINIO_EMPTY_ON_BACKUP icpdsupport/ignore-on-nd-backup=$MINIO_IGNORE_ON_BACKUP "
          ],
          "env": [
            { "name": "MINIO_RELEASENAME", "value": "wd-minio" },
            { "name": "MINIO_IGNORE_ON_BACKUP", "value": "true" },
            { "name": "MINIO_EMPTY_ON_BACKUP", "value": "true" },
            { "name": "MINIO_EXCLUDE_FROM_BACKUP", "value": "true" }
          ],
          "image": "cp.icr.io/cp/opencontent-minio-client@sha256:d22de890973f893083636ee55a2c95b0211c682bf66f76bf464e8901befd38e1",
          "imagePullPolicy": "IfNotPresent",
          "name": "updatelabel",
...
      "imagePullSecrets": [{ "name": "prod-cred" }],

...
      "serviceAccount": "wd-discovery-admin",
      "serviceAccountName": "wd-discovery-admin",
...

    "status": {
...
      "containerStatuses": [
        {
          "image": "cp.icr.io/cp/opencontent-minio-client@sha256:d22de890973f893083636ee55a2c95b0211c682bf66f76bf464e8901befd38e1",
          "imageID": "",
          "lastState": {},
          "name": "updatelabel",
          "ready": false,
          "restartCount": 0,
          "started": false,
          "state": {
            "waiting": {
              "message": "rpc error: code = Unknown desc = Requesting bear token: invalid status code from registry 400 (Bad Request)",
              "reason": "ErrImagePull"
            }
          }
        }
      ],
      "hostIP": "10.177.163.99",
      "phase": "Pending",
      "podIP": "172.30.156.99",
      "podIPs": [{ "ip": "172.30.156.99" }],
      "qosClass": "Guaranteed",
      "startTime": "2022-09-18T10:03:47Z"
    }
  }
}

```