### PR TITLE
[patch] Fix zookeeper default storage class handling

### DIFF
--- a/ibm/mas_devops/roles/kafka/tasks/determine-storage-classes.yml
+++ b/ibm/mas_devops/roles/kafka/tasks/determine-storage-classes.yml
@@ -32,11 +32,8 @@
 
 - name: Default Zookeeper Storage for ROKS if not set by user
   when: zookeeper_storage_class is not defined or zookeeper_storage_class == ""
-  vars:
-    # ROKS, OCS, Azure
-    supported_storage_classes: [ibmc-block-gold, ocs-storagecluster-ceph-rbd, managed-premium]
   set_fact:
-    zookeeper_storage_class: "{{ lookup_storageclasses | ibm.mas_devops.defaultStorageClass(supported_storage_classes) }}"
+    zookeeper_storage_class: "{{ lookup_storageclasses | ibm.mas_devops.defaultStorageClass(default_storage_classes_rwo) }}"
 
 - name: Assert that zookeeper storage class has been defined
   assert:


### PR DESCRIPTION
The main kafka_storage_class was correctly configured to use `default_storage_classes_rwo`, but `zookeeper_storage_class` was not.