### PR TITLE
[patch] Fix timing window in Mongo install

### DIFF
--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community.yml
@@ -153,6 +153,7 @@
   retries: 60 # 30 * 30 seconds = 15 minutes
   delay: 30
   until:
+    - mongodb_statefulset.resources is defined
     - mongodb_statefulset.resources | length > 0
     - mongodb_statefulset.resources[0].status.readyReplicas is defined
     - mongodb_statefulset.resources[0].status.readyReplicas ==  (mongodb_replicas|int)


### PR DESCRIPTION
This update fixes the following failure in the `mongodb` role:

```
The conditional check 'mongodb_statefulset.resources | length > 0' failed. The error was: error while evaluating conditional (mongodb_statefulset.resources | length > 0): 'dict object' has no attribute 'resources'
```

There's a small window where we can check for the stateful set when resources will not even be returned in the result.