### PR TITLE
[patch] Revert "Refine setupdb.sh reviewed by DBA (#576)"

### DIFF
--- a/ibm/mas_devops/roles/suite_db2_setup_for_manage/README.md
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_manage/README.md
@@ -56,13 +56,6 @@ The size of the tablespace indexes in the database.
 - Environment Variable: DB2_TABLESPACE_INDEX_SIZE
 - Default Value: `5000 M`
 
-### db2_mirrorlog_path
-The mirrorlog path replicates the active transaction logs.
-
-- Optional
-- Environment Variable: DB2_MIRRORLOG_PATH
-- Default Value: `/mnt/backup/MIRRORLOGPATH`
-
 
 Example Playbook
 ----------------

--- a/ibm/mas_devops/roles/suite_db2_setup_for_manage/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_manage/defaults/main.yml
@@ -4,7 +4,6 @@ db2_username: db2inst1
 db2_dbname: "{{ lookup('env', 'DB2_DBNAME') | default('BLUDB', true) }}"
 db2_tablespace_data_size: "{{ lookup('env', 'DB2_TABLESPACE_DATA_SIZE') | default('5000 M', true) }}"
 db2_tablespace_index_size: "{{ lookup('env', 'DB2_TABLESPACE_INDEX_SIZE') | default('5000 M', true) }}"
-db2_mirrorlog_path: "{{ lookup('env', 'DB2_MIRRORLOG_PATH') | default('/mnt/backup/MIRRORLOGPATH', true) }}"
 
 # TODO: The default that is built into the manage operator isn't following
 # the naming conventions for MAS.  It should have been some combination of

--- a/ibm/mas_devops/roles/suite_db2_setup_for_manage/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_manage/tasks/main.yml
@@ -61,11 +61,6 @@
 
 # 3. Prepare database for use with Maximo TPAE
 # -----------------------------------------------------------------------------
-- name: "Creating MIRRORLOGPATH folder in {{ db2_pod_name }}"
-  shell: |
-    oc exec -it -n {{ db2_namespace }} {{ db2_pod_name }} -- su -lc "rm -rf {{ db2_mirrorlog_path }} ; mkdir -p {{ db2_mirrorlog_path }}" db2inst1
-  register: creating_mirrorlog_folder_output
-
 - name: Create setupdb script in local /tmp
   ansible.builtin.template:
     src: setupdb.sh.j2

--- a/ibm/mas_devops/roles/suite_db2_setup_for_manage/templates/setupdb.sh.j2
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_manage/templates/setupdb.sh.j2
@@ -25,32 +25,17 @@ db2 update db cfg for {{ db2_dbname }} using dft_table_org ROW
 db2 update db cfg for {{ db2_dbname }} using AUTO_MAINT ON DEFERRED
 db2 update db cfg for {{ db2_dbname }} using AUTO_TBL_MAINT ON DEFERRED
 db2 update db cfg for {{ db2_dbname }} using AUTO_RUNSTATS ON DEFERRED
-
-db2 update db cfg for {{ db2_dbname }} using AUTO_REORG OFF DEFERRED
-
-
-db2 update db cfg for {{ db2_dbname }} using AUTO_DB_BACKUP OFF DEFERRED
-
+db2 update db cfg for {{ db2_dbname }} using AUTO_REORG ON DEFERRED
+db2 update db cfg for {{ db2_dbname }} using AUTO_DB_BACKUP ON DEFERRED
 db2 update db cfg for {{ db2_dbname }} using CATALOGCACHE_SZ 800 DEFERRED
 db2 update db cfg for {{ db2_dbname }} using CHNGPGS_THRESH 40 DEFERRED
 db2 update db cfg for {{ db2_dbname }} using DBHEAP AUTOMATIC
 db2 update db cfg for {{ db2_dbname }} using LOCKLIST AUTOMATIC DEFERRED
 db2 update db cfg for {{ db2_dbname }} using LOGBUFSZ 1024 DEFERRED
 db2 update db cfg for {{ db2_dbname }} using LOCKTIMEOUT 300 DEFERRED
-
-db2 update db cfg for {{ db2_dbname }} using LOGPRIMARY 100 DEFERRED
-
-db2 update db cfg for {{ db2_dbname }} using LOGSECOND 156 DEFERRED
-
-
-db2 update db cfg for {{ db2_dbname }} using LOGFILSIZ 50000 DEFERRED
-
-db2 update db cfg for {{ db2_dbname }} using MIRRORLOGPATH /mnt/backup/MIRRORLOGPATH   
-db2 update db cfg for {{ db2_dbname }} using NUM_DB_BACKUPS 60                         
-db2 update db cfg for {{ db2_dbname }} using LOGARCHCOMPR1 ON                          
-db2 update db cfg for {{ db2_dbname }} using REC_HIS_RETENTN 60                        
-
-
+db2 update db cfg for {{ db2_dbname }} using LOGPRIMARY 20 DEFERRED
+db2 update db cfg for {{ db2_dbname }} using LOGSECOND 100 DEFERRED
+db2 update db cfg for {{ db2_dbname }} using LOGFILSIZ 8192 DEFERRED
 db2 update db cfg for {{ db2_dbname }} using SOFTMAX 1000 DEFERRED
 db2 update db cfg for {{ db2_dbname }} using MAXFILOP 61440 DEFERRED
 db2 update db cfg for {{ db2_dbname }} using PCKCACHESZ AUTOMATIC DEFERRED
