### PR TITLE
[patch] Fix regex in udscfg that manipulates certs

### DIFF
--- a/ibm/mas_devops/roles/uds/tasks/install/udscfg.yml
+++ b/ibm/mas_devops/roles/uds/tasks/install/udscfg.yml
@@ -61,7 +61,7 @@
 # is necessary :)
 - name: "udscfg : Set UDS cert variable"
   set_fact:
-    uds_tls_crt: "{{ cluster_ingress_tls_crt | regex_findall('(-----BEGIN .+?-----(?s).+?-----END .+?-----)', multiline=True, ignorecase=True) }}"
+    uds_tls_crt: "{{ cluster_ingress_tls_crt | regex_findall('(?s)(-----BEGIN .+?-----.+?-----END .+?-----)', multiline=True, ignorecase=True) }}"
 
 
 # 5. Debug


### PR DESCRIPTION
### Fix deprecated use of regex

https://github.com/ibm-mas/ansible-devops/issues/564

The regex in the task `udscfg` causes a deprecation warning (and error in Python 3.11). 

Simply move the global flag that allows for matching newlines to the beginning of the regex. 