### PR TITLE
[patch] Update digest maps before updating catalogsource

### DIFF
--- a/ibm/mas_devops/roles/ibm_catalogs/tasks/main.yml
+++ b/ibm/mas_devops/roles/ibm_catalogs/tasks/main.yml
@@ -24,7 +24,14 @@
   when: airgap_install
   assert:
     that: mas_catalog_version is in mas_catalog_digests
-    fail_msg: "{{ mas_catalog_version }} does not exist or is not supported by this version of the ibm.mas_devops"
+    fail_msg: "{{ mas_catalog_version }} does not exist or is not supported by this version of the ibm.mas_devops collection"
+
+# If we are updating the catalog in an airgap environment, we first have to
+# update the image digest configmaps, otherwise when the operators update
+# they will not be able to use digests for the new images.
+- name: "Update digest maps ahead of catalog update"
+  when: airgap_install
+  include_tasks: tasks/update-digest-maps.yml
 
 - name: "Create IBM offline catalog"
   when: airgap_install

--- a/ibm/mas_devops/roles/ibm_catalogs/tasks/update-digest-maps.yml
+++ b/ibm/mas_devops/roles/ibm_catalogs/tasks/update-digest-maps.yml
@@ -1,0 +1,83 @@
+---
+
+- name: Load CASE bundle versions
+  include_vars:
+    file: "{{ role_path }}/../../common_vars/casebundles/{{ mas_catalog_version }}.yml"
+
+# We only support Core + 3 applications with disconnected installs today:
+# - Core
+# - IoT
+# - Manage
+# - Optimizer
+#
+# When new apps are supported they will need to be added here too (unless they are
+# upgraded to v2 airgap support which does not need the additional config map to be
+# installed).
+
+
+# 1. Updates for Core
+# -----------------------------------------------------------------------------
+- kubernetes.core.k8s_info:
+    api_version: core.mas.ibm.com/v1
+    kind: Suite
+  register: suites
+
+- name: "Update ibm-mas Image Digest Map"
+  include_role:
+    name: ibm.mas_devops.suite_install_digest_cm
+  with_items: "{{ suites.resources }}"
+  vars:
+    digest_image_map_namespace: "{{ item.metadata.namespace }}"
+    case_name: ibm-mas
+    case_version: "{{ mas_core_version }}"
+
+
+# 2. Updates for IoT
+# -----------------------------------------------------------------------------
+- kubernetes.core.k8s_info:
+    api_version: iot.ibm.com/v1
+    kind: IoT
+  register: iot_apps
+
+- name: "Update ibm-mas-iot Image Digest Map"
+  include_role:
+    name: ibm.mas_devops.suite_install_digest_cm
+  with_items: "{{ iot_apps.resources }}"
+  vars:
+    digest_image_map_namespace: "{{ item.metadata.namespace }}"
+    case_name: ibm-mas-iot
+    case_version: "{{ mas_iot_version }}"
+
+
+# 3. Updates for Manage
+# -----------------------------------------------------------------------------
+- kubernetes.core.k8s_info:
+    api_version: apps.mas.ibm.com/v1
+    kind: ManageApp
+  register: manage_apps
+
+- name: "Update ibm-mas-manage Image Digest Map"
+  include_role:
+    name: ibm.mas_devops.suite_install_digest_cm
+  with_items: "{{ manage_apps.resources }}"
+  vars:
+    digest_image_map_namespace: "{{ item.metadata.namespace }}"
+    case_name: ibm-mas-manage
+    case_version: "{{ mas_manage_version }}"
+
+
+# 3. Updates for Optimizer
+# -----------------------------------------------------------------------------
+- kubernetes.core.k8s_info:
+    api_version: apps.mas.ibm.com/v1
+    kind: optimizerApp
+  register: optimizer_apps
+
+- name: "Update ibm-mas-optimizer Image Digest Map"
+  include_role:
+    name: ibm.mas_devops.suite_install_digest_cm
+  with_items: "{{ optimizer_apps.resources }}"
+  vars:
+    digest_image_map_namespace: "{{ item.metadata.namespace }}"
+    case_name: ibm-mas-optimizer
+    case_version: "{{ mas_optimizer_version }}"

--- a/ibm/mas_devops/roles/suite_install_digest_cm/tasks/actions/merge.yml
+++ b/ibm/mas_devops/roles/suite_install_digest_cm/tasks/actions/merge.yml
@@ -1,0 +1,9 @@
+---
+# 2. We need to perform a merge to add the data to the configmap
+- name: "Get existing image map data"
+  set_fact:
+    existing_digest_image_map_data: "{{ existing_digest_cm.resources[0].data['image-map.yaml'] }}"
+
+- name: "Install the updated digest config map"
+  kubernetes.core.k8s:
+    template: 'templates/configmap.yml.j2'

