### PR TITLE
[patch] Fix Db2 jdbc_url generated value

### DIFF
--- a/ibm/mas_devops/roles/db2/defaults/main.yml
+++ b/ibm/mas_devops/roles/db2/defaults/main.yml
@@ -7,7 +7,7 @@ db2_instance_name: "{{ lookup('env', 'DB2_INSTANCE_NAME') }}" # e.g. db2u-iot or
 db2_dbname: "{{ lookup('env', 'DB2_DBNAME') | default('BLUDB', true) }}"
 db2_version: "{{ lookup('env', 'DB2_VERSION') | default('11.5.7.0-cn4', true)}}"
 db2_jdbc_username: db2inst1
-tls_version: "{{ lookup('env', 'TLS_VERSION') | default('TLSv1.2 ', true)}}"
+tls_version: "{{ lookup('env', 'TLS_VERSION') | default('TLSv1.2', true)}}"
 
 db2_table_org: "{{ lookup('env', 'DB2_TABLE_ORG') | default('ROW', true) }}" # e.g ROW or COLUMN
 

--- a/ibm/mas_devops/roles/db2/tasks/suite_jdbccfg.yml
+++ b/ibm/mas_devops/roles/db2/tasks/suite_jdbccfg.yml
@@ -27,7 +27,7 @@
 - name: Set Facts for JdbcCfg
   set_fact:
     jdbc_instance_password: "{{ _db2_instance_password.resources[0].data.password | b64decode }}"
-    jdbc_url: "jdbc:db2://c-{{db2_instance_name | lower}}-db2u-engn-svc.{{ db2_namespace }}.svc:{{db2_tls_serviceport}}/{{db2_dbname}}:sslConnection=true;sslVersion={{ tls_version }}"
+    jdbc_url: "jdbc:db2://c-{{db2_instance_name | lower}}-db2u-engn-svc.{{ db2_namespace }}.svc:{{db2_tls_serviceport}}/{{db2_dbname}}:sslConnection=true;sslVersion={{ tls_version }};"
 
 - name: Set facts for db2_jdbc_username and jdbc_instance_password
   set_fact:


### PR DESCRIPTION
Manage jdbccfg cr was missing a ; at the end of the url and also had an empty space at the end. 
This was causing manage selenium tasks to fail while connecting to manage db