### PR TITLE
[patch] Fixes to support no/single/dual Db2 MAS install

### DIFF
--- a/ibm/mas_devops/playbooks/oneclick_add_assist.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_assist.yml
@@ -20,7 +20,7 @@
     mas_app_spec:
       bindings:
         objectstorage: system
-    mas_app_ws_spec:
+    mas_appws_spec:
       bindings:
         watsondiscovery: application
 

--- a/ibm/mas_devops/roles/appconnect/tasks/appconnectcfg.yml
+++ b/ibm/mas_devops/roles/appconnect/tasks/appconnectcfg.yml
@@ -5,3 +5,4 @@
   ansible.builtin.template:
     src: appconnectcfg.yml.j2
     dest: "{{ mas_config_dir }}/appconnect-{{mas_instance_id}}-addons.yml"
+    mode: '664'

--- a/ibm/mas_devops/roles/cis/tasks/provider/ibm/provision.yml
+++ b/ibm/mas_devops/roles/cis/tasks/provider/ibm/provision.yml
@@ -164,3 +164,4 @@
   ansible.builtin.template:
     src: cis_output.yml.j2
     dest: "{{ mas_config_dir }}/cis-cm.yml"
+    mode: '664'

--- a/ibm/mas_devops/roles/cos/tasks/providers/ibm/provision.yml
+++ b/ibm/mas_devops/roles/cos/tasks/providers/ibm/provision.yml
@@ -128,3 +128,4 @@
   ansible.builtin.template:
     src: ibm/objectstoragecfg.yml.j2
     dest: "{{ mas_config_dir }}/cos-ibm-system.yml"
+    mode: '664'

--- a/ibm/mas_devops/roles/cos/tasks/providers/ocs/provision.yml
+++ b/ibm/mas_devops/roles/cos/tasks/providers/ocs/provision.yml
@@ -139,3 +139,4 @@
   ansible.builtin.template:
     src: ocs/objectstoragecfg.yml.j2
     dest: "{{ mas_config_dir }}/cos-ocs-system.yml"
+    mode: '664'

--- a/ibm/mas_devops/roles/cp4d_service/tasks/gencfg/gencfg-wd.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/gencfg/gencfg-wd.yml
@@ -123,3 +123,4 @@
   ansible.builtin.template:
     src: wd/wdscfg.yml.j2
     dest: "{{ mas_config_dir }}/{{ mas_instance_id }}-wd-config.yml" # WD does not use a WD CR to bind the service
+    mode: '664'

--- a/ibm/mas_devops/roles/cp4d_service/tasks/gencfg/gencfg-wsl.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/gencfg/gencfg-wsl.yml
@@ -143,9 +143,11 @@
   ansible.builtin.template:
     src: wsl/watsonstudiocfg.yml.j2
     dest: "{{ mas_config_dir }}/{{ mas_instance_id }}-watsonstudio-system.yml"
+    mode: '664'
 
 - name: "gencfg-wsl : Write our wsl_project_id into MAS Configuration Directory"
   copy:
     dest: "{{ mas_config_dir }}/{{ cpd_wsl_project_name }}.id"
     content: |
       {{ wsl_project_id }}
+    mode: '664'

--- a/ibm/mas_devops/roles/db2/README.md
+++ b/ibm/mas_devops/roles/db2/README.md
@@ -85,7 +85,7 @@ Define the username of db2 in the local LDAP registry. If this is defined, the L
 - Default: None
 
 ### db2_ldap_password
-Define the password of above db2 user in the local LDAP registry. Must define when `db2_ldap_username` is defined.
+Define the password of above db2 user in the local LDAP registry. Must define when `db2_ldap_username` is used.
 
 - Optional
 - Environment Variable: `DB2_LDAP_PASSWORD`

--- a/ibm/mas_devops/roles/db2/tasks/suite_jdbccfg.yml
+++ b/ibm/mas_devops/roles/db2/tasks/suite_jdbccfg.yml
@@ -46,3 +46,4 @@
   ansible.builtin.template:
     src: suite_jdbccfg.yml.j2
     dest: "{{ mas_config_dir }}/jdbc-{{ db2_instance_name | lower }}-{{ db2_namespace }}.yml"
+    mode: '664'

--- a/ibm/mas_devops/roles/gencfg_jdbc/tasks/main.yml
+++ b/ibm/mas_devops/roles/gencfg_jdbc/tasks/main.yml
@@ -98,4 +98,4 @@
   ansible.builtin.template:
     src: jdbccfg.yml.j2
     dest: "{{ mas_config_dir }}/jdbc.yml"
-    mode: '644'
+    mode: '664'

