### PR TITLE
[patch] Fix update support for disconnected installs

### DIFF
--- a/ibm/mas_devops/common_vars/casebundles/v8-220805-amd64.yml
+++ b/ibm/mas_devops/common_vars/casebundles/v8-220805-amd64.yml
@@ -33,7 +33,7 @@ mas_monitor_version:
 mas_optimizer_version:
   8.8.x: 8.2.0
 mas_predict_version:
-  8.8.x:  8.6.0
+  8.8.x: 8.6.0
 mas_visualinspection_version:
   8.8.x: 8.6.0
 

--- a/ibm/mas_devops/roles/ibm_catalogs/tasks/update-digest-maps.yml
+++ b/ibm/mas_devops/roles/ibm_catalogs/tasks/update-digest-maps.yml
@@ -23,7 +23,7 @@
   register: suites
 
 - name: "Update ibm-mas Image Digest Map (8.8.x)"
-  when: '8.8.x' in mas_core_version
+  when: '8.8.x' is in mas_core_version
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   with_items: "{{ suites.resources }}"
@@ -33,7 +33,7 @@
     case_version: "{{ mas_core_version['8.8.x'] }}"
 
 - name: "Update ibm-mas Image Digest Map (8.9.x)"
-  when: '8.9.x' in mas_core_version
+  when: '8.9.x' is in mas_core_version
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   with_items: "{{ suites.resources }}"
@@ -51,7 +51,7 @@
   register: iot_apps
 
 - name: "Update ibm-mas-iot Image Digest Map (8.8.x)"
-  when: '8.8.x' in mas_iot_version
+  when: '8.8.x' is in mas_iot_version
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   with_items: "{{ iot_apps.resources }}"
@@ -61,7 +61,7 @@
     case_version: "{{ mas_iot_version['8.8.x'] }}"
 
 - name: "Update ibm-mas-iot Image Digest Map (8.9.x)"
-  when: '8.9.x' in mas_iot_version
+  when: '8.9.x' is in mas_iot_version
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   with_items: "{{ iot_apps.resources }}"
@@ -79,7 +79,7 @@
   register: manage_apps
 
 - name: "Update ibm-mas-manage Image Digest Map (8.8.x)"
-  when: '8.8.x' in mas_manage_version
+  when: '8.8.x' is in mas_manage_version
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   with_items: "{{ manage_apps.resources }}"
@@ -89,7 +89,7 @@
     case_version: "{{ mas_manage_version['8.8.x'] }}"
 
 - name: "Update ibm-mas-manage Image Digest Map (8.9.x)"
-  when: '8.9.x' in mas_manage_version
+  when: '8.9.x' is in mas_manage_version
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   with_items: "{{ manage_apps.resources }}"
@@ -107,7 +107,7 @@
   register: optimizer_apps
 
 - name: "Update ibm-mas-optimizer Image Digest Map (8.8.x)"
-  when: '8.8.x' in mas_optimizer_version
+  when: '8.8.x' is in mas_optimizer_version
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   with_items: "{{ optimizer_apps.resources }}"
@@ -117,7 +117,7 @@
     case_version: "{{ mas_optimizer_version['8.8.x'] }}"
 
 - name: "Update ibm-mas-optimizer Image Digest Map (8.9.x)"
-  when: '8.9.x' in mas_optimizer_version
+  when: '8.9.x' is in mas_optimizer_version
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   with_items: "{{ optimizer_apps.resources }}"

--- a/ibm/mas_devops/roles/ibm_catalogs/tasks/update-digest-maps.yml
+++ b/ibm/mas_devops/roles/ibm_catalogs/tasks/update-digest-maps.yml
@@ -23,7 +23,7 @@
   register: suites
 
 - name: "Update ibm-mas Image Digest Map (8.8.x)"
