### PR TITLE
[patch] Replace use of community.kubernetes with kubernetes.core

### DIFF
--- a/ibm/mas_devops/roles/suite_app_config/tasks/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/manage.yml
@@ -5,7 +5,6 @@
   when: mas_app_settings_server_bundles_size == 'jms'
   block:
 
-
   - name: "Get ManageWorkspace to lookup existing persistent volumes"
     kubernetes.core.k8s_info:
       api_version: v1

--- a/ibm/mas_devops/roles/suite_app_config/tasks/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/manage.yml
@@ -5,6 +5,7 @@
   when: mas_app_settings_server_bundles_size == 'jms'
   block:
 
+
   - name: "Get ManageWorkspace to lookup existing persistent volumes"
     kubernetes.core.k8s_info:
       api_version: v1

--- a/ibm/mas_devops/roles/suite_app_config/tasks/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/manage.yml
@@ -6,7 +6,7 @@
   block:
 
   - name: "Get ManageWorkspace to lookup existing persistent volumes"
-    community.kubernetes.k8s_info:
+    kubernetes.core.k8s_info:
       api_version: v1
       kind: ManageWorkspace
       name: "{{ mas_instance_id }}-{{ mas_workspace_id }}"

--- a/ibm/mas_devops/roles/suite_manage_birt_report_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_manage_birt_report_config/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: "Lookup ManageWorkspace CR"
   no_log: true
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     kind: ManageWorkspace
     name: "{{ manage_workspace_cr_name }}"
@@ -33,7 +33,7 @@
 # Wait for ManageWorkspace CR to reconcile and to be ready
 # ---------------------------------------------------------------------------------------------------------------------
 - name: "Wait for ManageWorkspace to be ready (60s delay)"
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     name: "{{ manage_workspace_cr_name }}"
     namespace: "mas-{{mas_instance_id}}-manage"

--- a/ibm/mas_devops/roles/suite_manage_birt_report_config/tasks/setup-manage-birt-report.yml
+++ b/ibm/mas_devops/roles/suite_manage_birt_report_config/tasks/setup-manage-birt-report.yml
@@ -12,7 +12,7 @@
     var: existing_manage_report_name
 
 - name: "Get Suite Instance Domain"
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     kind: Suite
     name: "{{ mas_instance_id }}"
@@ -45,7 +45,7 @@
 # Configure Server bundle properties into Manage Workspace
 # -----------------------------------------------------------------------------
 - name: "Add the Server Bundle birt properties in ManageWorkspace CR"
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     definition:
       apiVersion: apps.mas.ibm.com/v1
       kind: ManageWorkspace
@@ -81,7 +81,7 @@
 # #       manage_MW: "{{ mas_instance_id }}-main"
 
 # #   - name: "Get ManageWorkspace"
-# #     community.kubernetes.k8s_info:
+# #     kubernetes.core.k8s_info:
 # #       api_version: v1
 # #       kind: ManageWorkspace
 # #       name: "{{manage_MW}}"
@@ -96,7 +96,7 @@
 # # # 2. Get MAS Domain
 # # # -----------------------------------------------------------------------------
 # #   - name: "Get Suite Instance Domain"
-# #     community.kubernetes.k8s_info:
+# #     kubernetes.core.k8s_info:
 # #       api_version: v1
 # #       kind: Suite
 # #       name: "{{mas_instance_id}}"
@@ -119,7 +119,7 @@
 # #       birtServerBundles: "{{_MW_instance.resources[0].spec.settings.deployment.serverBundles | ibm.sre_devops.setBirtProperties(rpt_route)}}"
 
 # #   - name: "Patch MW for birt server setup"
-# #     community.kubernetes.k8s:
+# #     kubernetes.core.k8s:
 # #       merge_type: merge
 # #       definition: "{{ lookup('template', 'templates/birt.yaml') }}"
 # #     register: _changed_bundle
@@ -132,7 +132,7 @@
 # #   # 8. Wait for application to be ready
 # # # -----------------------------------------------------------------------------
 # #   - name: "Wait for ManageWorkspace to be ready (60s delay)"