--- a/ibm/mas_devops/roles/gencfg_watsonstudio/tasks/main.yml
+++ b/ibm/mas_devops/roles/gencfg_watsonstudio/tasks/main.yml
@@ -69,4 +69,4 @@
   ansible.builtin.template:
     src: wscfg.yml.j2
     dest: "{{ mas_config_dir }}/watsonstudiocfg.yml"
-    mode: '644'
+    mode: '664'

--- a/ibm/mas_devops/roles/gencfg_workspace/tasks/main.yml
+++ b/ibm/mas_devops/roles/gencfg_workspace/tasks/main.yml
@@ -24,4 +24,4 @@
   ansible.builtin.template:
     src: workspace.yml.j2
     dest: "{{ mas_config_dir }}/workspace-{{ mas_workspace_id }}.yml"
-    mode: '644'
+    mode: '664'

--- a/ibm/mas_devops/roles/install_operator/tasks/main.yml
+++ b/ibm/mas_devops/roles/install_operator/tasks/main.yml
@@ -26,7 +26,6 @@
       - "Target Namespace ....................... {{ namespace }}"
       - "Artifactory Username ................... {{ artifactory_username | default('<undefined>', true) }}"
       - "Artifactory Password ................... {{ artifactory_apikey | default('<undefined>', true) }}"
-      - "ICR Host ............................... {{ icr_host | default('<undefined>', true) }}"
       - "ICR Username ........................... {{ icr_username | default('<undefined>', true) }}"
       - "ICR Password ........................... {{ icr_password | default('<undefined>', true) }}"
 

--- a/ibm/mas_devops/roles/kafka/tasks/main.yaml
+++ b/ibm/mas_devops/roles/kafka/tasks/main.yaml
@@ -183,3 +183,4 @@
   ansible.builtin.template:
     src: kafkacfg.yml.j2
     dest: "{{ mas_config_dir }}/kafka-{{ kafka_cluster_name }}-{{ kafka_namespace }}.yml"
+    mode: '664'

--- a/ibm/mas_devops/roles/mongodb/tasks/community/install.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/community/install.yml
@@ -228,6 +228,7 @@
   ansible.builtin.template:
     src: community/suite_mongocfg.yml.j2
     dest: "{{ mas_config_dir }}/mongo-{{ mongodb_namespace }}.yml"
+    mode: '664'
   vars:
     mongodb_ca_pem: "{{ mongodb_ca_lookup.resources[0].data['ca.crt'] }}"
     mongodb_admin_password: "{{ admin_password_lookup.resources[0].data.password | b64decode }}"

--- a/ibm/mas_devops/roles/sls/tasks/gencfg/main.yml
+++ b/ibm/mas_devops/roles/sls/tasks/gencfg/main.yml
@@ -43,7 +43,7 @@
   ansible.builtin.template:
     src: slscfg.yml.j2
     dest: "{{ mas_config_dir }}/sls.yml"
-    mode: '644'
+    mode: '664'
   when:
     - mas_instance_id is defined and mas_instance_id != ""
     - mas_config_dir is defined and mas_config_dir != ""

--- a/ibm/mas_devops/roles/sls/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/sls/tasks/install/main.yml
@@ -67,7 +67,6 @@
     name: ibm.mas_devops.install_operator
   vars:
     namespace: "{{ sls_namespace }}"
-    icr_host: "{{ sls_icr_cp }}"
     icr_username: "{{ sls_entitlement_username }}"
     icr_password: "{{ sls_entitlement_key }}"
     catalog_source: "{{ sls_catalog_source }}"

--- a/ibm/mas_devops/roles/suite_app_config/README.md
+++ b/ibm/mas_devops/roles/suite_app_config/README.md
@@ -6,13 +6,6 @@ This role is used to configure specific components of the application workspace 
 
 Role Variables - General
 -------------------------------------------------------------------------------
-### custom_labels
-List of comma separated key=value pairs for setting custom labels on instance specific resources.
-
-- Optional
-- Environment Variable: `CUSTOM_LABELS`
-- Default: None
-
 ### mas_instance_id
 Defines the instance id that was used for the MAS installation
 
@@ -34,24 +27,41 @@ MAS application workspace to use to configure app components
 - Environment Variable: `MAS_WORKSPACE_ID`
 - Default: None
 
