### PR TITLE
[patch] Fix delay unit to check Operator Condition in upgrade role

### DIFF
--- a/ibm/mas_devops/roles/suite_upgrade/tasks/upgrade.yml
+++ b/ibm/mas_devops/roles/suite_upgrade/tasks/upgrade.yml
@@ -44,7 +44,7 @@
       - "operators.coreos.com/ibm-mas.{{ mas_namespace }}"
   register: updated_opcon
   retries: 10
-  delay: 1 # minutes
+  delay: 60 # 1 minute
   until:
     - updated_opcon.resources is defined
     - updated_opcon.resources | length == 1


### PR DESCRIPTION
OperatorCondition checking is timing out in suite_upgrade role:

Logs:
```
TASK [ibm.mas_devops.suite_upgrade : upgrade : Lookup OperatorCondition for ibm-mas] ***
Monday 30 January 2023  07:33:48 +0000 (0:00:00.040)       0:01:19.578 ******** 
FAILED - RETRYING: [localhost]: upgrade : Lookup OperatorCondition for ibm-mas (10 retries left).
FAILED - RETRYING: [localhost]: upgrade : Lookup OperatorCondition for ibm-mas (9 retries left).
FAILED - RETRYING: [localhost]: upgrade : Lookup OperatorCondition for ibm-mas (8 retries left).
FAILED - RETRYING: [localhost]: upgrade : Lookup OperatorCondition for ibm-mas (7 retries left).
FAILED - RETRYING: [localhost]: upgrade : Lookup OperatorCondition for ibm-mas (6 retries left).
FAILED - RETRYING: [localhost]: upgrade : Lookup OperatorCondition for ibm-mas (5 retries left).
FAILED - RETRYING: [localhost]: upgrade : Lookup OperatorCondition for ibm-mas (4 retries left).
FAILED - RETRYING: [localhost]: upgrade : Lookup OperatorCondition for ibm-mas (3 retries left).
FAILED - RETRYING: [localhost]: upgrade : Lookup OperatorCondition for ibm-mas (2 retries left).
FAILED - RETRYING: [localhost]: upgrade : Lookup OperatorCondition for ibm-mas (1 retries left).
fatal: [localhost]: FAILED! => {"api_found": true, "attempts": 10, "changed": false, "resources": 
```

Looking at the role see that delay is specified as 1 second when the intention was 1 minute:

```
delay: 1 # minutes
```

updated to 

```
delay: 60 # 1 minute
```