### PR TITLE
[patch] Revert #638

### DIFF
--- a/ibm/mas_devops/roles/suite_install_digest_cm/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_install_digest_cm/tasks/main.yml
@@ -18,9 +18,9 @@
     digest_image_map_file: "{{ role_path }}/../../common_vars/digests/{{ case_name }}/{{ case_version }}.yaml"
     digest_image_map_label: "mas.ibm.com/{{ case_name }}-{{ case_version }}"
 
-# Manage v8.4.0-8.4.2, Visual Inspection v8.6.0, optimizer v8.2.0, Safety v8.3.0 all reference the wrong config map name
-- name: "Workaround for bug in ibm-mas-manage v8.4.0-8.4.2"
-  when: case_name == "ibm-mas-manage" and (case_version == "8.4.0" or case_version == "8.4.1" or case_version == "8.4.2" or case_version == "8.4.3" or case_version == "8.4.4" or case_version == "8.4.5")
+# Manage v8.4.0-8.4.3, Visual Inspection v8.6.0, optimizer v8.2.0, Safety v8.3.0 all reference the wrong config map name
+- name: "Workaround for bug in ibm-mas-manage v8.4.0-8.4.3"
+  when: case_name == "ibm-mas-manage" and (case_version == "8.4.0" or case_version == "8.4.1" or case_version == "8.4.2" or case_version == "8.4.3")
   set_fact:
     digest_image_map_name: "ibm-manage-image-map"
 


### PR DESCRIPTION
Whatever the problem is with Manage in airgap post 8.4.3 it's not an issue with the digest image map, which was fixed in the 8.4.4 release to the expected name of `ibm-mas-manage-image-map`.