+### custom_labels
+List of comma separated key=value pairs for setting custom labels on instance specific resources.
+
+- Optional
+- Environment Variable: `CUSTOM_LABELS`
+- Default: None
+
+
+Role Variables - Workspace Configuration
+-------------------------------------------------------------------------------
+### mas_appws_spec
+The application workspace deployment spec used to configure various aspects of the application workspace configuration. Note that use of this will override anything set in `mas_appws_components`
+
+- Optional
+- Environment Variable: `MAS_APPWS_SPEC`
+- Default: defaults are specified in `vars/defaultspecs/{mas_app_id}.yml`
+
+### mas_app_bindings_jdbc
+Set the binding scope for the application's JDBC binding (`system` or `application`)
+
+- Optional
+- Environment Variable: `MAS_APP_BINDINGS_JDBC`
+- Default: `system`
+
 ### mas_appws_components
 Defines the app components and versions to configure in the application workspace. Takes the form of key=value pairs seperated by a comma i.e. To install health within Manage set `base=latest,health=latest`
 
+- Optional
 - Environment Variable: `MAS_APPWS_COMPONENTS`
-- Default:
-  For Manage the default is:
-    `base=latest`
+- Default: Application specific
 
-  For Health (standalone) the default is:
-    `health=latest`
 
-### mas_app_ws_spec
-Optional.  The application workspace deployment spec used to configure various aspects of the application workspace configuration. Note that use of this will override anything set in `mas_appws_components`
-
-- Environment Variable: `MAS_APP_WS_SPEC`
-- Default: defaults are specified in `vars/defaultspecs/{{mas_app_id}}.yml`
-
-### mas_app_settings_deployment_size
+Role Variables - Predict Configuration
+-------------------------------------------------------------------------------
+### mas_appws_settings_deployment_size
 Controls the workload size of predict containers. Avaliable options are `developer`, `small`, `medium` and `small`
 
     | Deployment_size        | Replica |
@@ -61,7 +71,7 @@ Controls the workload size of predict containers. Avaliable options are `develop
     | medium                 |  3 |
 
 - Optional, only supported when configuring **Predict**
-- Environment Variable: `MAS_APP_SETTINGS_DEPLOYMENT_SIZE`
+- Environment Variable: `MAS_APPWS_SETTINGS_DEPLOYMENT_SIZE`
 - Default: `small`
 
 
@@ -92,7 +102,7 @@ Local directory where generated resource definitions are saved into. Used in con
 
 
 Role Variables - Watson Machine Learning
----------------------------------------------
+-------------------------------------------------------------------------------
 These variables are only used when using this role to configure **Predict**.
 
 ### cpd_product_version
@@ -117,7 +127,7 @@ URL to access WML service (same as Cloud Pak for Data URL).
 - Default: `https://internal-nginx-svc.ibm-cpd.svc:12443` (assumes CPD WML is installed the `ibm-cpd` namespace)
 
 
-Role Variables - Manage
+Role Variables - Manage Workspace
 -------------------------------------------------------------------------------
 ### mas_app_settings_aio_flag
 Optional. Flag indicating if Asset Investment Optimization (AIO) resource must be loaded or not. It can be loaded only when Optimizer application is installed.
@@ -227,7 +237,7 @@ Optional. Provide the persistent volume storage mount path to be used for JMS qu
 
 
 Example Playbook
-----------------
+-------------------------------------------------------------------------------
 
 ```yaml
 - hosts: localhost
@@ -242,7 +252,7 @@ Example Playbook
     # MAS application configuration
     mas_app_id: "{{ lookup('env', 'MAS_APP_ID') }}"
 
-    mas_app_ws_spec:
+    mas_appws_spec:
       bindings:
         jdbc: "{{ mas_appws_jdbc_binding | default( 'system' , true) }}"
 
@@ -251,6 +261,6 @@ Example Playbook
 ```
 
 License
--------
+-------------------------------------------------------------------------------
 
 EPL-2.0

--- a/ibm/mas_devops/roles/suite_app_config/README.md
+++ b/ibm/mas_devops/roles/suite_app_config/README.md
@@ -44,11 +44,11 @@ The application workspace deployment spec used to configure various aspects of t
 - Environment Variable: `MAS_APPWS_SPEC`
 - Default: defaults are specified in `vars/defaultspecs/{mas_app_id}.yml`
 
-### mas_app_bindings_jdbc
-Set the binding scope for the application's JDBC binding (`system` or `application`)
+### mas_appws_bindings_jdbc
+Set the binding scope for the application workspace's JDBC binding (`system`, `application`, `workspace`, or `workspace-application`)
 
 - Optional
-- Environment Variable: `MAS_APP_BINDINGS_JDBC`
+- Environment Variable: `MAS_APPWS_BINDINGS_JDBC`
 - Default: `system`
 
 ### mas_appws_components

