### PR TITLE
[patch] Fix missing ibmcloud_endpoint variable

### DIFF
--- a/ibm/mas_devops/roles/ocp_login/README.md
+++ b/ibm/mas_devops/roles/ocp_login/README.md
@@ -45,6 +45,13 @@ APIKey to be used by ibmcloud login comand
 - Environment Variable: `IBMCLOUD_APIKEY`
 - Default: None
 
+### ibmcloud_endpoint
+Override the default IBMCloud API endpoint.
+
+- Optional
+- Environment Variable: `IBMCLOUD_ENDPOINT`
+- Default Value: `https://cloud.ibm.com`
+
 
 Role Variables - IBM DevIT Fyre
 ------------------------------

--- a/ibm/mas_devops/roles/ocp_login/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_login/defaults/main.yml
@@ -8,6 +8,7 @@ ocp_token: "{{ lookup('env', 'OCP_TOKEN') }}"
 ocp_server: "{{ lookup('env', 'OCP_SERVER') }}"
 
 # IBM Cloud ROKS API Key - used when cluster_type == "roks"
+ibmcloud_endpoint: "{{ lookup('env', 'IBMCLOUD_ENDPOINT') | default('https://cloud.ibm.com', true) }}"
 ibmcloud_apikey: "{{ lookup('env', 'IBMCLOUD_APIKEY') }}"
 
 # Fyre username/password - used when cluster_type == "quickburn"

--- a/ibm/mas_devops/roles/ocp_login/tasks/login-roks.yml
+++ b/ibm/mas_devops/roles/ocp_login/tasks/login-roks.yml
@@ -16,7 +16,7 @@
 # 2. Login to IBM Cloud
 # -----------------------------------------------------------------------------
 - name: "login-roks : Login to IBM Cloud"
-  shell: ibmcloud login --apikey "{{ ibmcloud_apikey }}" -q --no-region
+  shell: ibmcloud login -a "{{ ibmcloud_endpoint }}" --apikey "{{ ibmcloud_apikey }}" -q --no-region
   register: login_result
   retries: 10
   delay: 30

--- a/ibm/mas_devops/roles/ocp_provision/README.md
+++ b/ibm/mas_devops/roles/ocp_provision/README.md
@@ -73,33 +73,45 @@ Required if `cluster_type = roks`.  The APIKey to be used by ibmcloud login coma
 - Environment Variable: `IBMCLOUD_APIKEY`
 - Default Value: None
 
+### ibmcloud_endpoint
+Override the default IBMCloud API endpoint.
+
+- Optional
+- Environment Variable: `IBMCLOUD_ENDPOINT`
+- Default Value: `https://cloud.ibm.com`
+
 ### ibmcloud_resourcegroup
 The resource group to create the cluster inside.
 
+- Optional
 - Environment Variable: `IBMCLOUD_RESOURCEGROUP`
 - Default Value: `Default`
 
 ### roks_zone
 IBM Cloud zone where the cluster should be provisioned.
 
+- Optional
 - Environment Variable: `ROKS_ZONE`
 - Default Value: `dal10`
 
 ### roks_flavor
 Worker node flavor
 
+- Optional
 - Environment Variable: `ROKS_FLAVOR`
 - Default Value: `b3c.16x64.300gb`
 
 ### roks_workers
 Number of worker nodes for the roks cluster
 
+- Optional
 - Environment Variable: `ROKS_WORKERS`
 - Default Value: `3`
 
 ### roks_flags
 Can be used to specify additional parameters for the cluster creation
 
+- Optional
 - Environment Variable: `ROKS_FLAGS`
 - Default Value: None
 

--- a/ibm/mas_devops/roles/ocp_provision/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/defaults/main.yml
@@ -29,6 +29,7 @@ gpu_workerpool_name: "{{ lookup('env', 'GPU_WORKERPOOL_NAME') | default('gpu', t
 
 # ROKS
 # -----------------------------------------------------------------------------
+ibmcloud_endpoint: "{{ lookup('env', 'IBMCLOUD_ENDPOINT') | default('https://cloud.ibm.com', true) }}"
 ibmcloud_apikey: "{{ lookup('env', 'IBMCLOUD_APIKEY') }}"
 ibmcloud_resourcegroup: "{{ lookup('env', 'IBMCLOUD_RESOURCEGROUP') | default('Default', true) }}"
 

--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/roks.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/roks.yml
@@ -27,7 +27,7 @@
 # -----------------------------------------------------------------------------
 - name: "roks : Login to IBM Cloud"
   shell: |
-    ibmcloud login --apikey "{{ ibmcloud_apikey }}" -q --no-region
+    ibmcloud login -a "{{ ibmcloud_endpoint }}" --apikey "{{ ibmcloud_apikey }}" -q --no-region
 
 
 # 4. Optionally, switch to a specified resource group (creating it if necessary)


### PR DESCRIPTION
Support for https://test.cloud.ibm.com seems to have slipped away in the `ocp_login` and `ocp_provision` roles during a refactor at some point.