### PR TITLE
[patch] Fix MVI airgap installation

### DIFF
--- a/ibm/mas_devops/roles/suite_app_install/tasks/install_digest_cm.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/install_digest_cm.yml
@@ -46,7 +46,9 @@
 
 # 4. Lookup the OperatorCondition for Truststore Manager
 # -----------------------------------------------------------------------------
+# Note that Visual Inspection does not use/need the IBM Truststore Manager
 - name: "Lookup Truststore Manager operator version"
+  when: mas_app_id != "visualinspection"
   kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v2
     kind: OperatorCondition
@@ -64,14 +66,18 @@
 
 # 5. If TSM is installed, determine at which version
 # -----------------------------------------------------------------------------
+# Note that Visual Inspection does not use/need the IBM Truststore Manager
 - name: "Lookup Truststore Manager operator version"
+  when: mas_app_id != "visualinspection"
   set_fact:
     tsm_operator_version: "{{ tsm_opcon.resources[0].metadata.name.split('.v')[1] }}"
 
 
 # 6. If TSM is installed, install it's digest map
 # -----------------------------------------------------------------------------
+# Note that Visual Inspection does not use/need the IBM Truststore Manager
 - name: "Create ibm-truststore-mgr Image Digest Map"
+  when: mas_app_id != "visualinspection"
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   vars:


### PR DESCRIPTION
Visual Inspection does not use IBM Truststore Manager, so we do not need to perform steps 4, 5, and 6.