-  when: '8.8.x' is in mas_core_version
+  when: "'8.8.x' is in mas_core_version"
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   with_items: "{{ suites.resources }}"
@@ -33,7 +33,7 @@
     case_version: "{{ mas_core_version['8.8.x'] }}"
 
 - name: "Update ibm-mas Image Digest Map (8.9.x)"
-  when: '8.9.x' is in mas_core_version
+  when: "'8.9.x' is in mas_core_version"
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   with_items: "{{ suites.resources }}"
@@ -51,7 +51,7 @@
   register: iot_apps
 
 - name: "Update ibm-mas-iot Image Digest Map (8.8.x)"
-  when: '8.8.x' is in mas_iot_version
+  when: "'8.8.x' is in mas_iot_version"
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   with_items: "{{ iot_apps.resources }}"
@@ -61,7 +61,7 @@
     case_version: "{{ mas_iot_version['8.8.x'] }}"
 
 - name: "Update ibm-mas-iot Image Digest Map (8.9.x)"
-  when: '8.9.x' is in mas_iot_version
+  when: "'8.9.x' is in mas_iot_version"
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   with_items: "{{ iot_apps.resources }}"
@@ -79,7 +79,7 @@
   register: manage_apps
 
 - name: "Update ibm-mas-manage Image Digest Map (8.8.x)"
-  when: '8.8.x' is in mas_manage_version
+  when: "'8.8.x' is in mas_manage_version"
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   with_items: "{{ manage_apps.resources }}"
@@ -89,7 +89,7 @@
     case_version: "{{ mas_manage_version['8.8.x'] }}"
 
 - name: "Update ibm-mas-manage Image Digest Map (8.9.x)"
-  when: '8.9.x' is in mas_manage_version
+  when: "'8.9.x' is in mas_manage_version"
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   with_items: "{{ manage_apps.resources }}"
@@ -107,7 +107,7 @@
   register: optimizer_apps
 
 - name: "Update ibm-mas-optimizer Image Digest Map (8.8.x)"
-  when: '8.8.x' is in mas_optimizer_version
+  when: "'8.8.x' is in mas_optimizer_version"
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   with_items: "{{ optimizer_apps.resources }}"
@@ -117,7 +117,7 @@
     case_version: "{{ mas_optimizer_version['8.8.x'] }}"
 
 - name: "Update ibm-mas-optimizer Image Digest Map (8.9.x)"
-  when: '8.9.x' is in mas_optimizer_version
+  when: "'8.9.x' is in mas_optimizer_version"
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   with_items: "{{ optimizer_apps.resources }}"

--- a/ibm/mas_devops/roles/ibm_catalogs/tasks/update-digest-maps.yml
+++ b/ibm/mas_devops/roles/ibm_catalogs/tasks/update-digest-maps.yml
@@ -22,14 +22,25 @@
     kind: Suite
   register: suites
 
-- name: "Update ibm-mas Image Digest Map"
+- name: "Update ibm-mas Image Digest Map (8.8.x)"
+  when: '8.8.x' in mas_core_version
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   with_items: "{{ suites.resources }}"
   vars:
     digest_image_map_namespace: "{{ item.metadata.namespace }}"
     case_name: ibm-mas
-    case_version: "{{ mas_core_version }}"
+    case_version: "{{ mas_core_version['8.8.x'] }}"
+
+- name: "Update ibm-mas Image Digest Map (8.9.x)"
+  when: '8.9.x' in mas_core_version
+  include_role:
+    name: ibm.mas_devops.suite_install_digest_cm
+  with_items: "{{ suites.resources }}"
+  vars:
+    digest_image_map_namespace: "{{ item.metadata.namespace }}"
+    case_name: ibm-mas
+    case_version: "{{ mas_core_version['8.9.x'] }}"
 
 
 # 2. Updates for IoT
@@ -39,14 +50,25 @@
     kind: IoT
   register: iot_apps
 
