### PR TITLE
[patch] Fix unquoted string in "until" clause

### DIFF
--- a/ibm/mas_devops/roles/suite_upgrade/tasks/upgrade.yml
+++ b/ibm/mas_devops/roles/suite_upgrade/tasks/upgrade.yml
@@ -26,7 +26,7 @@
   delay: 30 # seconds
   until:
     - updated_suite_sub_info.resources[0].status.installPlanGeneration > suite_sub_info.resources[0].status.installPlanGeneration
-    - updated_suite_sub_info.resources[0].status.state == AtLatestKnown
+    - updated_suite_sub_info.resources[0].status.state == "AtLatestKnown"
 
 - name: "upgrade : Debug Subscription"
   debug:


### PR DESCRIPTION
Fix for a simple typo in the `suite_upgrade` role.