--- a/ibm/mas_devops/roles/suite_app_config/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/defaults/main.yml
@@ -16,13 +16,12 @@ mas_config_dir: "{{ lookup('env', 'MAS_CONFIG_DIR') }}"
 mas_app_id: "{{ lookup('env', 'MAS_APP_ID') }}"
 mas_appws_jdbc_binding: "{{ lookup('env', 'MAS_APPWS_JDBC_BINDING') }}"
 mas_appws_components: "{{ lookup('env', 'MAS_APPWS_COMPONENTS') | ibm.mas_devops.appws_components | default('{}', true) }}"
-mas_app_ws_spec: "{{ lookup('env', 'MAS_APP_WS_SPEC') }}"
 
 # Only used by Predict currently - will be deprecated in favour of OM3.1 implementation
-mas_app_settings_deployment_size: "{{ lookup('env', 'MAS_APP_SETTINGS_DEPLOYMENT_SIZE') | default('small', true) }}"
+mas_appws_settings_deployment_size: "{{ lookup('env', 'MAS_APPWS_SETTINGS_DEPLOYMENT_SIZE') | default('small', true) }}"
 
 
-# 5. Cloud Pak for Data integration (Predict, HP Utils)
+# 4. Cloud Pak for Data integration (Predict, HP Utils)
 # -----------------------------------------------------------------------------
 # This is used to determine the version of WML, which Predict needs to be
 # provided at install time

--- a/ibm/mas_devops/roles/suite_app_config/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/defaults/main.yml
@@ -14,7 +14,7 @@ mas_config_dir: "{{ lookup('env', 'MAS_CONFIG_DIR') }}"
 # 3. MAS application configuration
 # -----------------------------------------------------------------------------
 mas_app_id: "{{ lookup('env', 'MAS_APP_ID') }}"
-mas_appws_jdbc_binding: "{{ lookup('env', 'MAS_APPWS_JDBC_BINDING') }}"
+mas_appws_bindings_jdbc: "{{ lookup('env', 'MAS_APPWS_BINDINGS_JDBC') }}"
 mas_appws_components: "{{ lookup('env', 'MAS_APPWS_COMPONENTS') | ibm.mas_devops.appws_components | default('{}', true) }}"
 
 # Only used by Predict currently - will be deprecated in favour of OM3.1 implementation

--- a/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
@@ -44,7 +44,7 @@
 # 4. Load default application workspace spec, if user does not provide one
 # -----------------------------------------------------------------------------
 - name: Load default application workspace spec
-  when: mas_app_ws_spec is not defined or mas_app_ws_spec == ""
+  when: mas_appws_spec is not defined or mas_appws_spec == ""
   include_vars: "vars/defaultspecs/{{ mas_app_id }}.yml"
 
 

--- a/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
@@ -13,10 +13,10 @@
 
 # 2. Load var files
 # -----------------------------------------------------------------------------
-- name: Load application-workspace variables
+- name: Load mas_appws variables
   include_vars: "vars/{{ mas_app_id }}.yml"
 
-- name: Load application variables
+- name: Load mas_app variables
   include_vars: "{{ role_path }}/../suite_app_install/vars/{{ mas_app_id }}.yml"
 
 
@@ -63,7 +63,7 @@
       - "Workspace ID ........................... {{ mas_workspace_id }}"
       - "Application namespace .................. {{ mas_app_namespace }}"
       - "JDBC Binding ........................... {{ mas_appws_bindings_jdbc | default('<undefined>', true) }}"
-      - "Templated workspace CR .... {{ lookup('template', 'templates/workspace.yml.j2') }}"
+      - "Templated workspace CR ................. {{ lookup('template', 'templates/workspace.yml.j2') }}"
 
 
 # 6. Workspace configuration

--- a/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
@@ -58,10 +58,11 @@
 - name: "Debug information"
   debug:
     msg:
-      - "Instance ID ............... {{ mas_instance_id }}"
-      - "Application ID ............ {{ mas_app_id }}"
-      - "Workspace ID .............. {{ mas_workspace_id }}"
-      - "MAS app namespace ......... {{ mas_app_namespace }}"
+      - "Instance ID ............................ {{ mas_instance_id }}"
+      - "Application ID ......................... {{ mas_app_id }}"
+      - "Workspace ID ........................... {{ mas_workspace_id }}"
+      - "Application namespace .................. {{ mas_app_namespace }}"
+      - "JDBC Binding ........................... {{ mas_appws_bindings_jdbc | default('<undefined>', true) }}"
       - "Templated workspace CR .... {{ lookup('template', 'templates/workspace.yml.j2') }}"
 
 

--- a/ibm/mas_devops/roles/suite_app_config/templates/workspace.yml.j2
+++ b/ibm/mas_devops/roles/suite_app_config/templates/workspace.yml.j2
@@ -13,4 +13,4 @@ metadata:
     {{ key }}: "{{ value }}"
 {% endfor %}
 {% endif %}
