### PR TITLE
[patch] Update configure_external_db env var name

### DIFF
--- a/docs/playbooks/oneclick-manage.md
+++ b/docs/playbooks/oneclick-manage.md
@@ -57,6 +57,7 @@ If the database is not SSL enabled, set the SSL_ENABLED variable to false. By de
 
 `export SSL_ENABLED=false`  
  
+ 
 ## Usage
 
 ```bash

--- a/docs/playbooks/oneclick-manage.md
+++ b/docs/playbooks/oneclick-manage.md
@@ -43,14 +43,14 @@ All timings are estimates, see the individual pages for each of these playbooks 
 ## Optional environment variables
 To connect to an external database (Oracle, SQL Server or DB2) set the following variables:
 
-- `CONFIGURE_EXTERNAL_DATABASE` Set it to true. By default, the value is false
+- `CONFIGURE_EXTERNAL_DB` Set it to true. By default, the value is false
 - `DB_INSTANCE_ID` Your database instance ID  
 - `MAS_JDBC_USER` Your database user name
 - `MAS_JDBC_PASSWORD` Your database password
 - `MAS_JDBC_URL` Your JDBC URL
 - `MAS_APP_SETTINGS_DB2_SCHEMA`  Your schema name. By default, the value is maximo
-- `MAS_APP_SETTINGS_TABLESPACE` Your tablespace name. By default, the value is maximo
-- `MAS_APP_SETTINGS_INDEXSPACE` Your indexspace name. By default, the value is maximo
+- `MAS_APP_SETTINGS_TABLESPACE` Your tablespace name. By default, the value is maxdata
+- `MAS_APP_SETTINGS_INDEXSPACE` Your indexspace name. By default, the value is maxindex
 - `MAS_JDBC_CERT_LOCAL_FILE` Path to your database certificate file if the database is SSL enabled
    
 If the database is not SSL enabled, set the SSL_ENABLED variable to false. By default, SSL_ENABLED is true.

--- a/docs/playbooks/oneclick-manage.md
+++ b/docs/playbooks/oneclick-manage.md
@@ -57,7 +57,6 @@ If the database is not SSL enabled, set the SSL_ENABLED variable to false. By de
 
 `export SSL_ENABLED=false`  
  
- 
 ## Usage
 
 ```bash

--- a/ibm/mas_devops/playbooks/oneclick_add_manage.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_manage.yml
@@ -20,7 +20,7 @@
     mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') | default('masdev', true) }}"
 
     # Check if external database is provided instead of the default DB2
-    configure_external_db: "{{ lookup('env', 'CONFIGURE_EXTERNAL_DATABASE') | default('False', true) | bool }}"
+    configure_external_db: "{{ lookup('env', 'CONFIGURE_EXTERNAL_DB') | default('False', true) | bool }}"
 
     mas_config_scope: "{{ lookup('env', 'MAS_CONFIG_SCOPE') | default('system', true) }}" # Supported values are "system", "ws", "app", or "wsapp"
 

--- a/ibm/mas_devops/roles/gencfg_jdbc/defaults/main.yml
+++ b/ibm/mas_devops/roles/gencfg_jdbc/defaults/main.yml
@@ -11,6 +11,7 @@ mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') }}"
 mas_config_scope: "{{ lookup('env', 'MAS_CONFIG_SCOPE')}}"
 mas_config_dir: "{{ lookup('env', 'MAS_CONFIG_DIR') }}"
 mas_application_id: "{{ lookup('env', 'MAS_APP_ID') }}"
+ssl_enabled: "{{ lookup('env', 'SSL_ENABLED') }}"
 
 # Custom Labels
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
1) Updated configure_external_database env variable name to configure_external_db.
2) Added the ssl_enabled flag to gencfg_jdbc role.