-- name: "Update ibm-mas-iot Image Digest Map"
+- name: "Update ibm-mas-iot Image Digest Map (8.8.x)"
+  when: '8.8.x' in mas_iot_version
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   with_items: "{{ iot_apps.resources }}"
   vars:
     digest_image_map_namespace: "{{ item.metadata.namespace }}"
     case_name: ibm-mas-iot
-    case_version: "{{ mas_iot_version }}"
+    case_version: "{{ mas_iot_version['8.8.x'] }}"
+
+- name: "Update ibm-mas-iot Image Digest Map (8.9.x)"
+  when: '8.9.x' in mas_iot_version
+  include_role:
+    name: ibm.mas_devops.suite_install_digest_cm
+  with_items: "{{ iot_apps.resources }}"
+  vars:
+    digest_image_map_namespace: "{{ item.metadata.namespace }}"
+    case_name: ibm-mas-iot
+    case_version: "{{ mas_iot_version['8.9.x'] }}"
 
 
 # 3. Updates for Manage
@@ -56,14 +78,25 @@
     kind: ManageApp
   register: manage_apps
 
-- name: "Update ibm-mas-manage Image Digest Map"
+- name: "Update ibm-mas-manage Image Digest Map (8.8.x)"
+  when: '8.8.x' in mas_manage_version
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   with_items: "{{ manage_apps.resources }}"
   vars:
     digest_image_map_namespace: "{{ item.metadata.namespace }}"
     case_name: ibm-mas-manage
-    case_version: "{{ mas_manage_version }}"
+    case_version: "{{ mas_manage_version['8.8.x'] }}"
+
+- name: "Update ibm-mas-manage Image Digest Map (8.9.x)"
+  when: '8.9.x' in mas_manage_version
+  include_role:
+    name: ibm.mas_devops.suite_install_digest_cm
+  with_items: "{{ manage_apps.resources }}"
+  vars:
+    digest_image_map_namespace: "{{ item.metadata.namespace }}"
+    case_name: ibm-mas-manage
+    case_version: "{{ mas_manage_version['8.9.x'] }}"
 
 
 # 3. Updates for Optimizer
@@ -73,11 +106,22 @@
     kind: optimizerApp
   register: optimizer_apps
 
-- name: "Update ibm-mas-optimizer Image Digest Map"
+- name: "Update ibm-mas-optimizer Image Digest Map (8.8.x)"
+  when: '8.8.x' in mas_optimizer_version
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   with_items: "{{ optimizer_apps.resources }}"
   vars:
     digest_image_map_namespace: "{{ item.metadata.namespace }}"
     case_name: ibm-mas-optimizer
-    case_version: "{{ mas_optimizer_version }}"
+    case_version: "{{ mas_optimizer_version['8.8.x'] }}"
+
+- name: "Update ibm-mas-optimizer Image Digest Map (8.9.x)"
+  when: '8.9.x' in mas_optimizer_version
+  include_role:
+    name: ibm.mas_devops.suite_install_digest_cm
+  with_items: "{{ optimizer_apps.resources }}"
+  vars:
+    digest_image_map_namespace: "{{ item.metadata.namespace }}"
+    case_name: ibm-mas-optimizer
+    case_version: "{{ mas_optimizer_version['8.9.x'] }}"

--- a/ibm/mas_devops/roles/suite_upgrade/tasks/upgrade.yml
+++ b/ibm/mas_devops/roles/suite_upgrade/tasks/upgrade.yml
@@ -26,7 +26,7 @@
   delay: 30 # seconds
   until:
     - updated_suite_sub_info.resources[0].status.installPlanGeneration > suite_sub_info.resources[0].status.installPlanGeneration
-    - updated_suite_sub_info.resources[0].status.state == AtLatestKnown
+    - updated_suite_sub_info.resources[0].status.state == "AtLatestKnown"
 
 - name: "upgrade : Debug Subscription"
   debug:


### PR DESCRIPTION
Restructuring of the common vars left the update method non-functional in airgap environments; when we update the config map we need to make updates for multiple versions based on the different channels available to the user in the catalog.