### PR TITLE
[patch] Increase ImagePullBackoff polling to 30 minutes

### DIFF
--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wd.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wd.yml
@@ -66,7 +66,7 @@
       imagePullSecrets:
         - name: ibm-entitlement-key
 
-# 3. Spend 15 minutes looking for pods stuck in ImagePullBackoff state
+# 3. Spend 30 minutes looking for pods stuck in ImagePullBackoff state
 # -----------------------------------------------------------------------------
 # If we look for pods in image pull backoff too early then we won't know which ones to
 # boot so that they pick up the image pull secret as it takes a while for pods to get
@@ -84,6 +84,33 @@
   include_tasks: wait-wd-detectimagepullbackoff.yml
 
 - name: "wait-wd : Catch any pods caughts in ImgPullBackOff (3)"
+  when:
+    - cpd_cr_wait_lookup.resources is defined
+    - cpd_cr_wait_lookup.resources | length == 1
+    - cpd_cr_wait_lookup.resources[0].status is defined
+    - cpd_cr_wait_lookup.resources[0].status.watsonDiscoveryStatus is defined
+    - cpd_cr_wait_lookup.resources[0].status.watsonDiscoveryStatus != "Completed"
+  include_tasks: wait-wd-detectimagepullbackoff.yml
+
+- name: "wait-wd : Catch any pods caughts in ImgPullBackOff (4)"
+  when:
+    - cpd_cr_wait_lookup.resources is defined
+    - cpd_cr_wait_lookup.resources | length == 1
+    - cpd_cr_wait_lookup.resources[0].status is defined
+    - cpd_cr_wait_lookup.resources[0].status.watsonDiscoveryStatus is defined
+    - cpd_cr_wait_lookup.resources[0].status.watsonDiscoveryStatus != "Completed"
+  include_tasks: wait-wd-detectimagepullbackoff.yml
+
+- name: "wait-wd : Catch any pods caughts in ImgPullBackOff (5)"
+  when:
+    - cpd_cr_wait_lookup.resources is defined
+    - cpd_cr_wait_lookup.resources | length == 1
+    - cpd_cr_wait_lookup.resources[0].status is defined
+    - cpd_cr_wait_lookup.resources[0].status.watsonDiscoveryStatus is defined
+    - cpd_cr_wait_lookup.resources[0].status.watsonDiscoveryStatus != "Completed"
+  include_tasks: wait-wd-detectimagepullbackoff.yml
+
+- name: "wait-wd : Catch any pods caughts in ImgPullBackOff (6)"
   when:
     - cpd_cr_wait_lookup.resources is defined
     - cpd_cr_wait_lookup.resources | length == 1


### PR DESCRIPTION
We want to catch this pod getting stuck in image pull backoff, but lately it's taking longer to get into this state and we are missing it ... we patch the serviceaccount that it uses the expected imagePullSecret (Discovery team are aware of the bug, but no plans to fix it yet), but in most cases we won't patch it early enough for the pod to work first time; thus we watch for the pod to be in `ImagePullBackOff` and if we detect this, we delete pod, forcing it to pull using the now-patched service account.

```
wd-discovery-cn-postgres-1-initdb--1-lnqss         0/1     ImagePullBackOff   0               31m
```