-# #     community.kubernetes.k8s_info:
+# #     kubernetes.core.k8s_info:
 # #       api_version: v1
 # #       name: "{{ mas_instance_id }}-main"
 # #       namespace: "{{ manage_namespace }}"

--- a/ibm/mas_devops/roles/suite_manage_doclinks_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_manage_doclinks_config/tasks/main.yml
@@ -24,7 +24,7 @@
     manage_workspace_cr_name: "{{ mas_instance_id }}-{{ mas_workspace_id }}"
 - name: "Lookup ManageWorkspace CR"
   no_log: true
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     kind: ManageWorkspace
     name: "{{ manage_workspace_cr_name }}"
@@ -81,7 +81,7 @@
 # Wait for ManageWorkspace CR to reconcile and to be ready
 # ---------------------------------------------------------------------------------------------------------------------
 - name: "Wait for ManageWorkspace to be ready (60s delay)"
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     name: "{{ manage_workspace_cr_name }}"
     namespace: "mas-{{mas_instance_id}}-manage"

--- a/ibm/mas_devops/roles/suite_manage_doclinks_config/tasks/setup-manage-doclinks.yml
+++ b/ibm/mas_devops/roles/suite_manage_doclinks_config/tasks/setup-manage-doclinks.yml
@@ -73,7 +73,7 @@
 # Configure Server bundle properties into Manage Workspace
 # -----------------------------------------------------------------------------
 - name: "Add the Server Bundle doclinks properties in ManageWorkspace CR"
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     definition:
       apiVersion: apps.mas.ibm.com/v1
       kind: ManageWorkspace

--- a/ibm/mas_devops/roles/suite_manage_import_certs_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_manage_import_certs_config/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: "Lookup ManageWorkspace CR to retrieve existing imported certificates"
   no_log: true
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     kind: ManageWorkspace
     name: "{{ manage_workspace_cr_name }}"
@@ -49,7 +49,7 @@
     - manage_certificates_alias_prefix is defined and manage_certificates_alias_prefix !=''
 
 - name: "Add the new certificates in ManageWorkspace CR"
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     definition:
       apiVersion: apps.mas.ibm.com/v1
       kind: ManageWorkspace

--- a/ibm/mas_devops/roles/suite_manage_logging_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_manage_logging_config/tasks/main.yml
@@ -27,7 +27,7 @@
 # Check if logging is already setup for ManageWorkspace
 - name: "Lookup ManageWorkspace CR to check if logging is already setup"
   no_log: true
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     kind: ManageWorkspace
     name: "{{ mas_instance_id }}-{{ mas_workspace_id }}"

--- a/ibm/mas_devops/roles/suite_manage_logging_config/tasks/setup-manage-logging.yml
+++ b/ibm/mas_devops/roles/suite_manage_logging_config/tasks/setup-manage-logging.yml
@@ -6,7 +6,7 @@
     name: ibm.mas_devops.cos_bucket
 
 - name: Create s3secretkey secret in Manage namespace
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     apply: yes
     definition: "{{ lookup('template', 'templates/logging-bucket-creds.yml.j2')}}"
 
@@ -20,7 +20,7 @@
   when: is_prod
   block:
     - name: "Lookup Manage db2 Pod"
-      community.kubernetes.k8s_info:
+      kubernetes.core.k8s_info:
         kind: Pod
         namespace: "{{ db2_namespace }}"
         label_selectors:
@@ -52,7 +52,7 @@
     manage_certificates_alias_prefix: "{{ cos_cert_alias_prefix }}"
 
 - name: "Add the `loggingS3Destination` in ManageWorkspace CR"
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     definition:
       apiVersion: apps.mas.ibm.com/v1
       kind: ManageWorkspace

--- a/ibm/mas_devops/roles/suite_manage_pvc_config/tasks/configure-manage-pvcs.yml
+++ b/ibm/mas_devops/roles/suite_manage_pvc_config/tasks/configure-manage-pvcs.yml
@@ -17,7 +17,7 @@
     msg: "{{ mas_app_settings_custom_persistent_volumes }}"
 
 - name: "Add the Persistent Volume definitions in ManageWorkspace CR"
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     merge_type: merge
     definition:
       apiVersion: apps.mas.ibm.com/v1
