### PR TITLE
[patch] Increase CertManagerController CPU limit

### DIFF
--- a/ibm/mas_devops/roles/cert_manager/tasks/main.yml
+++ b/ibm/mas_devops/roles/cert_manager/tasks/main.yml
@@ -33,7 +33,7 @@
     wait_timeout: 120
 
 - name: Increase common service cpu limit to account for increased cert privateKey sizings
- kubernetes.core.k8s:
+  kubernetes.core.k8s:
    template: 'templates/ibm-cert-manager-common-service.yml'
    wait: yes
    wait_timeout: 120

--- a/ibm/mas_devops/roles/cert_manager/tasks/main.yml
+++ b/ibm/mas_devops/roles/cert_manager/tasks/main.yml
@@ -32,17 +32,11 @@
     wait: yes
     wait_timeout: 120
 
-# Disabled ... causes install pipeline failure:
-#
-# TASK [ibm.mas_devops.cert_manager : Increase common service cpu limit to account for increased cert privateKey sizings] ***
-# Thursday 22 December 2022  14:36:20 +0000 (0:00:01.412)       0:00:04.905 *****
-# fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to find exact match for operator.ibm.com/v1alpha1.CommonService by [kind, name, singularName, shortNames]"}
-#
-#- name: Increase common service cpu limit to account for increased cert privateKey sizings
-#  kubernetes.core.k8s:
-#    template: 'templates/ibm-cert-manager-common-service.yml'
-#    wait: yes
-#    wait_timeout: 120
+- name: Increase common service cpu limit to account for increased cert privateKey sizings
+ kubernetes.core.k8s:
+   template: 'templates/ibm-cert-manager-common-service.yml'
+   wait: yes
+   wait_timeout: 120
 
 - name: "Wait for ibm-cert-manager-operator to be ready (60s delay)"
   kubernetes.core.k8s_info:

--- a/ibm/mas_devops/roles/cert_manager/templates/ibm-cert-manager-common-service.yml
+++ b/ibm/mas_devops/roles/cert_manager/templates/ibm-cert-manager-common-service.yml
@@ -1,8 +1,8 @@
 ---
 apiVersion: operator.ibm.com/v1alpha1
-kind: CommonService
+kind: OperandRequest
 metadata:
-  name: ibm-cert-manager-operator
+  name: common-service
   namespace: ibm-common-services
 spec:
   certManager:

--- a/ibm/mas_devops/roles/ibm_catalogs/defaults/main.yml
+++ b/ibm/mas_devops/roles/ibm_catalogs/defaults/main.yml
@@ -6,4 +6,3 @@ artifactory_username: "{{ lookup('env', 'ARTIFACTORY_USERNAME') | lower }}"
 artifactory_apikey: "{{ lookup('env', 'ARTIFACTORY_APIKEY') }}"
 
 mas_catalog_version: "{{ lookup('env', 'MAS_CATALOG_VERSION') | default ('v8-amd64', True) }}"
-


### PR DESCRIPTION
## Description
Fixing the task introduced in #563 that was then disabled in #573 

**The change has the same purpose as the [original PR (563)](https://github.com/ibm-mas/ansible-devops/pull/563) intended:**
With the new change to certificates in MAS that will need produce privateKey sizings of 4096 instead of 2048 we see that when installing a fresh install (new cluster, new cert-manager etc) around 5 times as long to get the suite ready due to the increased sizing. This change should provide a new Kubernetes CPU unit limit of 1000m instead of the previous of 80m ([as documented here](https://www.ibm.com/docs/en/cpfs?topic=services-configuring-foundational-by-using-custom-resource#cert_contr))