### PR TITLE
[patch] work around for old Java DB2 Driver

### DIFF
--- a/ibm/mas_devops/roles/db2/tasks/suite_jdbccfg.yml
+++ b/ibm/mas_devops/roles/db2/tasks/suite_jdbccfg.yml
@@ -27,7 +27,7 @@
 - name: Set Facts for JdbcCfg
   set_fact:
     jdbc_instance_password: "{{ _db2_instance_password.resources[0].data.password | b64decode }}"
-    jdbc_url: "jdbc:db2://c-{{db2_instance_name | lower}}-db2u-engn-svc.{{ db2_namespace }}.svc:{{db2_tls_serviceport}}/{{db2_dbname}}:sslConnection=true;"
+    jdbc_url: "jdbc:db2://c-{{db2_instance_name | lower}}-db2u-engn-svc.{{ db2_namespace }}.svc:{{db2_tls_serviceport}}/{{db2_dbname}}:sslConnection=true;sslVersion=TLSv1.2;"
 
 - name: Set facts for db2_jdbc_username and jdbc_instance_password
   set_fact:


### PR DESCRIPTION
### DB2 Driver work around

For issue: https://github.com/ibm-mas/ansible-devops/issues/633

As MAS begins migrating to Java 11.0.16.1 an issue with older DB2 Java drivers can occur. For reference see the following:

https://github.com/ibmruntimes/Semeru-Runtimes/issues/22#issuecomment-1277051104

Until all the MAS services/containers affected can be updated with the latest DB2 driver documented here:

https://www.ibm.com/support/pages/db2-version-115-mod-8-fix-pack-0-linux-unix-and-windows

A work around of appending the following to any JDBC URL should be employed:

`sslVersion=TLSv1.2`