--- a/ibm/mas_devops/roles/suite_install_digest_cm/tasks/actions/new.yml
+++ b/ibm/mas_devops/roles/suite_install_digest_cm/tasks/actions/new.yml
@@ -1,0 +1,5 @@
+---
+
+- name: "Install new digest config map"
+  kubernetes.core.k8s:
+    template: 'templates/configmap.yml.j2'

--- a/ibm/mas_devops/roles/suite_install_digest_cm/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_install_digest_cm/tasks/main.yml
@@ -16,6 +16,7 @@
   set_fact:
     digest_image_map_name: "{{ case_name }}-image-map"
     digest_image_map_file: "{{ role_path }}/../../common_vars/digests/{{ case_name }}/{{ case_version }}.yaml"
+    digest_image_map_label: "mas.ibm.com/{{ case_name }}-{{ case_version }}"
 
 # Manage v8.4.0-8.4.2, Visual Inspection v8.6.0, optimizer v8.2.0, Safety v8.3.0 all reference the wrong config map name
 - name: "Workaround for bug in ibm-mas-manage v8.4.0-8.4.2"
@@ -38,7 +39,6 @@
   set_fact:
     digest_image_map_name: "ibm-safety-image-map"
 
-
 - name: "Debug Image Digest Config Map"
   debug:
     msg:
@@ -47,14 +47,33 @@
       - "Case Version ....................... {{ case_version }}"
       - "Digest Map Name .................... {{ digest_image_map_name }}"
       - "Digest Map Local File .............. {{ digest_image_map_file }}"
+      - "Digest Map Label ................... {{ digest_image_map_label }}"
 
-
-# 3. Install the Digest Image Map
-# -----------------------------------------------------------------------------
 - name: "Initialize facts (2/2)"
   set_fact:
     digest_image_map_data: "{{ lookup('file', digest_image_map_file) }}"
 
-- name: "Install digest config maps"
-  kubernetes.core.k8s:
-    template: 'templates/configmap.yml.j2'
+- name: "Look for an existing image map"
+  kubernetes.core.k8s_info:
+    api_version: v1
+    name: "{{ digest_image_map_name }}"
+    kind: ConfigMap
+    namespace: "{{ digest_image_map_namespace }}"
+  register: existing_digest_cm
+
+
+# 3a. Merge with the existing Digest Image Map
+# -----------------------------------------------------------------------------
+- name: "Merge with existing image map"
+  when:
+    - existing_digest_cm.resources is defined
+    - existing_digest_cm.resources | length > 0
+    - (existing_digest_cm.resources[0].metadata.labels is defined and digest_image_map_label is not in existing_digest_cm.resources[0].metadata.labels) or existing_digest_cm.resources[0].metadata.labels is not defined
+  include_tasks: actions/merge.yml
+
+
+# 3b. Install the new Digest Image Map
+# -----------------------------------------------------------------------------
+- name: "Create new image map"
+  when: (existing_digest_cm.resources is defined and existing_digest_cm.resources | length == 0) or existing_digest_cm.resources is not defined
+  include_tasks: actions/new.yml

--- a/ibm/mas_devops/roles/suite_install_digest_cm/templates/configmap.yml.j2
+++ b/ibm/mas_devops/roles/suite_install_digest_cm/templates/configmap.yml.j2
@@ -4,6 +4,11 @@ kind: ConfigMap
 metadata:
   name: {{ digest_image_map_name }}
   namespace: {{ digest_image_map_namespace }}
+  labels:
+    {{ digest_image_map_label }}: "true"
 data:
   image-map.yaml: |
+{% if existing_digest_image_map_data is defined %}
+    {{ existing_digest_image_map_data | indent(4, false) }}
+{% endif %}
     {{ digest_image_map_data | indent(4, false) }}


### PR DESCRIPTION
This update addressed a flaw discovered in the update process in a disconnected MAS install.

When a catalog source is updated in a connected install, that is the only action required.  The operators will update and will in turn update the operands under their control.

However, in a disconnected install the need for the additional configmap containing the digest map references must be updated before the operator is updated, otherwise when the operator updates it will fall back to using image tags instead of digests, and will be unable to resolve the container images from the mirror registry.

The need for this additional config map to be installed is in the process of being eliminated, but at present most MAS operators require this step.

This update integrates the action of updating the configmaps for all installed (supported) operators.