### PR TITLE
[patch] set duration for MongoDB certificates

### DIFF
--- a/ibm/mas_devops/roles/mongodb/templates/community/ca-cert.yml
+++ b/ibm/mas_devops/roles/mongodb/templates/community/ca-cert.yml
@@ -8,6 +8,7 @@ spec:
   isCA: true
   commonName: mongo-ca-crt
   secretName: mongo-ca-secret
+  duration: 175200h # 20 years
   privateKey:
     algorithm: ECDSA
     size: 256

--- a/ibm/mas_devops/roles/mongodb/templates/community/server-cert.yml
+++ b/ibm/mas_devops/roles/mongodb/templates/community/server-cert.yml
@@ -4,6 +4,8 @@ metadata:
   name: mongo-server
   namespace: "{{mongodb_namespace}}"
 spec:
+  duration: 8760h # 365d
+  renewBefore: 360h # 15d
   dnsNames:
   - "*.mas-mongo-ce-svc.{{mongodb_namespace}}.svc.cluster.local"
   - "127.0.0.1"


### PR DESCRIPTION
### Extend duration of MongoDB CA Certificate and Server Certificate

The default expiration of three months for the MongoDB CA Certificate is too disruptive - even for non-production test deployments. The following is proposed:

- MongoDB CA Certificate duration set to 20 years
- MongoDB Server Certificate duration set to 1 year and renewed 15 days before

Output after test:

```bash
% oc get certificate mongo-ca-crt    
NAME           READY   SECRET            AGE     EXPIRATION
mongo-ca-crt   True    mongo-ca-secret   8m39s   2042-10-19T18:46:37Z


% oc get certificate mongo-server 
NAME           READY   SECRET              AGE     EXPIRATION
mongo-server   True    mongo-server-cert   8m39s   2023-10-24T18:46:50Z
```


https://github.com/ibm-mas/ansible-devops/issues/488