-spec: {{ mas_app_ws_spec }}
+spec: {{ mas_appws_spec }}

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/assist.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/assist.yml
@@ -1,5 +1,5 @@
 ---
 # Default application spec for Assist
-mas_app_ws_spec:
+mas_appws_spec:
   bindings:
     watsondiscovery: application

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/health.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/health.yml
@@ -2,7 +2,7 @@
 # Default application spec for Health
 mas_appws_spec:
   bindings:
-    jdbc: "{{ mas_appws_jdbc_binding | default( 'system' , true) }}"
+    jdbc: "{{ mas_appws_bindings_jdbc | default( 'system' , true) }}"
   components: "{{ mas_appws_components | default({'health':{'version':'latest'}}, true) }}"
   settings:
     deployment:

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/health.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/health.yml
@@ -1,6 +1,6 @@
 ---
 # Default application spec for Health
-mas_app_ws_spec:
+mas_appws_spec:
   bindings:
     jdbc: "{{ mas_appws_jdbc_binding | default( 'system' , true) }}"
   components: "{{ mas_appws_components | default({'health':{'version':'latest'}}, true) }}"

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/hputilities.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/hputilities.yml
@@ -5,7 +5,7 @@
 # - If not available, fail
 
 # Default application spec for HPUtilities
-mas_app_ws_spec:
+mas_appws_spec:
   bindings:
     watsonstudio: system
   components: '{{ mas_appws_components | default({}, true) }}'

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/iot.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/iot.yml
@@ -1,3 +1,3 @@
 ---
 # Default application spec for IoT
-mas_app_ws_spec: {}
+mas_appws_spec: {}

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/manage.yml
@@ -2,7 +2,7 @@
 # Default application spec for Manage
 mas_appws_spec:
   bindings:
-    jdbc: "{{ mas_appws_jdbc_binding | default( 'system' , true) }}"
+    jdbc: "{{ mas_appws_bindings_jdbc | default( 'system' , true) }}"
   components: "{{ mas_appws_components | default({'base':{'version':'latest'}}, true) }}"
   settings:
     deployment:

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/manage.yml
@@ -1,6 +1,6 @@
 ---
 # Default application spec for Manage
-mas_app_ws_spec:
+mas_appws_spec:
   bindings:
     jdbc: "{{ mas_appws_jdbc_binding | default( 'system' , true) }}"
   components: "{{ mas_appws_components | default({'base':{'version':'latest'}}, true) }}"

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/monitor.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/monitor.yml
@@ -1,6 +1,6 @@
 ---
 # Default application spec for Monitor
-mas_app_ws_spec:
+mas_appws_spec:
   bindings:
     iot: workspace
-    jdbc: system
+    jdbc: "{{ mas_appws_jdbc_binding | default( 'system' , true) }}"

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/monitor.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/monitor.yml
@@ -3,4 +3,4 @@
 mas_appws_spec:
   bindings:
     iot: workspace
-    jdbc: "{{ mas_appws_jdbc_binding | default( 'system' , true) }}"
+    jdbc: "{{ mas_appws_bindings_jdbc | default( 'system' , true) }}"

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/mso.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/mso.yml
@@ -1,5 +1,5 @@
 ---
 # Default application spec for MSO
-mas_app_ws_spec:
+mas_appws_spec:
   bindings:
     manage: workspace

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/optimizer.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/optimizer.yml
@@ -1,3 +1,3 @@
 ---
 # Default application spec for Optimizer
-mas_app_ws_spec: {}
+mas_appws_spec: {}

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/predict.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/predict.yml
@@ -1,8 +1,8 @@
 ---
 # Default application spec for Predict
-mas_app_ws_spec:
+mas_appws_spec:
   bindings:
-    jdbc: system
+    jdbc: "{{ mas_appws_jdbc_binding | default( 'system' , true) }}"
     watsonstudio: system
   settings:
     watsonstudio:
@@ -12,4 +12,4 @@ mas_app_ws_spec:
       url: "{{ cpd_wml_url }}"
       version: "{{ cpd_product_version.split('.')[0] }}.{{ cpd_product_version.split('.')[1] }}"
     deployment:
-      size: "{{ mas_app_settings_deployment_size }}"
+      size: "{{ mas_appws_settings_deployment_size }}"

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/predict.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/predict.yml
@@ -2,7 +2,7 @@
 # Default application spec for Predict
 mas_appws_spec:
   bindings:
