### PR TITLE
[patch] Fix timing window with OperatorCondition check

### DIFF
--- a/ibm/mas_devops/roles/suite_app_install/tasks/install_digest_cm.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/install_digest_cm.yml
@@ -10,19 +10,15 @@
     label_selectors:
       - "operators.coreos.com/ibm-mas-{{ mas_app_id }}.{{ mas_app_namespace }}"
   register: app_opcon
+  retries: 10
+  delay: 1 # minutes
+  until:
+    - app_opcon.resources is defined
+    - app_opcon.resources | length == 1
+    - app_opcon.resources[0].metadata.name is defined
 
 
-# 2. Fail if we can't find the OperatorCondition for the application
-# -----------------------------------------------------------------------------
-- name: "Check that the OperatorCondition was found"
-  assert:
-    that:
-      - app_opcon.resources is defined
-      - app_opcon.resources | length == 1
-      - app_opcon.resources[0].metadata.name is defined
-
-
-# 3. Set the application operator version
+# 2. Set the application operator version
 # -----------------------------------------------------------------------------
 # OperatorCondition names are in the format {packageName}.{packageVersion}
 # We want to strip off the "v" prefix from the version while we do this
@@ -37,7 +33,7 @@
       - "Application operator version ........... {{ mas_app_operator_version }}"
 
 
-# 4. Create the Image Digest Map
+# 3. Create the Image Digest Map
 # -----------------------------------------------------------------------------
 - name: "Create ibm-mas-{{ mas_app_id }} Image Digest Map"
   include_role:
@@ -48,7 +44,7 @@
     case_version: "{{ mas_app_operator_version }}"
 
 
-# 5. Lookup the OperatorCondition for Truststore Manager
+# 4. Lookup the OperatorCondition for Truststore Manager
 # -----------------------------------------------------------------------------
 - name: "Lookup Truststore Manager operator version"
   kubernetes.core.k8s_info:
@@ -66,14 +62,14 @@
     - tsm_opcon.resources[0].metadata.name is defined
 
 
-# 6. If TSM is installed, determine at which version
+# 5. If TSM is installed, determine at which version
 # -----------------------------------------------------------------------------
 - name: "Lookup Truststore Manager operator version"
   set_fact:
     tsm_operator_version: "{{ tsm_opcon.resources[0].metadata.name.split('.v')[1] }}"
 
 
-# 7. If TSM is installed, install it's digest map
+# 6. If TSM is installed, install it's digest map
 # -----------------------------------------------------------------------------
 - name: "Create ibm-truststore-mgr Image Digest Map"
   include_role:

--- a/ibm/mas_devops/roles/suite_app_upgrade/tasks/upgrade.yml
+++ b/ibm/mas_devops/roles/suite_app_upgrade/tasks/upgrade.yml
@@ -28,17 +28,16 @@
     label_selectors:
       - "operators.coreos.com/{{ mas_app_fqn }}.{{ mas_app_namespace }}"
   register: updated_opcon
+  retries: 10
+  delay: 1 # minutes
+  until:
+    - updated_opcon.resources is defined
+    - updated_opcon.resources | length == 1
+    - updated_opcon.resources[0].metadata.name is defined
 
 - name: "upgrade : Debug OperatorCondition"
   debug:
     var: updated_opcon
-
-- name: "upgrade : Check that the OperatorCondition was found"
-  assert:
-    that:
-      - updated_opcon.resources is defined
-      - updated_opcon.resources | length == 1
-      - updated_opcon.resources[0].metadata.name is defined
 
 
 # 3. Set the operator version


### PR DESCRIPTION
We fixed many examples of this timing window in the previous release, but missed a couple it seems.  When the OperatorCondition is not created promptly the code will fail, a small retry loop has been effective at eliminating this timing window:

```
TASK [ibm.mas_devops.suite_app_install : detect-airgap : Debug Airgap detection] ***
Friday 04 November 2022  14:38:09 +0000 (0:00:00.049)       0:00:21.774 ******* 
ok: [localhost] => {
    "msg": "Airgap environment .................... True"
}

TASK [ibm.mas_devops.suite_app_install : Enable use of image digests] **********
Friday 04 November 2022  14:38:09 +0000 (0:00:00.039)       0:00:21.814 ******* 
included: /opt/app-root/lib64/python3.9/site-packages/ansible_collections/ibm/mas_devops/roles/suite_app_install/tasks/install_digest_cm.yml for localhost

TASK [ibm.mas_devops.suite_app_install : Lookup Application operator version] ***
Friday 04 November 2022  14:38:09 +0000 (0:00:00.052)       0:00:21.867 ******* 
ok: [localhost] => {"api_found": true, "changed": false, "resources": []}

TASK [ibm.mas_devops.suite_app_install : Check that the OperatorCondition was found] ***
Friday 04 November 2022  14:38:12 +0000 (0:00:03.003)       0:00:24.871 ******* 
fatal: [localhost]: FAILED! => {
    "assertion": "app_opcon.resources | length == 1",
    "changed": false,
    "evaluated_to": false,
    "msg": "Assertion failed"
}

NO MORE HOSTS LEFT *************************************************************

PLAY RECAP *********************************************************************
localhost                  : ok=20   changed=4    unreachable=0    failed=1    skipped=5    rescued=0    ignored=0   
```