@@ -38,7 +38,7 @@
       - "ManageWorkspace Changed ............... {{ _changed_pvc.changed }}"
 
 - name: "Wait for ManageWorkspace to be ready (60s delay)"
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     name: "{{ manage_workspace_cr_name }}"
     namespace: "mas-{{mas_instance_id}}-manage"

--- a/ibm/mas_devops/roles/suite_manage_pvc_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_manage_pvc_config/tasks/main.yml
@@ -28,7 +28,7 @@
 
 # Check if logging is already setup for ManageWorkspace
 - name: "Get ManageWorkspace"
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     kind: ManageWorkspace
     name: "{{ manage_workspace_cr_name }}"

--- a/ibm/mas_devops/roles/suite_switch_to_olm/tasks/ibm-common-services.yml
+++ b/ibm/mas_devops/roles/suite_switch_to_olm/tasks/ibm-common-services.yml
@@ -5,7 +5,7 @@
     msg: "{{ item }}"
 
 - name: "Verify if ibm operator is already installed"
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
     kind: Subscription
     namespace: "{{ ibm_common_services_namespace }}"
@@ -16,7 +16,7 @@
 - name: Lookup and Approve IBM Common Services operators
   block:
     - name: "Lookup and wait for Operator subscription to exist"
-      community.kubernetes.k8s_info:
+      kubernetes.core.k8s_info:
         api_version: operators.coreos.com/v1alpha1
         kind: Subscription
         namespace: "{{ ibm_common_services_namespace }}"
@@ -28,7 +28,7 @@
       until: _item_subscription_result.resources | length > 0
 
     - name: Lookup Operator install plan
-      community.kubernetes.k8s_info:
+      kubernetes.core.k8s_info:
         api_version: operators.coreos.com/v1alpha1
         kind: InstallPlan
         namespace: "{{ ibm_common_services_namespace }}"
@@ -47,7 +47,7 @@
         - _item_subscription_result.resources[0].status.state != "AtLatestKnown"
         - item_install_plan.resources | length > 0
         - item_install_plan.resources[0].status.phase != "Complete"
-      community.kubernetes.k8s:
+      kubernetes.core.k8s:
         definition:
           apiVersion: operators.coreos.com/v1alpha1
           kind: InstallPlan

--- a/ibm/mas_devops/roles/suite_switch_to_olm/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_switch_to_olm/tasks/main.yml
@@ -28,7 +28,7 @@
 # 3. Lookup for Suite deployed Instance
 # -----------------------------------------------------------------------------
 - name: Lookup Currently MAS Instance
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     kind: Suite
     name: "{{ mas_instance_id }}"
@@ -46,7 +46,7 @@
 # 5. Cleanup MAS Operator Deployment
 # -----------------------------------------------------------------------------
 - name: Delete MAS Operator Deployment
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     state: absent
     definition:
       apiVersion: v1
@@ -59,7 +59,7 @@
 # 6. Cleanup MAS TM Operator Deployment
 # -----------------------------------------------------------------------------
 - name: Delete TM Operator Deployment
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     state: absent
     definition:
       apiVersion: v1
@@ -97,7 +97,7 @@
 - name: Lookup and Approve MAS Subscription
   block:
     - name: Lookup Operator install plan
-      community.kubernetes.k8s_info:
+      kubernetes.core.k8s_info:
         api_version: operators.coreos.com/v1alpha1
         kind: InstallPlan
         namespace: "{{ mas_namespace }}"
@@ -112,7 +112,7 @@
       when:
         - mas_install_plan.resources | length > 0
         - mas_install_plan.resources[0].status.phase != "Complete"
-      community.kubernetes.k8s:
+      kubernetes.core.k8s:
         definition:
           apiVersion: operators.coreos.com/v1alpha1
           kind: InstallPlan


### PR DESCRIPTION
community.kubernetes has been deprecated and we need to use kubernetes.core instead.