### PR TITLE
[patch] New case versions as a workaround for mispelled image map name

### DIFF
--- a/ibm/mas_devops/roles/suite_install_digest_cm/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_install_digest_cm/tasks/main.yml
@@ -20,7 +20,7 @@
 
 # Manage v8.4.0-8.4.2, Visual Inspection v8.6.0, optimizer v8.2.0, Safety v8.3.0 all reference the wrong config map name
 - name: "Workaround for bug in ibm-mas-manage v8.4.0-8.4.2"
-  when: case_name == "ibm-mas-manage" and (case_version == "8.4.0" or case_version == "8.4.1" or case_version == "8.4.2")
+  when: case_name == "ibm-mas-manage" and (case_version == "8.4.0" or case_version == "8.4.1" or case_version == "8.4.2" or case_version == "8.4.3" or case_version == "8.4.4" or case_version == "8.4.5")
   set_fact:
     digest_image_map_name: "ibm-manage-image-map"
 


### PR DESCRIPTION
This update allows Manage 8.4.x versions in the Nov 22, Dec 22, and Jan 23 catalogs to be used in a disconnected install.