-    jdbc: "{{ mas_appws_jdbc_binding | default( 'system' , true) }}"
+    jdbc: "{{ mas_appws_bindings_jdbc | default( 'system' , true) }}"
     watsonstudio: system
   settings:
     watsonstudio:

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/safety.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/safety.yml
@@ -1,3 +1,3 @@
 ---
 # Default application spec for Safety
-mas_app_ws_spec: {}
+mas_appws_spec: {}

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/visualinspection.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/visualinspection.yml
@@ -1,3 +1,3 @@
 ---
 # Default application spec for Visual Inspection
-mas_app_ws_spec: {}
+mas_appws_spec: {}

--- a/ibm/mas_devops/roles/suite_app_install/README.md
+++ b/ibm/mas_devops/roles/suite_app_install/README.md
@@ -1,20 +1,99 @@
 suite_app_install
-=================
+===============================================================================
 
 This role is used to install a specified application in Maximo Application Suite.
 
-Role Variables
---------------
-- `mas_app_catalog_source` Defines the catalog to be used to install the MAS app. You can set it to ibm-operator-catalog for release install or ibm-mas-{mas_app_id}-operators for development, where {mas_app_id} will be manage for the Manage and Health app installation, for example.
-- `artifactory_username` Required when using this role for development versions of the MAS application
-- `artifactory_apikey` Required when using this role for development versions of the MAS application
-- `mas_app_channel` Defines which channel of the MAS application to subscribe to. Set to `8.x` when installing released version
-- `mas_instance_id` Defines the instance id that was used for the MAS installation
-- `mas_icr_cp` Defines the entitled registry from the images should be pulled from. Set this to `cp.icr.io/cp` when installing release version of MAS or `wiotp-docker-local.artifactory.swg-devops.com` for dev
-- `mas_entitlement_username` Username for entitled registry. This username will be used to create the image pull secret. Set to `cp` when installing release or use your `w3Id` for dev
-- `mas_entitlement_key` API Key for entitled registry. This password will be used to create the image pull secret. Set to with IBM entitlement key when installing release or use your artifactory `apikey` for dev.
-- `mas_app_id` Defines the kind of application that is intended for installation such as `assist`, `health`, `iot`, `manage`, `monitor`, `mso`, `predict`, or `safety`
-- `mas_app_upgrade_strategy` Defines the Upgrade strategy for the MAS Application Operator. Default is set to Automatic
+
+Role Variables - General
+-------------------------------------------------------------------------------
+### mas_instance_id
+Defines the instance id that was used for the MAS installation
+
+- **Required**
+- Environment Variable: `MAS_INSTANCE_ID`
+- Default: None
+
+### mas_app_id
+Defines the kind of application that is intended for installation such as `assist`, `health`, `iot`, `manage`, `monitor`, `mso`, `predict`, or `safety`
+
+- Optional
+- Environment Variable: `MAS_APP_ID`
+- Default: None
+
+### mas_app_catalog_source
+Defines the catalog to be used to install the MAS app. You can set it to ibm-operator-catalog for release install or ibm-mas-{mas_app_id}-operators for development, where {mas_app_id} will be manage for the Manage and Health app installation, for example.
+
+- Optional
+- Environment Variable: `MAS_APP_CATALOG_SOURCE`
+- Default: `ibm-operator-catalog`
+
+### mas_app_channel
+Defines which channel of the MAS application to subscribe to
+
+- **Required**
+- Environment Variable: `MAS_APP_CHANNEL`
+- Default: None
+
+### mas_app_upgrade_strategy
+Defines the Upgrade strategy for the MAS Application Operator. Default is set to Automatic
+
+- Optional
+- Environment Variable: `MAS_APP_UPGRADE_STRATEGY`
+- Default: None
+
+### custom_labels
+Optional. List of comma separated key=value pairs for setting custom labels on instance specific resources.
+
+- Environment Variable: `CUSTOM_LABELS`
+- Default: None
+
+
+Role Variables - Pre-Release Support
+-------------------------------------------------------------------------------
+### artifactory_username
+Required when using this role for development versions of the MAS application.
+
+- Optional
+- Environment Variable: `ARTIFACTORY_USERNAME`
+- Default: None
+
+### artifactory_apikey
+Required when using this role for development versions of the MAS application
+
+- Optional
+- Environment Variable: `ARTIFACTORY_APIKEY`
+- Default: None
+
+### mas_entitlement_username
+Username for entitled registry. This username will be used to create the image pull secret. Set to `cp` when installing release or use your `w3Id` for dev
+
+- Optional
+- Environment Variable: `MAS_ENTITLEMENT_USERNAME`
+- Default: None
+
+### mas_entitlement_key
+API Key for entitled registry. This password will be used to create the image pull secret. Set to with IBM entitlement key when installing release or use your artifactory `apikey` for dev.
+
+- Optional
+- Environment Variable: `MAS_ENTITLEMENT_KEY`
+- Default: None
+
+
+Role Variables - Application Configuration
+-------------------------------------------------------------------------------
+### mas_app_spec
+Use of mas_app_spec will override all other application configuration variables.
+
+- Optional
+- Environment Variable: None
+- Default: defaults are specified in `vars/defaultspecs/{{mas_app_id}}.yml`
+
+### mas_app_bindings_jdbc
+Set the binding scope for the application's JDBC binding (`system` or `application`)
+
+- Optional
+- Environment Variable: `MAS_APP_BINDINGS_JDBC`
+- Default: `system`
 
 ### mas_app_plan
 Optional. Defines what plan will be used in application install.
