### PR TITLE
[patch] Fix application install role

### DIFF
--- a/ibm/mas_devops/roles/suite_app_install/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_app_install/defaults/main.yml
@@ -21,3 +21,13 @@ mas_entitlement_key: "{{ lookup('env', 'MAS_ENTITLEMENT_KEY') | default(ibm_enti
 # MAS application configuration
 mas_app_id: "{{ lookup('env', 'MAS_APP_ID') }}"
 mas_app_plan: "{{ lookup('env', 'MAS_APP_PLAN') }}"
+
+# Additional Visual Inspection Settings
+mas_app_settings_visualinspection_storage_class: "{{ lookup('env', 'MAS_APP_SETTINGS_VISUALINSPECTION_STORAGE_CLASS') }}"
+mas_app_settings_visualinspection_storage_size: "{{ lookup('env', 'MAS_APP_SETTINGS_VISUALINSPECTION_STORAGE_SIZE') | default('100Gi', true) }}"
+
+# Additional IoT Settings
+mas_app_settings_iot_deployment_size: "{{ lookup('env', 'MAS_APP_SETTINGS_IOT_DEPLOYMENT_SIZE') | default('small', true) }}"
+mas_app_settings_iot_fpl_pvc_storage_class: "{{ lookup('env', 'MAS_APP_SETTINGS_IOT_FPL_PVC_STORAGE_CLASS') }}"
+mas_app_settings_iot_fpl_router_pvc_size: "{{ lookup('env', 'MAS_APP_SETTINGS_IOT_FPL_ROUTER_PVC_SIZE') | default('100Gi', true) }}"
+mas_app_settings_iot_fpl_executor_pvc_size: "{{ lookup('env', 'MAS_APP_SETTINGS_IOT_FPL_EXECUTOR_PVC_SIZE') | default('100Gi', true) }}"

--- a/ibm/mas_devops/roles/suite_app_install/vars/iot.yml
+++ b/ibm/mas_devops/roles/suite_app_install/vars/iot.yml
@@ -5,11 +5,3 @@ mas_app_api_version: iot.ibm.com/v1
 mas_app_kind: IoT
 mas_app_install_delay: 120
 mas_app_install_retries: 30
-
-# properties to configure IoT deployment size
-mas_app_settings_iot_deployment_size: "{{ lookup('env', 'MAS_APP_SETTINGS_IOT_DEPLOYMENT_SIZE') | default('small', true) }}"
-
-# properties to configure persistent volumes for FPL
-mas_app_settings_iot_fpl_pvc_storage_class: "{{ lookup('env', 'MAS_APP_SETTINGS_IOT_FPL_PVC_STORAGE_CLASS') }}" # if not defined by user, it will be automatically defined while setting persistent storage
-mas_app_settings_iot_fpl_router_pvc_size: "{{ lookup('env', 'MAS_APP_SETTINGS_IOT_FPL_ROUTER_PVC_SIZE') | default('100Gi', true) }}"
-mas_app_settings_iot_fpl_executor_pvc_size: "{{ lookup('env', 'MAS_APP_SETTINGS_IOT_FPL_EXECUTOR_PVC_SIZE') | default('100Gi', true) }}"

--- a/ibm/mas_devops/roles/suite_app_install/vars/visualinspection.yml
+++ b/ibm/mas_devops/roles/suite_app_install/vars/visualinspection.yml
@@ -4,9 +4,5 @@ mas_app_fqn: visualinspectionapps.apps.mas.ibm.com
 mas_app_api_version: apps.mas.ibm.com/v1
 mas_app_kind: VisualInspectionApp
 
-# Storage
-mas_app_settings_visualinspection_storage_class: "{{ lookup('env', 'MAS_APP_SETTINGS_VISUALINSPECTION_STORAGE_CLASS') }}"
-mas_app_settings_visualinspection_storage_size: "{{ lookup('env', 'MAS_APP_SETTINGS_VISUALINSPECTION_STORAGE_SIZE') | default('100Gi', true) }}"
-
 mas_app_install_delay: 120
 mas_app_install_retries: 30


### PR DESCRIPTION
Defaults should be in defaults, setting env var lookups in var files will mean the env vars override any values passed in as ansible vars - even if the former are not set and the latter are.