### PR TITLE
[patch] Handle slow install for SLS and Discovery

### DIFF
--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wd.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wd.yml
@@ -20,8 +20,8 @@
     name: wd-discovery-cn-postgres
     namespace: "{{ cpd_instance_namespace }}"
   register: discovery_sa_lookup
-  retries: 50 # Up to 25 minutes
-  delay: 30 # Every 30 seconds
+  retries: 40 # Up to 40 minutes
+  delay: 60 # Every 1 minute
   until:
     - discovery_sa_lookup.resources is defined
     - discovery_sa_lookup.resources | length > 0
@@ -35,8 +35,8 @@
     name: wd-discovery-etcd-serviceaccount
     namespace: "{{ cpd_instance_namespace }}"
   register: discovery_etcd_sa_lookup
-  retries: 50 # Up to 25 minutes
-  delay: 30 # Every 30 seconds
+  retries: 40 # Up to 40 minutes
+  delay: 60 # Every 1 minute
   until:
     - discovery_etcd_sa_lookup.resources is defined
     - discovery_etcd_sa_lookup.resources | length > 0

--- a/ibm/mas_devops/roles/sls/tasks/install/sls-verify.yml
+++ b/ibm/mas_devops/roles/sls/tasks/install/sls-verify.yml
@@ -32,8 +32,8 @@
         - sls_cr_result.resources[0].status.conditions is defined
         - sls_cr_result.resources[0].status.conditions | selectattr('type', 'equalto', 'Ready') | map(attribute='status') | list | length > 0
         - sls_cr_result.resources[0].status.conditions | selectattr('type', 'equalto', 'Ready')| map(attribute='status') | list | first == "True"
-      retries: 30 # approx 30 minutes before we give up
-      delay: 60 # 1 minute
+      retries: 20 # approx 40 minutes before we give up
+      delay: 120 # 2 minutes
 
     - name: "Wait for LicenseService to be initialized (60s delay)"
       kubernetes.core.k8s_info:


### PR DESCRIPTION
Add extra retries while we wait for SLS and Watson Discovery instalation to complete.  Recent testing has shown that the current timeouts are no longer sufficient/the install time is too close to the timeout.