### PR TITLE
[patch] Multiple Db2 role bug fixes

### DIFF
--- a/ibm/mas_devops/roles/db2/README.md
+++ b/ibm/mas_devops/roles/db2/README.md
@@ -1,5 +1,5 @@
 db2
-===
+===============================================================================
 
 This role creates a Db2 Warehouse instance using the Db2u Operator. A namespace called `db2u` will be created and the db2u operator will be installed into the `ibm-common-services` namespace to service the `db2ucluster` requests in `db2u` namespace. A private root CA certificate is created and is used to secure the TLS connections to the database. A Db2 Warehouse cluster will be created along with a public TLS encrypted route to allow external access to the cluster (access is via the ssl-server nodeport port on the *-db2u-engn-svc service). Internal access is via the *-db2u-engn-svc service and port 50001. Both the external route and the internal service use the same server certificate.
 
@@ -20,7 +20,7 @@ If the `mas_instance_id` and `mas_config_dir` are provided then the role will ge
 
 
 Role Variables - Installation
------------------------------
+-------------------------------------------------------------------------------
 ### db2_instance_name
 Name of the database instance, note that this is the instance **name**.
 
@@ -92,7 +92,7 @@ Define the password of above db2 user in the local LDAP registry. Must define wh
 - Default: None
 
 Role Variables - Storage
-------------------------
+-------------------------------------------------------------------------------
 ### db2_meta_storage_class
 Storage class used for metadata. This must support ReadWriteMany
 
@@ -200,7 +200,7 @@ The access mode for the storage.
 
 
 Role Variables - Resource Requests
-----------------------------------
+-------------------------------------------------------------------------------
 ### db2_cpu_requests
 Define the Kubernetes CPU request for the Db2 pod.
 
@@ -229,8 +229,9 @@ Define the Kubernetes memory limit for the Db2 pod.
 - Environment Variable: `DB2_MEMORY_LIMITS`
 - Default: `16Gi`
 
+
 Role Variables - Node Affinity
-----------------------------------
+-------------------------------------------------------------------------------
 ### db2_node_label
 The label used to specify node affinity and tolerations in the db2ucluster CR.
 
@@ -255,54 +256,37 @@ List of comma separated key=value pairs for setting custom labels on instance sp
 
 
 Role Variables - DB2UCluster Database Configuration Settings
-----------------------------------
-The following variables will overwrite DB2UCluster default properties for the DB2 configuration sections:
+-------------------------------------------------------------------------------
+The following variables will overwrite DB2UCluster default properties for the DB2 configuration sections, in each case when using environment variables provide a semi-colon separated name=value pairs, which will be converted into the appropriate data structure.
 
-- spec.environment.database.dbConfig
-- spec.environment.instance.dbmConfig
-- spec.environment.instance.registry
+- `spec.environment.database.dbConfig`
+- `spec.environment.instance.dbmConfig`
+- `spec.environment.instance.registry`
 
-```
-dbConfig:
-  APPLHEAPSZ: 8192 AUTOMATIC # Recommended heap memory size: https://www.ibm.com/docs/en/mas83/8.3.0?topic=dependencies-configure-database-health
-dbmConfig:
-  INSTANCE_MEMORY: AUTOMATIC
-registry:
-  DB2AUTH: 'OSAUTHDB,ALLOW_LOCAL_FALLBACK,PLUGIN_AUTO_RELOAD'
-  DB2_4K_DEVICE_SUPPORT: '{{ db2_4k_device_support }}'
-  DB2_FMP_RUN_AS_CONNECTED_USER: 'NO'
-  DB2_WORKLOAD: '{{ db2_workload }}'
-```
-
-### db2_database_db_config:
+### db2_database_db_config
 Overwrites the db2ucluster database configuration settings under `spec.environment.database.dbConfig` section.
-You can define parameters to be included in this section using semicolon separated values.
-
-Example: `export DB2_DATABASE_DB_CONFIG='APPLHEAPSZ=8192 AUTOMATIC'`
-
 - Optional
