### PR TITLE
[patch] adding flag to enhance dns security

### DIFF
--- a/ibm/mas_devops/plugins/modules/cis_dns_entries.py
+++ b/ibm/mas_devops/plugins/modules/cis_dns_entries.py
@@ -55,17 +55,17 @@ def main():
 
         cis_waf = dict(
             type = 'bool',
-            required = True
+            required = False
         ),
 
         edge_certificate_routes = dict(
             type = 'list',
-            required = True
+            required = False
         ),
 
         cis_proxy = dict(
             type = 'bool',
-            required = True
+            required = False
         ),
 
         cis_subdomain = dict(

--- a/ibm/mas_devops/roles/suite_dns/README.md
+++ b/ibm/mas_devops/roles/suite_dns/README.md
@@ -121,6 +121,26 @@ Role Variables - IBM Cloud Internet Services DNS Integration
 - Environment Variable: `CIS_SUBDOMAIN`
 - Default: None
 
+### cis_enhanced_security
+Set this to true to enable the enhanced CIS DNS integration security. See below for details.
+
+- Optional
+- Environment Variable: `CIS_ENHANCED_SECURITY`
+- Default: false
+
+
+Role Variables - Enhanced IBM CIS DNS Integration Secruity
+------------------------------------------------------------
+- Enable WAF firewall disabling rules that affect MAS application functionalities
+- Enable Proxy for DNS entries
+- Ensure there are no wildcard DNS entry in CIS
+- Create Edge Certificates in CIS instance
+
+### ibmcloud_api_key
+
+- **Required** if `cis_enhanced_security` is set to `true`
+- Environment Variable: `IBMCLOUD_API_KEY`
+
 ### cis_waf
 
 - Optional
@@ -160,12 +180,6 @@ Set this to false to not override and delete any existing edge certificates in c
 - Environment Variable: `OVERRIDE_EDGE_CERTS`
 - Default: true
 
-### cis_skip_dns_entries
-Set this to true to skip DNS entries creation
-
-- Optional
-- Environment Variable: `CIS_SKIP_DNS_ENTRIES`
-- Default: false
 
 ### output_dir
 Location to output the edge-routes-{mas_instance_id}.txt

--- a/ibm/mas_devops/roles/suite_dns/defaults/main.yaml
+++ b/ibm/mas_devops/roles/suite_dns/defaults/main.yaml
@@ -41,6 +41,11 @@ cis_email: "{{ lookup('env', 'CIS_EMAIL') }}"
 cis_apikey: "{{ lookup('env', 'CIS_APIKEY') }}"
 cis_crn: "{{ lookup('env', 'CIS_CRN') }}"
 cis_subdomain: "{{ lookup('env', 'CIS_SUBDOMAIN') }}"
+cis_enhanced_security: "{{ lookup('env', 'CIS_ENHANCED_SECURITY') | default(false, false) }}"
+
+# Enhanced IBM CIS DNS Integration Secruity
+# -----------------------------------------------------------------------------
+ibmcloud_api_key: "{{ lookup('env', 'IBMCLOUD_API_KEY') | default(true, true) }}"
 cis_waf: "{{ lookup('env', 'CIS_WAF') | default(true, true) }}"
 cis_proxy: "{{ lookup('env', 'CIS_PROXY') | default(false, true) }}"
 cis_service_name: "{{ lookup('env', 'CIS_SERVICE_NAME')}}"
@@ -50,9 +55,6 @@ update_dns: "{{ lookup('env', 'UPDATE_DNS_ENTRIES') | default(true, true) }}"
 delete_wildcards: "{{ lookup('env', 'DELETE_WILDCARDS') | default(false, true)}}"
 # Override and delete any existing edge certificates in cis instance
 override_edge_certs: "{{ lookup('env', 'OVERRIDE_EDGE_CERTS') | default(true, true)}}"
-# Skip DNS entries creation
-cis_skip_dns_entries: "{{ lookup('env', 'CIS_SKIP_DNS_ENTRIES') | default(false, true) }}"
-
 
 cis_apiservice:
   group_name: acme.cis.ibm.com

--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
@@ -1,3 +1,4 @@
+---
 - name: "cis : Ensure IBMCloud CIS is installed"
   ansible.builtin.shell: |
     ibmcloud plugin install cis -f
@@ -35,13 +36,13 @@
     hasDedicated: "{{'advanced' in _cis_certificates.stdout_lines[2]}}"
     dedicatedId: "{{ _cis_certificates.stdout_lines[2].split(' ')[0]}}"
 
-- name: Delete Existent Advanced Edge Certificate
+- name: "cis : Delete Existent Advanced Edge Certificate"
   ansible.builtin.shell: |
     ibmcloud cis certificate-delete {{(_cis_domains_result.stdout | from_json)[0].id}}  {{dedicatedId}} -i {{cis_service_name}} -f
   when: hasDedicated and override_edge_certs
   register: _deleted_certificate
 
-- name: Order certificate if there no dedicated yet
+- name: "cis : Order certificate if there no dedicated yet"
   ansible.builtin.shell: |
     ibmcloud cis certificate-order {{(_cis_domains_result.stdout | from_json)[0].id}} --hostnames {{edge_cert_routes|join(',')}} -i {{cis_service_name}}
   when:

--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_suitedns_basic.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_suitedns_basic.yml
@@ -20,7 +20,7 @@
     name: cluster
   register: _cluster_subdomain
 
-- name: "cis : onfigure ingress"
+- name: "Configure ingress"
   when: ocp_ingress is not defined or ocp_ingress == ""
   set_fact:
     ocp_ingress: "cis-proxy-route.{{ _cluster_subdomain.resources[0].spec.domain }}"
@@ -29,53 +29,49 @@
 # 3. Set up the DNS entries
 # =============================================================================
 - name: "cis : Define DNS Entries"
-  include_vars: vars/dnsentries.yml
-
-# Load variables to order the edge certificate
-- name: "cis : Define Edge Certificate Routes"
-  include_vars: vars/edge_certificate_routes.yml
+  set_fact:
+    dns_entries:
+      - ""
+      - "*"
+      - "*.api.monitor"
+      - "*.assist"
+      - "*.health"
+      - "*.home"
+      - "*.hputilities"
+      - "*.iot"
+      - "*.manage"
+      - "*.messaging.iot"
+      - "*.monitor"
+      - "*.predict"
+      - "*.safety"
+      - "*.visualinspection"
+      - "cis.test.cert"
+      - "cp4d"
 
 - name: "cis : Debug information"
   debug:
     msg:
-      - "CIS CRN .................. {{ cis_crn }}"
-      - "CIS Subdomain ............ {{ cis_subdomain }}"
-      - "OpenShift Ingress ........ {{ ocp_ingress }}"
-      - "CIS WAF .................. {{ cis_waf }}"
-      - "Delete Wildcards ......... {{ delete_wildcards }}"
-      - "Override Edge Certs ...... {{ override_edge_certs }}"
-      - "Update DNS Entries ....... {{ update_dns }}"
-      - "DNS Entries .............. {{ dns_entries }}"
+      - "CIS CRN ................................ {{ cis_crn }}"
+      - "CIS Subdomain .......................... {{ cis_subdomain }}"
+      - "OpenShift Ingress ...................... {{ ocp_ingress }}"
+      - "DNS Entries ............................ {{ dns_entries }}"
 
 
 # 4. Add DNS entries
 # =============================================================================
-- name: "cis : run cis_dns_entries module (this can take several minutes)"
+- name: "cis : run cis_dns_entries module"
   ibm.mas_devops.cis_dns_entries:
     ocp_ingress: "{{ ocp_ingress }}"
     cis_crn: "{{ cis_crn }}"
     cis_subdomain: "{{ cis_subdomain }}"
-    update_dns: "{{ update_dns }}"
+    update_dns: true
     cis_apikey: "{{ cis_apikey }}"
-    delete_wildcards: "{{ delete_wildcards }}"
     dns_entries: "{{ dns_entries }}"
-    cis_waf: "{{ cis_waf }}"
-    edge_certificate_routes: "{{edge_cert_routes}}"
-    cis_proxy: "{{cis_proxy}}"
+    cis_waf: null
+    edge_certificate_routes: null
+    cis_proxy: null
   register: dnsoutput
 
 - name: "cis : dump output"
   debug:
     msg: '{{ dnsoutput }}'
-
-- name: "cis : Show Edge Routes to create the Certificate"
-  debug:
-    msg:
-      - "CIS has been updated with the non wildcard CNAMES"
-      - "Use the following routes to create the certificate"
-      - "{{edge_cert_routes}}"
-
-- name: "cis : Copy routes to file"
-  ansible.builtin.template:
-    src: routes_edge_certificates.txt.j2
-    dest: "{{ output_dir }}/edge-routes-{{ mas_instance_id }}.txt"

--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_suitedns_enhanced.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_suitedns_enhanced.yml
@@ -1,0 +1,19 @@
+---
+- include_tasks: tasks/providers/cis/cis_dns_mgmt.yml
+
+- name: "cis : login to IBM Cloud"
+  shell: |
+    ibmcloud login --apikey "{{ ibmcloud_apikey }}" -q --no-region
+  retries: 10
+  delay: 60
+
+- include_tasks: tasks/providers/cis/cis_edge_certificate.yml
+
+# Load the WAF rules to disable
+- name: "cis : WAF rules to disable"
+  include_vars: vars/waf_rules_to_disable.yml
+
+- include_tasks: tasks/providers/cis/cis_waf_rule.yml
+  loop: "{{ waf_rules_to_disable }}"
+
+- include_tasks: tasks/providers/cis/cis_domain_setting.yml

--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/main.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/main.yml
@@ -1,24 +1,13 @@
 ---
-
-- include_tasks: tasks/providers/cis/cis_dns_mgmt.yml
+- name: "cis : running standard cis suite dns"
+  include_tasks: tasks/providers/cis/cis_suitedns_basic.yml
   when:
-    - not cis_skip_dns_entries
+    - not cis_enhanced_security
 
-- include_tasks: tasks/providers/cis/cis_edge_certificate.yml
+- name: "cis : running cis suite dns with enhanced security"
+  include_tasks: tasks/providers/cis/cis_suitedns_enhanced.yml
   when:
-    - not cis_skip_dns_entries
-
-# Load the WAF rules to disable
-- name: "WAF rules to disable"
-  include_vars: vars/waf_rules_to_disable.yml
-
-- include_tasks: tasks/providers/cis/cis_waf_rule.yml
-  loop: "{{ waf_rules_to_disable }}"
-  when:
-    - not cis_skip_dns_entries
-
-- include_tasks: tasks/providers/cis/cis_domain_setting.yml
-  when:
-    - not cis_skip_dns_entries
+    - cis_enhanced_security
 
 - include_tasks: tasks/providers/cis/cis_webhook.yml
+


### PR DESCRIPTION
- Added `cis_enhanced_security` flag (default: false) so that users can choose to use the new or old cis suitedns methods
- Removed need to log into ibmcloud in the terminal to run the enhanced version
- Updated readMe to include details on what the enhanced security option means

See [relevant slack thread](https://ibm-watson-iot.slack.com/archives/C0195MVCEUD/p1673989120058799?thread_ts=1673986757.612829&cid=C0195MVCEUD)