### PR TITLE
[patch] Increase retry count for Db2 LDAP users

### DIFF
--- a/ibm/mas_devops/roles/db2/tasks/create_ldap_user.yml
+++ b/ibm/mas_devops/roles/db2/tasks/create_ldap_user.yml
@@ -52,6 +52,6 @@
   shell: |
     oc exec -it {{ db2_manage_pod_name }} -n {{ db2_namespace }} -c db2u -- su -lc "db2 connect to bludb user {{ db2_ldap_username }} using {{ db2_ldap_password }}" db2inst1
   register: db2_connect_result
-  retries: 6
+  retries: 20
   delay: 20
   until: db2_connect_result.rc == 0


### PR DESCRIPTION
This update increases the rety limit when setting up new LDAP users for Db2 to avoid failures in slower clusters.