### PR TITLE
[patch] Fix common services uninstall

### DIFF
--- a/ibm/mas_devops/playbooks/uninstall_core.yml
+++ b/ibm/mas_devops/playbooks/uninstall_core.yml
@@ -1,6 +1,6 @@
 ---
-
-- hosts: localhost
+- name: Uninstall Core Playbook
+  hosts: localhost
   any_errors_fatal: true
   vars:
     # Flip the default actions for each role to "uninstall"
@@ -14,7 +14,7 @@
 
   pre_tasks:
     - name: Check for required environment variables
-      assert:
+      ansible.builtin.assert:
         that:
           - lookup('env', 'MAS_INSTANCE_ID') != ""
 

--- a/ibm/mas_devops/playbooks/uninstall_core.yml
+++ b/ibm/mas_devops/playbooks/uninstall_core.yml
@@ -20,10 +20,10 @@
 
   roles:
     - ibm.mas_devops.suite_uninstall
+    - ibm.mas_devops.uds
     - ibm.mas_devops.sls
     - ibm.mas_devops.mongodb
-    - ibm.mas_devops.uds
+    - ibm.mas_devops.cluster_monitoring
     - ibm.mas_devops.cert_manager
     - ibm.mas_devops.common_services
     - ibm.mas_devops.ibm_catalogs
-    - ibm.mas_devops.cluster_monitoring

--- a/ibm/mas_devops/roles/common_services/tasks/actions/install.yml
+++ b/ibm/mas_devops/roles/common_services/tasks/actions/install.yml
@@ -9,23 +9,21 @@
 # Also, an operator group will be created in the namespace if one does not already exist
 
 - name: Check if operator group is present in ibm-common-services already
-  k8s_info:
+  kubernetes.core.k8s_info:
     namespace: ibm-common-services
     kind: OperatorGroup
   register: og_info
 
-
 # Look up the default channel for the ibm-common-service-operator package manifest
-# The way ODLM works (which we have to use) means that when an istance of MAS Core
-# is installed in the cluster, the ODLM framework will automatically upgdate the installed
+# The way ODLM works (which we have to use) means that when an instance of MAS Core
+# is installed in the cluster, the ODLM framework will automatically upgrade the installed
 # version of the IBM common service operator to whatever is set as the default channel.
 #
 # This can cause the subsequent installation of the Licensing Operator to fail in
 # horrible ways, setting the subscription channel correctly here will hopefully avoid
 # this problem.
 - name: Lookup ibm-common-service-operator packagemanifest
-  when: common_services_channel is not defined or common_services_channel == ""
-  k8s_info:
+  kubernetes.core.k8s_info:
     api_version: packages.operators.coreos.com/v1
     kind: PackageManifest
     name: ibm-common-service-operator
@@ -34,14 +32,15 @@
   until: common_services_manifest_info.resources[0].status.defaultChannel is defined
   retries: 60 # Approximately 30 minutes before we give up
   delay: 30 # 30 seconds
+  when: common_services_channel is not defined or common_services_channel == ""
 
 - name: Set ibm-common-services-operator channel
-  when: common_services_channel is not defined or common_services_channel == ""
-  set_fact:
+  ansible.builtin.set_fact:
     common_services_channel: "{{ common_services_manifest_info.resources[0].status.defaultChannel }}"
+  when: common_services_channel is not defined or common_services_channel == ""
 
 - name: Debug IBM Common Services Install
-  debug:
+  ansible.builtin.debug:
     msg:
       - "Channel ................................ {{ common_services_channel }}"
       - "Source ................................. {{ common_services_catalog_source }}"

--- a/ibm/mas_devops/roles/common_services/tasks/actions/install.yml
+++ b/ibm/mas_devops/roles/common_services/tasks/actions/install.yml
@@ -16,7 +16,7 @@
 
 # Look up the default channel for the ibm-common-service-operator package manifest
 # The way ODLM works (which we have to use) means that when an instance of MAS Core
-# is installed in the cluster, the ODLM framework will automatically upgrade the installed
+# is installed in the cluster, the ODLM framework will automatically update the installed
 # version of the IBM common service operator to whatever is set as the default channel.
 #
 # This can cause the subsequent installation of the Licensing Operator to fail in

--- a/ibm/mas_devops/roles/common_services/tasks/actions/uninstall.yml
+++ b/ibm/mas_devops/roles/common_services/tasks/actions/uninstall.yml
@@ -3,6 +3,15 @@
 # For example this should always run after the cert_manager role's uninstall if IBM Certificate Manager
 # is installed, and after uds role's uninstall action if IBM User Data Services is installed.
 
+# NamespaceScope CRs get stuck on their finalizer
+# because the IBM NamespaceScope Operator gets deleted first
+# blocking the removal of the ibm-common-services namespace
+- name: Delete all NamespaceScopes
+  ansible.builtin.command: oc delete --all NamespaceScope -n ibm-common-services
+  ignore_errors: True
+  register: deletion_results
+  changed_when: deletion_results.rc != 0
+
 - name: Delete the ibm-common-services namespace
   kubernetes.core.k8s:
     state: absent

--- a/ibm/mas_devops/roles/common_services/tasks/actions/uninstall.yml
+++ b/ibm/mas_devops/roles/common_services/tasks/actions/uninstall.yml
@@ -6,11 +6,21 @@
 # NamespaceScope CRs get stuck on their finalizer
 # because the IBM NamespaceScope Operator gets deleted first
 # blocking the removal of the ibm-common-services namespace
+- name: Get all NamespaceScopes
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: NamespaceScope
+    namespace: ibm-common-services
+  register: ns_scopes_lookup
+
 - name: Delete all NamespaceScopes
-  ansible.builtin.command: oc delete --all NamespaceScope -n ibm-common-services
-  ignore_errors: True
-  register: deletion_results
-  changed_when: deletion_results.rc != 0
+  kubernetes.core.k8s:
+    state: absent
+    api_version: v1
+    kind: NamespaceScope
+    namespace: ibm-common-services
+    name: "{{ item.metadata.name }}"
+  loop: "{{ ns_scopes_lookup.resources }}"
 
 - name: Delete the ibm-common-services namespace
   kubernetes.core.k8s:

--- a/ibm/mas_devops/roles/common_services/tasks/main.yml
+++ b/ibm/mas_devops/roles/common_services/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
 - name: "Execute the chosen action"
-  include_tasks: "tasks/actions/{{ common_services_action }}.yml"
+  ansible.builtin.include_tasks:
+    file: "tasks/actions/{{ common_services_action }}.yml"
   when: common_services_action != "none"


### PR DESCRIPTION
## Details
The uninstall task for common_services role was not working as intended. When deleting the ibm-common-services namespace the IBM NamespaceScope Operator gets deleted with it but the NamespaceScope CRs then get stuck on their finalizer ultimately blocking the deletion of the namespace.

- I have added an oc command to delete the NamespaceScope CRs before deleting the ibm-common-services namespace.
- I have also re-arranged the order of roles in the uninstall_core playbook to match the reverse of how we install core.
- Changed some pieces in common_services according to ansible lint recommendations. Should really be done for all files. But this serves as an example.
## Testing

- I have tested various scenarios manually