### PR TITLE
[patch] Update cert-manager sizing call

### DIFF
--- a/ibm/mas_devops/roles/cert_manager/tasks/main.yml
+++ b/ibm/mas_devops/roles/cert_manager/tasks/main.yml
@@ -32,12 +32,6 @@
     wait: yes
     wait_timeout: 120
 
-- name: Increase common service cpu limit to account for increased cert privateKey sizings
-  kubernetes.core.k8s:
-   template: 'templates/ibm-cert-manager-common-service.yml'
-   wait: yes
-   wait_timeout: 120
-
 - name: "Wait for ibm-cert-manager-operator to be ready (60s delay)"
   kubernetes.core.k8s_info:
     api_version: apps/v1
@@ -71,3 +65,9 @@
     - certmanager_webhook_deployment.resources[0].status.readyReplicas == certmanager_webhook_deployment.resources[0].status.replicas
   retries: 60 # Approximately 1/2 hour before we give up
   delay: 60 # 1 minute
+
+- name: Increase common service cpu limit to account for increased cert privateKey sizings
+  kubernetes.core.k8s:
+   template: 'templates/ibm-cert-manager-common-service.yml'
+   wait: yes
+   wait_timeout: 120

--- a/ibm/mas_devops/roles/cert_manager/templates/ibm-cert-manager-common-service.yml
+++ b/ibm/mas_devops/roles/cert_manager/templates/ibm-cert-manager-common-service.yml
@@ -1,12 +1,11 @@
 ---
 apiVersion: operator.ibm.com/v1alpha1
-kind: OperandRequest
+kind: CertManager
 metadata:
-  name: common-service
+  name: default
   namespace: ibm-common-services
 spec:
-  certManager:
     certManagerController:
       resources:
         limits:
-          cpu: 1000
+          cpu: 1000m


### PR DESCRIPTION
Building on https://github.com/ibm-mas/ansible-devops/pull/605 - this change means that the sizing increase mentioned there will instead target the default certManager instance.

_See [relevant slack thread](https://ibm-watson-iot.slack.com/archives/C031Q7W21FZ/p1673955769867269)_

**Tested on active cluster as shown below:**

![image](https://user-images.githubusercontent.com/51744616/212910229-a6771371-a778-4a05-aaef-b234c20831f7.png)