### PR TITLE
[patch] Remove default CPD product version from cp4d and cp4d_service roles

### DIFF
--- a/ibm/mas_devops/playbooks/cp4d.yml
+++ b/ibm/mas_devops/playbooks/cp4d.yml
@@ -10,7 +10,7 @@
     install_analytics_engine: "{{ lookup('env', 'CP4D_INSTALL_SPARK') | default('False', true) | bool }}"
     install_watson_openscale: "{{ lookup('env', 'CP4D_INSTALL_OPENSCALE') | default('False', true) | bool }}"
     install_watson_discovery: "{{ lookup('env', 'CP4D_INSTALL_DISCOVERY') | default('False', true) | bool }}"
-    cpd_product_version: "{{ lookup('env', 'CP4D_PRODUCT_VERSION') | default('4.0.9', true) }}"
+    cpd_product_version: "{{ lookup('env', 'CP4D_PRODUCT_VERSION') | default('4.5.0', true) }}"
 
   roles:
     # Cloud Pak for Data Platform (~1 1/2 hours)

--- a/ibm/mas_devops/roles/cp4d/README.md
+++ b/ibm/mas_devops/roles/cp4d/README.md
@@ -103,7 +103,7 @@ Defines the IBM Cloud Pak for Data release version to be installed.
 
 - **Required**
 - Environment Variable: `CPD_PRODUCT_VERSION`
-- Default: `4.0.9`
+- Default: None
 
 ### ibm_entitlement_key
 Provide your [IBM entitlement key](https://myibm.ibm.com/products-services/containerlibrary).

--- a/ibm/mas_devops/roles/cp4d/defaults/main.yml
+++ b/ibm/mas_devops/roles/cp4d/defaults/main.yml
@@ -31,7 +31,7 @@ cpd_entitlement_key: "{{ lookup('env', 'CPD_ENTITLEMENT_KEY') | default(ibm_enti
 # for the Cloud Pak for Data operators.
 cpd_operators_namespace: "{{ lookup('env', 'CPD_OPERATORS_NAMESPACE') | default('ibm-cpd-operators', true) }}"
 cpd_instance_namespace: "{{ lookup('env', 'CPD_INSTANCE_NAMESPACE') | default('ibm-cpd', true) }}"
-cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default('4.0.9', true)  }}"
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') }}"
 cpd_supported_versions: ['4.0.9', '4.5.0', '4.5.1', '4.5.2']
 cpd_default_channels:
   4.0.9:

--- a/ibm/mas_devops/roles/cp4d_service/defaults/main.yml
+++ b/ibm/mas_devops/roles/cp4d_service/defaults/main.yml
@@ -2,13 +2,7 @@
 # Important: Do not confuse this with the operator versions, CP4D operator and
 # product versions are completely different
 
-# Important (2): Product/Operand version doesn't actually work in CP4D.  Newer versions of the operators
-# can't actually support older product versions being used.  We have reached out to the CP4D team and have
-# been told to basically install a fixed version operator catalog for CP4D.  It's unfortunate, but it's out
-# of our control -- the only version of CP4D that works with MAS 8.7 is v4.0.7, but we can't install that
-# from the IBM operator catalog at present, much more work is needed in this collection to support the operating
-# model of the Cloud Pak for Data team :/
-cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default('4.0.9', true)  }}"
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') }}"
 cpd_supported_versions: ['4.0.9', '4.5.0', '4.5.1', '4.5.2']
 cpd_minor_version: "{{ cpd_product_version | regex_search('(?<=)(.*)(?=..)') }}" # extract the cpd minor version as depending on the version some extra steps are needed i.e 4.0 or 4.5
 


### PR DESCRIPTION
This causes too much confusion.  CPD product version must always be supplied, otherwise risk unknowingly installing mismatching versions, which although supported by the operators, doesn't work so well in reality.

The defaults are now only set in the CP4D playbook, and MAS application playbooks that also install CP4D as a dependency.