### PR TITLE
[patch] Remove bad wait condition added in #466

### DIFF
--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wd.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wd.yml
@@ -135,6 +135,5 @@
     - cpd_cr_lookup.resources[0].status is defined
     - cpd_cr_lookup.resources[0].status.watsonDiscoveryStatus is defined
     - cpd_cr_lookup.resources[0].status.watsonDiscoveryStatus == "Completed"
-    - cpd_cr_lookup.resources[0].status.versions.reconciled == cpd_product_version # needed for the wd upgrade
   retries: 60 # Up to 5 (yes, FIVE !!) hours
   delay: 300 # Every 5 minutes


### PR DESCRIPTION
When you set CPD product version to x you don't always get all the services at x .. in this case CPD v4.5.2 results in WD v4.5.1 being used.

Need to use the configmap in `ibm/mas_devops/roles/cp4d/templates/config_maps/olm-utils-cm-4.5.2.yml.j2` to determine the expected version of the service.  It appears WD is the only CPD service this logic was added to.