### PR TITLE
[patch] Fix permission error on EFS Storage class

### DIFF
--- a/ibm/mas_devops/roles/ocp_efs/templates/efs-csi-storage-class.yml.j2
+++ b/ibm/mas_devops/roles/ocp_efs/templates/efs-csi-storage-class.yml.j2
@@ -5,10 +5,10 @@ metadata:
 provisioner: efs.csi.aws.com
 parameters:
   basePath: /rosa
-  directoryPerms: '755'
+  directoryPerms: '777'
   fileSystemId: "{{ efs_id }}"
-  gidRangeEnd: '20000'
-  gidRangeStart: '10000'
+  uid: "0"
+  gid: "0"
   provisioningMode: efs-ap
 reclaimPolicy: Delete
 volumeBindingMode: Immediate


### PR DESCRIPTION
This fixes the errors when deploying db2 on ROSA

<img width="1633" alt="image" src="https://user-images.githubusercontent.com/5027321/207084131-08a4da4a-c437-463b-82da-22186e65ef35.png">