@@ -59,11 +44,6 @@ db2 update db cfg for {{ db2_dbname }} using STMTHEAP AUTOMATIC DEFERRED
 db2 update db cfg for {{ db2_dbname }} using UTIL_HEAP_SZ 10000 DEFERRED
 db2 update db cfg for {{ db2_dbname }} using DATABASE_MEMORY AUTOMATIC DEFERRED
 db2 update db cfg for {{ db2_dbname }} using AUTO_STMT_STATS OFF DEFERRED
-
-### the STMT_CONC may need to be set to off for sum customers
-### For customers that need this parameter set to OFF, we will need to update the configmap settings for this parameter to OFF 
-### so the database will retain his value (Currently, there is only one customer that needs it set to OFF). 
-### However, if, in the future we support Text Search, this parameter will need to be OFF for all databases with Text search enabled.
 db2 update db cfg for {{ db2_dbname }} using STMT_CONC LITERALS DEFERRED
 db2 update alert cfg for database on {{ db2_dbname }} using db.db_backup_req SET THRESHOLDSCHECKED YES
 db2 update alert cfg for database on {{ db2_dbname }} using db.tb_reorg_req SET THRESHOLDSCHECKED YES
@@ -84,24 +64,13 @@ db2set DB2_FMP_COMM_HEAPSZ=65536
 db2set DB2_SKIPDELETED=ON
 db2set DB2_USE_ALTERNATE_PAGE_CLEANING=ON
 
-echo "###  set the tmp backup location   ###"
-db2set DB2_OBJECT_STORAGE_LOCAL_STAGING_PATH=/mnt/backup/staging       
-echo "###  Enable PIT recovery  ###"
-db2set DB2_CDE_REDUCED_LOGGING=REDUCED_REDO:NO                         
-
 # These will fail if re-running the script, but I don't know enough about Db2 to make them idempotent
 # so for now we will ignore failures in them
 set +e
 db2 CREATE BUFFERPOOL MAXBUFPOOL IMMEDIATE SIZE 4096 AUTOMATIC PAGESIZE 32 K
-
-### db2 CREATE REGULAR TABLESPACE MAXDATA PAGESIZE 32 K MANAGED BY AUTOMATIC STORAGE INITIALSIZE {{ db2_tablespace_data_size }} BUFFERPOOL MAXBUFPOOL
-db2 CREATE LARGE TABLESPACE MAXDATA PAGESIZE 32 K MANAGED BY AUTOMATIC STORAGE INITIALSIZE {{ db2_tablespace_data_size }} BUFFERPOOL MAXBUFPOOL
-
+db2 CREATE REGULAR TABLESPACE MAXDATA PAGESIZE 32 K MANAGED BY AUTOMATIC STORAGE INITIALSIZE {{ db2_tablespace_data_size }} BUFFERPOOL MAXBUFPOOL
 db2 CREATE TEMPORARY TABLESPACE MAXTEMP PAGESIZE 32 K MANAGED BY AUTOMATIC STORAGE BUFFERPOOL MAXBUFPOOL
-
-### db2 CREATE REGULAR TABLESPACE MAXINDEX PAGESIZE 32 K MANAGED BY AUTOMATIC STORAGE INITIALSIZE {{ db2_tablespace_index_size }} BUFFERPOOL MAXBUFPOOL
-db2 CREATE LARGE TABLESPACE MAXINDEX PAGESIZE 32 K MANAGED BY AUTOMATIC STORAGE INITIALSIZE {{ db2_tablespace_index_size }} BUFFERPOOL MAXBUFPOOL
-
+db2 CREATE REGULAR TABLESPACE MAXINDEX PAGESIZE 32 K MANAGED BY AUTOMATIC STORAGE INITIALSIZE {{ db2_tablespace_index_size }} BUFFERPOOL MAXBUFPOOL
 db2 create schema {{ db2_schema }} authorization {{ db2_username }}
 
 set -e
@@ -114,4 +83,3 @@ chmod a+rw /tmp/setupdb_complete
 
 # If we get this far, then we can consider the setup a success
 exit 0
-


### PR DESCRIPTION
This reverts commit 4045f32c944a4fa12f5ca327a95e25e845e0be8c.

We've been unable to successfully run maxinst since this update, so are reverting these changes:

> When I looked, it is complaining the maxdata tablespace is not there. I went to the db and found the tablespace indeed is not there. But when I tried to list the schema, the db is acting weird complaining resource not enough. I checked the automation, looks right, except the from the log I can't tell if it was run successfully. So I restarted the db2u pod, haven't checked back.
the setupdb.sh does show creating the schema name, and the db doesn't have this tablespace. Just manually created the bufferpool and schema.

```
BMXAA6814W - Maxinst Connection warning: com.ibm.db2.jcc.am.SqlWarning: DB2 SQL Warning: SQLCODE=0, SQLSTATE=00000, SQLERRMC=1;1208;DB2INST1;BLUDB;QDB2/LINUXX8664;5214;5214;0;1208;1;0;, DRIVER=4.29.24
java.lang.Exception: Invalid tablespace for -s and/or -t parameters. - MAXINDEX
	at psdi.configure.Maxinst.endSetupInstance(Maxinst.java:2600)
	at psdi.configure.CommonShell.endSetup(CommonShell.java:1846)
	at psdi.configure.CommonShell.setup(CommonShell.java:1347)
	at psdi.configure.Maxinst.main(Maxinst.java:2725)
Invalid tablespace for -s and/or -t parameters. - MAXINDEX Wed Jan 18 00:10:38 GMT 2023
Invalid tablespace for -s and/or -t parameters. - MAXINDEX Wed Jan 18 00:10:38 GMT 2023
```