### PR TITLE
[patch] Fix timing window with CCS SA patch

### DIFF
--- a/ibm/mas_devops/roles/cp4d_service/tasks/prereqs/prereqs-wml.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/prereqs/prereqs-wml.yml
@@ -1,7 +1,14 @@
 ---
 # This shouldn't be necessary
 # Ref: https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/3481#issuecomment-44648280
-- name: "prereqs-ccs : Pre-create CCS ServiceAccounts with the right ImagePullSecret"
+- name: "prereqs-wml : Pre-create CCS ServiceAccounts with the right ImagePullSecret"
   kubernetes.core.k8s:
     apply: yes
     template: templates/ccs/serviceAccounts.yml.j2
+  register: wml_ccs_sa_create
+  retries: 2
+  delay: 15 # seconds
+  until: wml_ccs_sa_create.error is not defined # The error field will be set to 409 if there was a conflict
+
+# Note regarding retry logic:
+# If we are installing WML and WSL at exactly the same time then this task my fail with an AlreadyExists error because CCS is a common component

--- a/ibm/mas_devops/roles/cp4d_service/tasks/prereqs/prereqs-wsl.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/prereqs/prereqs-wsl.yml
@@ -1,7 +1,14 @@
 ---
 # This shouldn't be necessary
 # Ref: https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/3481#issuecomment-44648280
-- name: "prereqs-ccs : Pre-create CCS ServiceAccounts with the right ImagePullSecret"
+- name: "prereqs-wsl : Pre-create CCS ServiceAccounts with the right ImagePullSecret"
   kubernetes.core.k8s:
     apply: yes
     template: templates/ccs/serviceAccounts.yml.j2
+  register: wsl_ccs_sa_create
+  retries: 2
+  delay: 15 # seconds
+  until: wsl_ccs_sa_create.error is not defined # The error field will be set to 409 if there was a conflict
+
+# Note regarding retry logic:
+# If we are installing WML and WSL at exactly the same time then this task my fail with an AlreadyExists error because CCS is a common component


### PR DESCRIPTION
If Watson Studio and Watson Machine Learning are being installed in parallel, and the `prereqs-wml` and `prereqs-wsl` tasks are invoked at exactly the same time then both will attempt to patch the CCS ServiceAccount (to add the missing reference to the `ibm-entitlement-key` image pull secret).

This update, adds a retry to this action, so that in the case where this small timing window is hit the task that recieves a conflict error from Kubernetes will retry (and effectively perform a no-op) instead of failing the role.