@@ -24,15 +103,13 @@ Optional. Defines what plan will be used in application install.
 - Application Support:
   - Optimizer v8.2+: `full` and `limited` are supported, defaults to `full`
 
-### mas_app_spec
-Optional. The application deployment spec used to configure different aspects of the application deployment configuration.
 
-- Environment Variable: None
-- Default: defaults are specified in vars/defaultspecs/{{mas_app_id}}.yml
-
+Role Variables - Visual Inspection Configuration
+-------------------------------------------------------------------------------
 ### mas_app_settings_visualinspection_storage_class
-Optional. Storage class used for user data. This must support ReadWriteOnce
+Storage class used for user data. This must support ReadWriteOnce
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_VISUALINSPECTION_STORAGE_CLASS`
 - Default: Defaults to `ibmc-file-gold` if the storage class is available in the cluster.
 
@@ -42,6 +119,9 @@ Optional. Size of data persistent volume.
 - Environment Variable: `MAS_APP_SETTINGS_VISUALINSPECTION_STORAGE_SIZE`
 - Default: `100Gi`
 
+
+Role Variables - IoT Configuration
+-------------------------------------------------------------------------------
 ### mas_app_settings_iot_deployment_size
 Optional, The IoT deployment size, one of `dev`, `small` or `large`.
 
@@ -74,15 +154,9 @@ Optional. The persistent volume size used by the iot fpl pipeline router for tra
 - Application Support:
   - IoT 8.6
 
-### custom_labels
-Optional. List of comma separated key=value pairs for setting custom labels on instance specific resources.
-
-- Environment Variable: `CUSTOM_LABELS`
-- Default: None
-
 
 Example Playbook
-----------------
+-------------------------------------------------------------------------------
 
 ```yaml
 - hosts: localhost
@@ -96,9 +170,6 @@ Example Playbook
 
     # MAS configuration
     mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
-
-    # MAS configuration - IBM container registry configuration
-    mas_icr_cp: "{{ lookup('env', 'MAS_ICR_CP') | default('cp.icr.io/cp', true) }}"
 
     # MAS configuration - Entitlement
     mas_entitlement_username: "{{ lookup('env', 'MAS_ENTITLEMENT_USERNAME') | default('cp', true) }}"
@@ -123,15 +194,15 @@ Example Playbook
             size: 100Gi
         deployment:
           size: medium
-    
+
     # Application Configuration - Install Plan
     mas_app_plan: "{{ lookup('env', 'MAS_APP_PLAN') | default('full', true) }}"
