### PR TITLE
[patch] Fix playbook use of IBM_ENTITLEMENT_KEY

### DIFF
--- a/docs/playbooks/oneclick-iot.md
+++ b/docs/playbooks/oneclick-iot.md
@@ -34,7 +34,7 @@ Usually fulfilled by block storage classes:
 ## Required environment variables
 - `MAS_INSTANCE_ID` Declare the instance ID for the MAS install
 - `MAS_CONFIG_DIR` Directory where generated config files will be saved (you may also provide pre-generated config files here)
-- `MAS_ENTITLEMENT_KEY` Your IBM Entitlement key to access the IBM Container Registry
+- `IBM_ENTITLEMENT_KEY` Your IBM Entitlement key to access the IBM Container Registry
 
 ## Optional environment variables
 - `MAS_APP_SETTINGS_IOT_DEPLOYMENT_SIZE` Define the IoT deployment size, one of `dev`,
@@ -44,7 +44,7 @@ Usually fulfilled by block storage classes:
 ```bash
 export MAS_INSTANCE_ID=inst1
 export MAS_CONFIG_DIR=/home/david/masconfig
-export MAS_ENTITLEMENT_KEY=xxx
+export IBM_ENTITLEMENT_KEY=xxx
 
 oc login --token=xxxx --server=https://myocpserver
 ansible-playbook ibm.mas_devops.oneclick_add_iot

--- a/docs/playbooks/oneclick-manage.md
+++ b/docs/playbooks/oneclick-manage.md
@@ -23,7 +23,7 @@ All timings are estimates, see the individual pages for each of these playbooks 
 ## Required environment variables
 - `MAS_INSTANCE_ID` Declare the instance ID for the MAS install
 - `MAS_CONFIG_DIR` Directory where generated config files will be saved (you may also provide pre-generated config files here)
-- `MAS_ENTITLEMENT_KEY` Your IBM Entitlement key to access the IBM Container Registry
+- `IBM_ENTITLEMENT_KEY` Your IBM Entitlement key to access the IBM Container Registry
 - `MAS_APP_ID` Declare app_id as either `manage` or `health`
 
 !!! tip
@@ -45,7 +45,7 @@ All timings are estimates, see the individual pages for each of these playbooks 
 ```bash
 export MAS_INSTANCE_ID=inst1
 export MAS_CONFIG_DIR=~/masconfig
-export MAS_ENTITLEMENT_KEY=xxx
+export IBM_ENTITLEMENT_KEY=xxx
 export MAS_APP_ID=manage
 
 oc login --token=xxxx --server=https://myocpserver

--- a/docs/playbooks/oneclick-monitor.md
+++ b/docs/playbooks/oneclick-monitor.md
@@ -18,13 +18,13 @@ All timings are estimates, see the individual pages for each of these playbooks 
 ## Required environment variables
 - `MAS_INSTANCE_ID` Declare the instance ID for the MAS install
 - `MAS_CONFIG_DIR` Directory where generated config files will be saved (you may also provide pre-generated config files here)
-- `MAS_ENTITLEMENT_KEY` Your IBM Entitlement key to access the IBM Container Registry
+- `IBM_ENTITLEMENT_KEY` Your IBM Entitlement key to access the IBM Container Registry
 
 ## Usage
 ```bash
 export MAS_INSTANCE_ID=inst1
 export MAS_CONFIG_DIR=/home/david/masconfig
-export MAS_ENTITLEMENT_KEY=xxx
+export IBM_ENTITLEMENT_KEY=xxx
 
 oc login --token=xxxx --server=https://myocpserver
 ansible-playbook ibm.mas_devops.oneclick_add_monitor

--- a/docs/playbooks/oneclick-optimizer.md
+++ b/docs/playbooks/oneclick-optimizer.md
@@ -17,13 +17,13 @@ All timings are estimates, see the individual pages for each of these playbooks 
 ## Required environment variables
 - `MAS_INSTANCE_ID` Declare the instance ID for the MAS install
 - `MAS_CONFIG_DIR` Directory where generated config files will be saved (you may also provide pre-generated config files here)
-- `MAS_ENTITLEMENT_KEY` Your IBM Entitlement key to access the IBM Container Registry
+- `IBM_ENTITLEMENT_KEY` Your IBM Entitlement key to access the IBM Container Registry
 
 ## Usage
 ```bash
 export MAS_INSTANCE_ID=inst1
 export MAS_CONFIG_DIR=/home/david/masconfig
-export MAS_ENTITLEMENT_KEY=xxx
+export IBM_ENTITLEMENT_KEY=xxx
 
 oc login --token=xxxx --server=https://myocpserver
 ansible-playbook ibm.mas_devops.oneclick_add_optimizer

--- a/docs/playbooks/oneclick-predict.md
+++ b/docs/playbooks/oneclick-predict.md
@@ -23,7 +23,7 @@ All timings are estimates, see the individual pages for each of these playbooks 
 ## Required environment variables
 - `MAS_INSTANCE_ID` Declare the instance ID for the MAS install
 - `MAS_CONFIG_DIR` Directory where generated config files will be saved (you may also provide pre-generated config files here)
