### PR TITLE
[patch] Remove refs to old container image

### DIFF
--- a/docs/playbooks/oneclick-core.md
+++ b/docs/playbooks/oneclick-core.md
@@ -93,7 +93,7 @@ ansible-playbook ibm.mas_devops.oneclick_core
 ```
 
 !!! tip
-    If you do not want to set up all the dependencies on your local system, you can run the install inside our docker image as well: `docker run -ti quay.io/ibmmas/ansible-devops:latest bash`
+    If you do not want to set up all the dependencies on your local system, you can run the install inside our docker image as well: `docker run -ti quay.io/ibmmas/cli:latest`
 
 
 ### Pre-release build
@@ -126,4 +126,4 @@ ansible-playbook ibm.mas_devops.oneclick_core
 ```
 
 !!! tip
-    If you do not want to set up all the dependencies on your local system, you can run the install inside our docker image as well: `docker run -ti quay.io/ibmmas/ansible-devops:latest bash`
+    If you do not want to set up all the dependencies on your local system, you can run the install inside our docker image as well: `docker run -ti quay.io/ibmmas/cli:latest`

--- a/docs/playbooks/oneclick-iot.md
+++ b/docs/playbooks/oneclick-iot.md
@@ -51,5 +51,5 @@ ansible-playbook ibm.mas_devops.oneclick_add_iot
 ```
 
 !!! tip
-    If you do not want to set up all the dependencies on your local system, you can run the install inside our docker image as well: `docker run -ti quay.io/ibmmas/ansible-devops:latest bash`
+    If you do not want to set up all the dependencies on your local system, you can run the install inside our docker image as well: `docker run -ti quay.io/ibmmas/cli:latest`
 

--- a/docs/playbooks/oneclick-manage.md
+++ b/docs/playbooks/oneclick-manage.md
@@ -53,5 +53,5 @@ ansible-playbook ibm.mas_devops.oneclick_add_manage
 ```
 
 !!! tip
-    If you do not want to set up all the dependencies on your local system, you can run the install inside our docker image as well: `docker run -ti quay.io/ibmmas/ansible-devops:latest bash`
+    If you do not want to set up all the dependencies on your local system, you can run the install inside our docker image as well: `docker run -ti quay.io/ibmmas/cli:latest`
 

--- a/docs/playbooks/oneclick-monitor.md
+++ b/docs/playbooks/oneclick-monitor.md
@@ -31,5 +31,5 @@ ansible-playbook ibm.mas_devops.oneclick_add_monitor
 ```
 
 !!! tip
-    If you do not want to set up all the dependencies on your local system, you can run the install inside our docker image as well: `docker run -ti quay.io/ibmmas/ansible-devops:latest bash`
+    If you do not want to set up all the dependencies on your local system, you can run the install inside our docker image as well: `docker run -ti quay.io/ibmmas/cli:latest`
 

--- a/docs/playbooks/oneclick-optimizer.md
+++ b/docs/playbooks/oneclick-optimizer.md
@@ -30,4 +30,4 @@ ansible-playbook ibm.mas_devops.oneclick_add_optimizer
 ```
 
 !!! tip
-    If you do not want to set up all the dependencies on your local system, you can run the install inside our docker image as well: `docker run -ti quay.io/ibmmas/ansible-devops:latest bash`
+    If you do not want to set up all the dependencies on your local system, you can run the install inside our docker image as well: `docker run -ti quay.io/ibmmas/cli:latest`

--- a/docs/playbooks/oneclick-predict.md
+++ b/docs/playbooks/oneclick-predict.md
@@ -15,8 +15,8 @@ This playbook can be ran against any OCP cluster regardless of it's type; whethe
     - Install Spark (~30 minutes)
     - Install Openscale (~1 hour)
 - Install Predict application:
