### PR TITLE
[patch] Fix IoT v8.6.0 digest map

### DIFF
--- a/ibm/mas_devops/common_vars/digests/ibm-mas-iot/8.6.0.yaml
+++ b/ibm/mas_devops/common_vars/digests/ibm-mas-iot/8.6.0.yaml
@@ -70,7 +70,9 @@ cp.icr.io/cp/wiotp/kafkamodel-state:1.4.6: cp.icr.io/cp/wiotp/kafkamodel-state@s
 cp.icr.io/cp/wiotp/masuseragent:1.4.8: cp.icr.io/cp/wiotp/masuseragent@sha256:06a65a089e71b9cb07bf64da7bdd75faa265970de868309e2da460cdc5aed1d3
 cp.icr.io/cp/wiotp/messagesight-configurator:5.14.35: cp.icr.io/cp/wiotp/messagesight-configurator@sha256:e90f01c84e4a84fefafdcf02731b8f79c08d23d3501c3cdccb1f532514c346bf
 cp.icr.io/cp/wiotp/messagesight:5.14.35: cp.icr.io/cp/wiotp/messagesight@sha256:24597be9d139ba12c4573fff74a41f1323d77be9443469d8633fbd4bde8e6744
-cp.icr.io/cp/wiotp/monagent-iot:1.0.3: cp.icr.io/cp/wiotp/monagent-iot@sha256:d0e470681a17e9db13b0f2677762561a4e46b05c61f286f6a2d349c10dc7bfd3
+# This is the wrong image for IoT 8.6.0
+# cp.icr.io/cp/wiotp/monagent-iot:1.0.3: cp.icr.io/cp/wiotp/monagent-iot@sha256:d0e470681a17e9db13b0f2677762561a4e46b05c61f286f6a2d349c10dc7bfd3
+cp.icr.io/cp/wiotp/monagent-iot:1.1.0: cp.icr.io/cp/wiotp/monagent-iot@sha256:da292da546da4acdc27f9865b0040384dcb79ca16eb9455ea907ffdcd5c37b0c
 cp.icr.io/cp/wiotp/monagent-msserver:4.3.70: cp.icr.io/cp/wiotp/monagent-msserver@sha256:9067b5c576333dcd272883cb20ccd45950cdd5f30e2d566c8af7501e2079b1be
 cp.icr.io/cp/wiotp/monagent-org:2.1.83: cp.icr.io/cp/wiotp/monagent-org@sha256:0ac2638d4d4c590fa7a3566aa6b8a902de54e8ecbd93c61c851a0cbe461cedf3
 cp.icr.io/cp/wiotp/mongomodel-actions:1.2.76: cp.icr.io/cp/wiotp/mongomodel-actions@sha256:b30714e01aedcf2654f718308a29591157937290301cb2c157ea1536975bdd79


### PR DESCRIPTION
Another CASE bundle packaging error that we need to work around for airgap support of IoT v8.6.0.