-- Environment Variable: `'DB2_DATABASE_DB_CONFIG'`
+- Environment Variable: `DB2_DATABASE_DB_CONFIG`
 - Default: None
 
-### db2_instance_dbm_config:
+### db2_instance_dbm_config
 Overwrites the db2ucluster instance database configuration settings under `spec.environment.instance.dbmConfig` section.
-You can define parameters to be included in this section using semicolon separated values.
 
-Example: `export DB2_INSTANCE_DBM_CONFIG='INSTANCE_MEMORY=AUTOMATIC'`
+!!! important
+    Do not set [instance_memory](https://www.ibm.com/docs/en/db2/11.5?topic=parameters-instance-memory-instance-memory).  The Db2 engine does not know Db2 is running inside a container, setting `dbmConfig.INSTANCE_MEMORY: automatic` will cause it to read the cgroups of the node and potentially go beyond the pod memory limit.  Db2U has logic built in to use a normalized percentage that takes into account the memory limit and free memory of the node.
 
 - Optional
-- Environment Variable: `'DB2_INSTANCE_DBM_CONFIG'`
+- Environment Variable: `DB2_INSTANCE_DBM_CONFIG`
 - Default: None
 
-### db2_instance_registry:
+### db2_instance_registry
 Overwrites the db2ucluster instance database configuration settings under `spec.environment.instance.registry` section.
 You can define parameters to be included in this section using semicolon separated values.
 
-Example: `export DB2_INSTANCE_REGISTRY='DB2AUTH=OSAUTHDB,ALLOW_LOCAL_FALLBACK,PLUGIN_AUTO_RELOAD;DB2_4K_DEVICE_SUPPORT=ON;DB2_FMP_RUN_AS_CONNECTED_USER=NO;DB2_WORKLOAD=ANALYTICS'`
-
 - Optional
-- Environment Variable: `'DB2_INSTANCE_REGISTRY'`
+- Environment Variable: `DB2_INSTANCE_REGISTRY`
 - Default: None
+
 
 Role Variables - MPP System
 ---------------------------
@@ -325,7 +309,7 @@ The number of Db2 pods to create in the instance. Note that `db2_num_pods` must 
 
 
 Role Variables - MAS Configuration
-----------------------------------
+-------------------------------------------------------------------------------
 ### mas_instance_id
 Providing this and `mas_config_dir` will instruct the role to generate a JdbcCfg template that can be used to configure MAS to connect to this database.
 
@@ -363,7 +347,7 @@ This is only used when both `mas_config_dir` and `mas_instance_id` are set, and 
 
 
 Example Playbook
-----------------
+-------------------------------------------------------------------------------
 
 ```yaml
 - hosts: localhost
@@ -390,6 +374,6 @@ Example Playbook
 ```
 
 License
--------
+-------------------------------------------------------------------------------
 
 EPL-2.0

--- a/ibm/mas_devops/roles/db2/defaults/main.yml
+++ b/ibm/mas_devops/roles/db2/defaults/main.yml
@@ -18,16 +18,9 @@ db2_node_label: "{{ lookup('env', 'DB2_NODE_LABEL') | default(None, true) }}" # 
 db2_dedicated_node: "{{ lookup('env', 'DB2_DEDICATED_NODE') | default(None, true) }}" # by default there is no dedicated node
 db2_workload: "{{ lookup('env', 'DB2_WORKLOAD') | default('ANALYTICS', true) }}" # default workload is ANALYTICS, other option is PUREDATA_OLAP
 
-# The following settings will overwrite db2ucluster default properties for:
-# spec.environment.database.dbConfig
-# spec.environment.instance.dbmConfig
-# spec.environment.instance.registry
-
 db2_default_config:
   dbConfig:
     APPLHEAPSZ: 8192 AUTOMATIC # Recommended heap memory size: https://www.ibm.com/docs/en/mas83/8.3.0?topic=dependencies-configure-database-health
-  dbmConfig:
-    INSTANCE_MEMORY: AUTOMATIC
   registry:
     DB2AUTH: 'OSAUTHDB,ALLOW_LOCAL_FALLBACK,PLUGIN_AUTO_RELOAD'
     DB2_4K_DEVICE_SUPPORT: '{{ db2_4k_device_support }}'
@@ -35,7 +28,7 @@ db2_default_config:
     DB2_WORKLOAD: '{{ db2_workload }}'
 
 db2_database_db_config: "{{ lookup('env', 'DB2_DATABASE_DB_CONFIG') | ibm.mas_devops.db2_overwrite_config | default(db2_default_config.dbConfig, true) }}"
-db2_instance_dbm_config: "{{ lookup('env', 'DB2_INSTANCE_DBM_CONFIG') | ibm.mas_devops.db2_overwrite_config | default(db2_default_config.dbmConfig, true) }}"
+db2_instance_dbm_config: "{{ lookup('env', 'DB2_INSTANCE_DBM_CONFIG') | ibm.mas_devops.db2_overwrite_config }}"
 db2_instance_registry: "{{ lookup('env', 'DB2_INSTANCE_REGISTRY') | ibm.mas_devops.db2_overwrite_config |  default(db2_default_config.registry, true) }}"
 
 # Support DB2 MPP configurations

--- a/ibm/mas_devops/roles/suite_db2_setup_for_manage/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_manage/tasks/main.yml
@@ -69,6 +69,10 @@
 
 - name: Copy the setupdb script into the db2u pod
   shell: "oc cp /tmp/setupdb.sh {{ db2_namespace }}/{{ db2_pod_name }}:/tmp/setupdb.sh -c db2u"
+  register: copy_result
+  retries: 10
+  delay: 30 # seconds
+  until: copy_result.rc == 0
 
 # The log file will also be available inside the pod /tmp/setupdb.log
 # The script will exit early if /tmp/setupdb_complete exists to avoid unnecessarily re-running

--- a/ibm/mas_devops/roles/suite_db2_setup_for_manage/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_manage/tasks/main.yml
@@ -68,7 +68,7 @@
     mode: '777'
 
 - name: Copy the setupdb script into the db2u pod
-  shell: "oc cp /tmp/setupdb.sh {{ db2_namespace }}/{{ db2_pod_name }}:/tmp/setupdb.sh"
+  shell: "oc cp /tmp/setupdb.sh {{ db2_namespace }}/{{ db2_pod_name }}:/tmp/setupdb.sh -c db2u"
 
 # The log file will also be available inside the pod /tmp/setupdb.log
 # The script will exit early if /tmp/setupdb_complete exists to avoid unnecessarily re-running


### PR DESCRIPTION
This update address a number of issues with the db2u role:

`oc copy` command in `suite_db2_setup_for_manage` does not specifcy a container in the pod to copy to.

`oc copy` command in `suite_db2_setup_for_manage` has been reported to be unreliable, however when re-running the role it works; to address this a simple retry logic has been added to the role so that it will automatically retry.  This does not rule out future additional work if we can determine the cause of the unreliability.

- Reported in issue #503 

PR #479 updated the spec in `Db2uCluster` to add `spec.environment.instance.dbmConfig.INSTANCE_MEMORY`, in discussions with the Db2u team we have been advised this in an error as that setting should never be used with the operator.

- Reported in issue #604 

> The engine does not know Db2 is running inside a container.. automatic will read the cgroups of the node and potentially go beyond the pod memory limit.
> Db2U has logic built in to use a normalized percentage that takes into account the memory limit and free memory of the node. No instance_memory is needed to be specified under dbmConfig.


Issue #604 is likely responsible for the increase is reports of issues with Db2 .. if you have low load on Db2, and relatively low utilization in a cluster you may never see a problem, but if you are cramming pods onto your nodes it's highly likely Db2 is going to try to use some memory that it can't!