-    - Install application (~15 Minutes) 
-    - Configure workspace (~30 Minutes) 
+    - Install application (~15 Minutes)
+    - Configure workspace (~30 Minutes)
 
 All timings are estimates, see the individual pages for each of these playbooks for more information.  Use this sample playbook as a starting point for installing any MAS application, just customize the application install and configure stages at the end of the playbook.
 
@@ -25,14 +25,14 @@ All timings are estimates, see the individual pages for each of these playbooks 
 - `MAS_CONFIG_DIR` Directory where generated config files will be saved (you may also provide pre-generated config files here)
 - `MAS_ENTITLEMENT_KEY` Your IBM Entitlement key to access the IBM Container Registry
 - `WML_INSTANCE_ID` Set Default value to "openshift"
-- `WML_URL` Set Default value to "https://internal-nginx-svc.ibm-cpd.svc:12443" . ibm-cpd in the URL corresponds to the project name (namespace) of cp4d installation 
+- `WML_URL` Set Default value to "https://internal-nginx-svc.ibm-cpd.svc:12443" . ibm-cpd in the URL corresponds to the project name (namespace) of cp4d installation
 - `CPD_PRODUCT_VERSION` (Required if `WML_VERSION` is not informed) Cloud Pak for Data version installed in the cluster in 4.X format, it will be used to obtain the correct WML version to be installed
 - `WML_VERSION` (Required if `CPD_PRODUCT_VERSION` is not informed) The wml_version for cp4d 4.0.x will be 4.0, if cp4d is 4.5.x , wml_version should change to 4.5
-- `PREDICT_DEPLOYMENT_SIZE` Controls the workload size of predict containers. Avaliable options are `developer`, `small`, `medium`. 'small' is the choosen one set by default. 
+- `PREDICT_DEPLOYMENT_SIZE` Controls the workload size of predict containers. Avaliable options are `developer`, `small`, `medium`. 'small' is the choosen one set by default.
 
     | Deployment_size        | Replica |
-    | ---------------------- | :--: | 
-    | developer              |  1 | 
+    | ---------------------- | :--: |
+    | developer              |  1 |
     | small                  |  2 |
     | medium                 |  3 |
 
@@ -98,4 +98,4 @@ ansible-playbook ibm.mas_devops.oneclick_add_predict
 ```
 
 !!! tip
-    If you do not want to set up all the dependencies on your local system, you can run the install inside our docker image as well: `docker run -ti quay.io/ibmmas/ansible-devops:latest bash`
+    If you do not want to set up all the dependencies on your local system, you can run the install inside our docker image as well: `docker run -ti quay.io/ibmmas/cli:latest`

--- a/docs/playbooks/oneclick-visualinspection.md
+++ b/docs/playbooks/oneclick-visualinspection.md
@@ -32,4 +32,4 @@ ansible-playbook ibm.mas_devops.oneclick_add_visualinspection
 ```
 
 !!! tip
-    If you do not want to set up all the dependencies on your local system, you can run the install inside our docker image as well: `docker run -ti quay.io/ibmmas/ansible-devops:latest bash`
+    If you do not want to set up all the dependencies on your local system, you can run the install inside our docker image as well: `docker run -ti quay.io/ibmmas/cli:latest`

--- a/ibm/mas_devops/roles/suite_mustgather_download/templates/deployment.yml
+++ b/ibm/mas_devops/roles/suite_mustgather_download/templates/deployment.yml
@@ -21,7 +21,7 @@ spec:
       # =======================================================================
       containers:
         - name: mas-devops-mustgather-download
-          image: quay.io/ibmmas/ansible-devops:6.3.0
+          image: quay.io/ibmmas/cli:3.2.1
           imagePullPolicy: Always
 
           command: ["/bin/sh", "-c", "while true; do sleep 30; done;"]


### PR DESCRIPTION
User reported various pages in the documentation that are still referencing the old container image (ibmmas/ansible-devops); this update fixes all references to point at `quay.io/ibmmas/cli`