-- `MAS_ENTITLEMENT_KEY` Your IBM Entitlement key to access the IBM Container Registry
+- `IBM_ENTITLEMENT_KEY` Your IBM Entitlement key to access the IBM Container Registry
 - `WML_INSTANCE_ID` Set Default value to "openshift"
 - `WML_URL` Set Default value to "https://internal-nginx-svc.ibm-cpd.svc:12443" . ibm-cpd in the URL corresponds to the project name (namespace) of cp4d installation
 - `CPD_PRODUCT_VERSION` (Required if `WML_VERSION` is not informed) Cloud Pak for Data version installed in the cluster in 4.X format, it will be used to obtain the correct WML version to be installed
@@ -62,7 +62,7 @@ All timings are estimates, see the individual pages for each of these playbooks 
 ```bash
 export MAS_INSTANCE_ID=inst1
 export MAS_CONFIG_DIR=~/masconfig
-export MAS_ENTITLEMENT_KEY=xxx
+export IBM_ENTITLEMENT_KEY=xxx
 
 export CPD_ADMIN_USERNAME="admin"
 export CPD_ADMIN_PASSWORD="xxx"
@@ -81,7 +81,7 @@ ansible-playbook ibm.mas_devops.oneclick_add_predict
 ```bash
 export MAS_INSTANCE_ID=inst1
 export MAS_CONFIG_DIR=~/masconfig
-export MAS_ENTITLEMENT_KEY=xxx
+export IBM_ENTITLEMENT_KEY=xxx
 
 export CP4D_INSTALL_PLATFORM="true"
 export CP4D_INSTALL_WSL="true"

--- a/docs/playbooks/oneclick-visualinspection.md
+++ b/docs/playbooks/oneclick-visualinspection.md
@@ -19,13 +19,13 @@ All timings are estimates, see the individual pages for each of these playbooks 
 ## Required environment variables
 - `MAS_INSTANCE_ID` Declare the instance ID for the MAS install
 - `MAS_CONFIG_DIR` Directory where generated config files will be saved (you may also provide pre-generated config files here)
-- `MAS_ENTITLEMENT_KEY` Your IBM Entitlement key to access the IBM Container Registry
+- `IBM_ENTITLEMENT_KEY` Your IBM Entitlement key to access the IBM Container Registry
 
 ## Usage
 ```bash
 export MAS_INSTANCE_ID=inst1
 export MAS_CONFIG_DIR=/home/david/masconfig
-export MAS_ENTITLEMENT_KEY=xxx
+export IBM_ENTITLEMENT_KEY=xxx
 
 oc login --token=xxxx --server=https://myocpserver
 ansible-playbook ibm.mas_devops.oneclick_add_visualinspection

--- a/ibm/mas_devops/playbooks/oneclick_add_assist.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_assist.yml
@@ -34,7 +34,7 @@
         that:
           - lookup('env', 'MAS_INSTANCE_ID') != ""
           - lookup('env', 'MAS_CONFIG_DIR') != ""
-          - lookup('env', 'MAS_ENTITLEMENT_KEY') != ""
+          - lookup('env', 'IBM_ENTITLEMENT_KEY') != ""
         fail_msg: "One or more required environment variables are not defined"
 
   roles:

--- a/ibm/mas_devops/playbooks/oneclick_add_optimizer.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_optimizer.yml
@@ -22,7 +22,7 @@
         that:
           - lookup('env', 'MAS_INSTANCE_ID') != ""
           - lookup('env', 'MAS_CONFIG_DIR') != ""
-          - lookup('env', 'MAS_ENTITLEMENT_KEY') != ""
+          - lookup('env', 'IBM_ENTITLEMENT_KEY') != ""
         fail_msg: "One or more required environment variables are not defined"
 
   roles:

--- a/ibm/mas_devops/playbooks/oneclick_add_predict.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_predict.yml
@@ -67,7 +67,7 @@
       assert:
         that:
           - lookup('env', 'MAS_INSTANCE_ID') != ""
-          - lookup('env', 'MAS_ENTITLEMENT_KEY') != ""
+          - lookup('env', 'IBM_ENTITLEMENT_KEY') != ""
           - cpd_url != ""
           - cpd_admin_username != ""
           - cpd_admin_password != ""

--- a/ibm/mas_devops/playbooks/oneclick_add_visualinspection.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_visualinspection.yml
@@ -24,7 +24,7 @@
         that:
           - lookup('env', 'MAS_INSTANCE_ID') != ""
           - lookup('env', 'MAS_CONFIG_DIR') != ""
-          - lookup('env', 'MAS_ENTITLEMENT_KEY') != ""
+          - lookup('env', 'IBM_ENTITLEMENT_KEY') != ""
         fail_msg: "One or more required environment variables are not defined"
 
   roles:


### PR DESCRIPTION
Multiple playbooks are set up to use MAS_ENTITLEMENT_KEY (development override) instead of the primary IBM_ENTITLEMENT_KEY environment variable.  This update corrects that.