-  
+
   roles:
     - ibm.mas_devops.suite_app_install
 ```
 
 License
--------
+-------------------------------------------------------------------------------
 
 EPL-2.0

--- a/ibm/mas_devops/roles/suite_app_install/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_app_install/defaults/main.yml
@@ -10,9 +10,6 @@ mas_app_channel: "{{ lookup('env', 'MAS_APP_CHANNEL') | default('8.x', true) }}"
 # MAS configuration
 mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
 
-# MAS configuration - IBM container registry configuration
-mas_icr_cp: "{{ lookup('env', 'MAS_ICR_CP') | default('cp.icr.io/cp', true) }}"
-
 # MAS configuration - Entitlement
 mas_entitlement_username: "{{ lookup('env', 'MAS_ENTITLEMENT_USERNAME') | default('cp', true) }}"
 ibm_entitlement_key: "{{ lookup('env', 'IBM_ENTITLEMENT_KEY') }}"
@@ -21,6 +18,9 @@ mas_entitlement_key: "{{ lookup('env', 'MAS_ENTITLEMENT_KEY') | default(ibm_enti
 # MAS application configuration
 mas_app_id: "{{ lookup('env', 'MAS_APP_ID') }}"
 mas_app_plan: "{{ lookup('env', 'MAS_APP_PLAN') }}"
+
+# Bindings
+mas_app_bindings_jdbc: "{{ lookup('env', 'MAS_APP_BINDINGS_JDBC') | default('system', true) }}"
 
 # Additional Visual Inspection Settings
 mas_app_settings_visualinspection_storage_class: "{{ lookup('env', 'MAS_APP_SETTINGS_VISUALINSPECTION_STORAGE_CLASS') }}"

--- a/ibm/mas_devops/roles/suite_app_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/main.yml
@@ -60,7 +60,6 @@
     name: ibm.mas_devops.install_operator
   vars:
     namespace: "{{ mas_app_namespace }}"
-    icr_host: "{{ mas_icr_cp }}"
     icr_username: "{{ mas_entitlement_username }}"
     icr_password: "{{ mas_entitlement_key }}"
     catalog_source: "{{ mas_app_catalog_source }}"

--- a/ibm/mas_devops/roles/suite_app_install/vars/defaultspecs/iot.yml
+++ b/ibm/mas_devops/roles/suite_app_install/vars/defaultspecs/iot.yml
@@ -2,7 +2,7 @@
 # Default application spec for IoT
 mas_app_spec:
   bindings:
-    jdbc: system
+    jdbc: "{{ mas_app_bindings_jdbc }}"
     mongo: system
     kafka: system
   components: {}

--- a/ibm/mas_devops/roles/suite_app_install/vars/defaultspecs/predict.yml
+++ b/ibm/mas_devops/roles/suite_app_install/vars/defaultspecs/predict.yml
@@ -2,7 +2,7 @@
 # Default application specs for Predict
 mas_app_spec:
   bindings:
-    jdbc: system
+    jdbc: "{{ mas_app_bindings_jdbc }}"
   components: {}
   settings:
     deployment:

--- a/ibm/mas_devops/roles/suite_app_install/vars/defaultspecs/safety.yml
+++ b/ibm/mas_devops/roles/suite_app_install/vars/defaultspecs/safety.yml
@@ -2,5 +2,5 @@
 # Default application spec for Safety
 mas_app_spec:
   bindings:
-    jdbc: system
+    jdbc: "{{ mas_app_bindings_jdbc }}"
   components: {}

--- a/ibm/mas_devops/roles/suite_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_install/tasks/main.yml
@@ -133,7 +133,6 @@
     name: ibm.mas_devops.install_operator
   vars:
     namespace: "{{ mas_namespace }}"
-    icr_host: "{{ mas_icr_cp }}"
     icr_username: "{{ mas_entitlement_username }}"
     icr_password: "{{ mas_entitlement_key }}"
     catalog_source: "{{ mas_catalog_source }}"

--- a/ibm/mas_devops/roles/suite_switch_to_olm/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_switch_to_olm/tasks/main.yml
@@ -87,7 +87,6 @@
     name: ibm.mas_devops.install_operator
   vars:
     namespace: "{{ mas_namespace }}"
-    icr_host: "{{ mas_icr_cp }}"
     icr_username: "{{ mas_entitlement_username }}"
     icr_password: "{{ mas_entitlement_key }}"
     catalog_source: "{{ mas_catalog_source }}"

--- a/ibm/mas_devops/roles/uds/tasks/gencfg/main.yml
+++ b/ibm/mas_devops/roles/uds/tasks/gencfg/main.yml
@@ -46,5 +46,5 @@
   ansible.builtin.template:
     src: bascfg.yml.j2
     dest: "{{ mas_config_dir }}/uds.yml"
-    mode: '644'
+    mode: '664'
   when: mas_instance_id is defined


### PR DESCRIPTION
This update introduces numerous tweaks and bug fixes into the Ansible collection in order to support multiple installation modes in the MAS CLI related to the use of Db2:

- No Db2 (user will provide their own JDBCCfg)
- Single Db2 (the only option the CLI supports today, everything in the MAS instance uses a single system database instance)
- Dual Db2 (Manage is configured with a dedicated Db2 instance, IoT, Monitor, & Predict share the system database)


Also:
- Fixes issue where files written to mas_config_dir are not group writeable, causing them to be read only when accessed from pods that did not create the file when mas_config_dir points to a directory that resides in a mounted volume inside OpenShift.
- Overhaul of docs for suite_app_install and suite_app_config.
- Remove icr_host from suite_app_install, it was only being used in a debug statement, forcing this parameter to be provided for no useful reason.
- Corrects naming convention for mas_app_ws_xxx to mas_appws_xxx, so that we have some consistency in the code (note that many workspace-scope variables are still incorrectly named mas_app_xxx instead of mas_appws_xxx, I haven't made an attempt to fix them in this update).