### PR TITLE
[patch] Set ICR entitlement host to cp.icr.io/cp

### DIFF
--- a/ibm/mas_devops/roles/install_operator/templates/ibm-entitlement-with-artifactory.json.j2
+++ b/ibm/mas_devops/roles/install_operator/templates/ibm-entitlement-with-artifactory.json.j2
@@ -2,4 +2,4 @@
 {% if artifactory_username is defined and artifactory_username != "" %}
 "wiotp-docker-local.artifactory.swg-devops.com":{"username":"{{ artifactory_username }}","password":"{{ artifactory_apikey }}","auth":"{{ (artifactory_username ~ ':' ~ artifactory_apikey) | b64encode }}"},
 {% endif %}
-"icr.io":{"username":"{{ icr_username }}","password":"{{ icr_password }}","auth":"{{ (icr_username ~ ':' ~ icr_password) | b64encode }}"}}}
+"cp.icr.io/cp":{"username":"{{ icr_username }}","password":"{{ icr_password }}","auth":"{{ (icr_username ~ ':' ~ icr_password) | b64encode }}"}}}


### PR DESCRIPTION
Previous commit changed the entry from `cp.icr.io/cp` to `icr.io` ... both should work based on previous tests, but why take the risk? :) 