### PR TITLE
[minor] Support FIPS option on FYRE infrastructure

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,6 +1,6 @@
 ## Changes
 Note that links to pull requests prior to public release of the code (4.0) direct to IBM GitHub Enterprise, and will only be accessible to IBM employees.
-
+- `12.4` Support FIPS option on FYRE infrastructure ([#562](https://github.com/ibm-mas/ansible-devops/pull/562))
 - `12.3` Multiple Updates:
     - Support ad-hoc DBC scripts into Manage server ([#521](https://github.com/ibm-mas/ansible-devops/pull/521))
     - Support IBM Cloud COS buckets and Manage logging feature ([#526](https://github.com/ibm-mas/ansible-devops/pull/526))

--- a/ibm/mas_devops/roles/ocp_provision/README.md
+++ b/ibm/mas_devops/roles/ocp_provision/README.md
@@ -169,6 +169,10 @@ Provide a description for the cluster.
 - Environment Variable: `FYRE_CLUSTER_DESCRIPTION`
 - Default Value: None
 
+- Optional
+- Environment Variable: `OCP_FIPS`
+- Default Value: false
+
 ### fyre_cluster_size
 The name of one of Fyre's pre-defined cluster sizes to use for the new cluster.
 

--- a/ibm/mas_devops/roles/ocp_provision/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/defaults/main.yml
@@ -90,3 +90,5 @@ ipi_config_dir: "{{ ipi_dir }}/config/{{ cluster_name }}"
 
 ocp_installer_dir: "{{ ipi_dir }}/installer/{{ ocp_version }}"
 ocp_installer_exe: "{{ ipi_dir }}/installer/{{ ocp_version }}/openshift-install"
+
+ocp_fips: "{{ lookup('env', 'OCP_FIPS') | default('no', true) }}"

--- a/ibm/mas_devops/roles/ocp_provision/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/defaults/main.yml
@@ -6,6 +6,7 @@ cluster_type: "{{ lookup('env', 'CLUSTER_TYPE')}}"
 cluster_platform: "{{lookup('env', 'CLUSTER_PLATFORM') | default('x',true)}}"
 
 ocp_version: "{{ lookup('env', 'OCP_VERSION') }}"
+ocp_fips: "{{ lookup('env', 'OCP_FIPS') | default('false', true) | bool }}"
 
 supported_cluster_types:
   - fyre
@@ -90,5 +91,3 @@ ipi_config_dir: "{{ ipi_dir }}/config/{{ cluster_name }}"
 
 ocp_installer_dir: "{{ ipi_dir }}/installer/{{ ocp_version }}"
 ocp_installer_exe: "{{ ipi_dir }}/installer/{{ ocp_version }}/openshift-install"
-
-ocp_fips: "{{ lookup('env', 'OCP_FIPS') | default('no', true) }}"

--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/fyre.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/fyre.yml
@@ -29,6 +29,7 @@
       - "Username ..................... {{ fyre_username }}"
       - "Fyre product ID .............. {{ fyre_product_id }}"
       - "Fyre Quota Type .............. {{ fyre_quota_type }}"
+      - "fips enabled ................. {{ ocp_fips }}"
       # Quickburn specific
       - "Fyre cluster size ............ {{ fyre_cluster_size | default('<undefined>', true) }}"
       # Product Group specific

--- a/ibm/mas_devops/roles/ocp_provision/templates/fyre/product_group.json.j2
+++ b/ibm/mas_devops/roles/ocp_provision/templates/fyre/product_group.json.j2
@@ -16,6 +16,7 @@
             "check": "10s"
         }
     },
+    "fips":"{{'yes' if ocp_fips else 'no'}}",
     "worker":  [
         {
             "count": "{{ fyre_worker_count }}",

--- a/ibm/mas_devops/roles/ocp_provision/templates/fyre/quick_burn.json.j2
+++ b/ibm/mas_devops/roles/ocp_provision/templates/fyre/quick_burn.json.j2
@@ -18,5 +18,5 @@
             "check": "10s"
         }
     },
-    "fips":"{{ ocp_fips }}"
+    "fips":"{{'yes' if ocp_fips else 'no'}}"
 }

--- a/ibm/mas_devops/roles/ocp_provision/templates/fyre/quick_burn.json.j2
+++ b/ibm/mas_devops/roles/ocp_provision/templates/fyre/quick_burn.json.j2
@@ -17,5 +17,6 @@
             "http-keep-alive": "10s",
             "check": "10s"
         }
-    }
+    },
+    "fips":"{{ ocp_fips }}"
 }


### PR DESCRIPTION
## Description
MAS Devops Ansible Collection to support enabling FIPS when provisioning an OCP cluster
fyre environment provision will be configured by setting an environment variable `OCP_FIPS = yes/no`

## Related Issues
- https://github.ibm.com/wiotp/tracker/issues/11038

## How Has This Been Tested?
Have created quickburn cluster on fyre by providing environment variable `OCP_FIPS` and also ran without providing the env