### PR TITLE
[patch] Close timing window in WD wait logic

### DIFF
--- a/ibm/mas_devops/roles/cp4d_service/tasks/prereqs/prereqs-wd.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/prereqs/prereqs-wd.yml
@@ -15,6 +15,8 @@
   until:
     - cpd_cr_lookup.resources is defined
     - cpd_cr_lookup.resources | length == 1
+    - cpd_cr_lookup.resources[0].status is defined
+    - cpd_cr_lookup.resources[0].status.phase is defined
     - cpd_cr_lookup.resources[0].status.phase == "Running"
   retries: 30 # Up to 1 hour
   delay: 120 # Every 2 minutes
@@ -31,6 +33,8 @@
   until:
     - cpd_pod_lookup.resources is defined
     - cpd_pod_lookup.resources | length == 1
+    - cpd_pod_lookup.resources[0].status is defined
+    - cpd_pod_lookup.resources[0].status.phase is defined
     - cpd_pod_lookup.resources[0].status.phase == "Running"
   retries: 30 # Up to 1 hour
   delay: 120 # Every 2 minutes


### PR DESCRIPTION
While waiting for WD prereqs, we wait for a field to contain a certain value but we do not wait for the field to first exist, so on a slow cluster the logic will fail as below:

```
TASK [ibm.mas_devops.cp4d_service : prereqs-wd : Wait for operand request to be processed] ***
Wednesday 21 December 2022  01:17:37 +0000 (0:00:01.194)       0:00:08.768 **** 
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'cpd_cr_lookup.resources[0].status.phase == \"Running\"' failed. The error was: error while evaluating conditional (cpd_cr_lookup.resources[0].status.phase == \"Running\"): 'dict object' has no attribute 'status'"}
```