### PR TITLE
[patch] maskafka user needs cluster level ACLs for FPL producers

### DIFF
--- a/ibm/mas_devops/roles/kafka/templates/masuser.yml.j2
+++ b/ibm/mas_devops/roles/kafka/templates/masuser.yml.j2
@@ -43,6 +43,12 @@ spec:
         operation: All
         resource:
           name: '*'
+          patternType: prefix
+          type: cluster
+      - host: '*'
+        operation: All
+        resource:
+          name: '*'
           patternType: literal
           type: topic
       - host: '*'
@@ -51,3 +57,9 @@ spec:
           name: '*'
           patternType: literal
           type: group
+      - host: '*'
+        operation: All
+        resource:
+          name: '*'
+          patternType: literal
+          type: cluster


### PR DESCRIPTION
The new FPL component of the IoT tool utilises idempotent Kafka producers.  This capability of the Kafka producer client requires that the Kafka user has cluster level ACLs in the Kafka cluster.

Without these permissions, attempts to publish events will fail and messages such as the following would be present in the logs of `fpl-pipelinerouter-<n>` and `fpl-functionsexecutor-<n>` pods:

```
[11/03/22 2:02:43:704 UTC] 53    com.ibm.wiotp.internal.pipeline.pipelinerouter.workflow.workers.EventPublisher SEVERE lambda$processInput$0 
[masdev]: failed to publish metric record: ProducerRecord(topic=fvtdev_fpl-repartition-events, ... 
becuase: Cluster authorization failed.

2022-11-03 02:02:47,816 INFO exited: iotapp (exit status 1; not expected)
```

Provided that users install or update MAS via these tools, then the necessary updates to the user ACLs should be applied.  If they update via alternative mechanisms, then the failures can be resolved by manually updating the Kafka user CR to add cluster type ACLs (as per the template in this PR).