### PR TITLE
[patch] Fix registry CA cert path used when simulating airgap network

### DIFF
--- a/ibm/mas_devops/roles/ocp_simulate_disconnected_network/templates/mc2.yml.j2
+++ b/ibm/mas_devops/roles/ocp_simulate_disconnected_network/templates/mc2.yml.j2
@@ -15,4 +15,4 @@ spec:
           source: data:text/plain;charset=utf-8;base64,{{ registry_ca_crt_b64 }}
         mode: 0644
         overwrite: true
-        path: /etc/pki/ca-trust/source/anchors/registry-ca.crt
+        path: /etc/ssl/certs/registry-ca.crt


### PR DESCRIPTION
Fix registry cert path so that it is being used to pull fvt test cases images from the registry. 