### PR TITLE
[patch] Updates to support new Artifactory hostnames

### DIFF
--- a/docs/playbooks/oneclick-core.md
+++ b/docs/playbooks/oneclick-core.md
@@ -104,8 +104,8 @@ export IBM_ENTITLEMENT_KEY=xxx
 
 export ARTIFACTORY_USERNAME=$W3_USERNAME_LOWERCASE
 export ARTIFACTORY_APIKEY=xxx
-export MAS_ICR_CP=wiotp-docker-local.artifactory.swg-devops.com
-export MAS_ICR_CPOPEN=wiotp-docker-local.artifactory.swg-devops.com
+export MAS_ICR_CP=docker-na-public.artifactory.swg-devops.com/wiotp-docker-local
+export MAS_ICR_CPOPEN=docker-na-public.artifactory.swg-devops.com/wiotp-docker-local
 export MAS_ENTITLEMENT_USERNAME=$W3_USERNAME_LOWERCASE
 export MAS_ENTITLEMENT_KEY=$ARTIFACTORY_APIKEY
 

--- a/ibm/mas_devops/roles/ibm_catalogs/tasks/install/development-catalog.yml
+++ b/ibm/mas_devops/roles/ibm_catalogs/tasks/install/development-catalog.yml
@@ -8,7 +8,8 @@
     artifactoryAuthStr: "{{artifactory_username}}:{{artifactory_apikey}}"
     artifactoryAuth: "{{ artifactoryAuthStr | b64encode }}"
     content:
-      - '{"auths":{"docker-na-public.artifactory.swg-devops.com/wiotp-docker-local": {"username":"{{artifactory_username}}","password":"{{artifactory_apikey}}","auth":"{{artifactoryAuth}}"}'
+      - '{"auths":{"docker-na-public.artifactory.swg-devops.com/wiotp-docker-local": {"username":"{{artifactory_username}}","password":"{{artifactory_apikey}}","auth":"{{artifactoryAuth}}"},'
+      - '{"wiotp-docker-local.artifactory.swg-devops.com": {"username":"{{artifactory_username}}","password":"{{artifactory_apikey}}","auth":"{{artifactoryAuth}}"}'
       - '}'
       - '}'
   kubernetes.core.k8s:

--- a/ibm/mas_devops/roles/ibm_catalogs/tasks/install/development-catalog.yml
+++ b/ibm/mas_devops/roles/ibm_catalogs/tasks/install/development-catalog.yml
@@ -8,8 +8,8 @@
     artifactoryAuthStr: "{{artifactory_username}}:{{artifactory_apikey}}"
     artifactoryAuth: "{{ artifactoryAuthStr | b64encode }}"
     content:
-      - '{"auths":{"docker-na-public.artifactory.swg-devops.com/wiotp-docker-local": {"username":"{{artifactory_username}}","password":"{{artifactory_apikey}}","auth":"{{artifactoryAuth}}"},'
-      - '{"wiotp-docker-local.artifactory.swg-devops.com": {"username":"{{artifactory_username}}","password":"{{artifactory_apikey}}","auth":"{{artifactoryAuth}}"}'
+      - '{"auths":{"docker-na-public.artifactory.swg-devops.com": {"username":"{{artifactory_username}}","password":"{{artifactory_apikey}}","auth":"{{artifactoryAuth}}"},'
+      - '"wiotp-docker-local.artifactory.swg-devops.com": {"username":"{{artifactory_username}}","password":"{{artifactory_apikey}}","auth":"{{artifactoryAuth}}"}'
       - '}'
       - '}'
   kubernetes.core.k8s:

--- a/ibm/mas_devops/roles/ibm_catalogs/tasks/install/development-catalog.yml
+++ b/ibm/mas_devops/roles/ibm_catalogs/tasks/install/development-catalog.yml
@@ -8,7 +8,7 @@
     artifactoryAuthStr: "{{artifactory_username}}:{{artifactory_apikey}}"
     artifactoryAuth: "{{ artifactoryAuthStr | b64encode }}"
     content:
-      - '{"auths":{"wiotp-docker-local.artifactory.swg-devops.com": {"username":"{{artifactory_username}}","password":"{{artifactory_apikey}}","auth":"{{artifactoryAuth}}"}'
+      - '{"auths":{"docker-na-public.artifactory.swg-devops.com/wiotp-docker-local": {"username":"{{artifactory_username}}","password":"{{artifactory_apikey}}","auth":"{{artifactoryAuth}}"}'
       - '}'
       - '}'
   kubernetes.core.k8s:

--- a/ibm/mas_devops/roles/ibm_catalogs/templates/development-catalog.yml.j2
+++ b/ibm/mas_devops/roles/ibm_catalogs/templates/development-catalog.yml.j2
@@ -9,7 +9,7 @@ spec:
   publisher: IBM
   description: Catalog Source for IBM Maximo Application Suite (Internal Use Only)
   sourceType: grpc
-  image: wiotp-docker-local.artifactory.swg-devops.com/cpopen/ibm-maximo-operator-catalog:{{ mas_catalog_version }}
+  image: docker-na-public.artifactory.swg-devops.com/wiotp-docker-local/cpopen/ibm-maximo-operator-catalog:{{ mas_catalog_version }}
   updateStrategy:
     registryPoll:
       interval: 45m

--- a/ibm/mas_devops/roles/install_operator/templates/ibm-entitlement-with-artifactory.json.j2
+++ b/ibm/mas_devops/roles/install_operator/templates/ibm-entitlement-with-artifactory.json.j2
@@ -1,6 +1,6 @@
 {"auths":{
 {% if artifactory_username is defined and artifactory_username != "" %}
-"docker-na-public.artifactory.swg-devops.com/wiotp-docker-local":{"username":"{{ artifactory_username }}","password":"{{ artifactory_apikey }}","auth":"{{ (artifactory_username ~ ':' ~ artifactory_apikey) | b64encode }}"},
+"docker-na-public.artifactory.swg-devops.com":{"username":"{{ artifactory_username }}","password":"{{ artifactory_apikey }}","auth":"{{ (artifactory_username ~ ':' ~ artifactory_apikey) | b64encode }}"},
 "wiotp-docker-local.artifactory.swg-devops.com":{"username":"{{ artifactory_username }}","password":"{{ artifactory_apikey }}","auth":"{{ (artifactory_username ~ ':' ~ artifactory_apikey) | b64encode }}"},
 {% endif %}
 "cp.icr.io/cp":{"username":"{{ icr_username }}","password":"{{ icr_password }}","auth":"{{ (icr_username ~ ':' ~ icr_password) | b64encode }}"}}}

--- a/ibm/mas_devops/roles/install_operator/templates/ibm-entitlement-with-artifactory.json.j2
+++ b/ibm/mas_devops/roles/install_operator/templates/ibm-entitlement-with-artifactory.json.j2
@@ -1,5 +1,5 @@
 {"auths":{
 {% if artifactory_username is defined and artifactory_username != "" %}
-"wiotp-docker-local.artifactory.swg-devops.com":{"username":"{{ artifactory_username }}","password":"{{ artifactory_apikey }}","auth":"{{ (artifactory_username ~ ':' ~ artifactory_apikey) | b64encode }}"},
+"docker-na-public.artifactory.swg-devops.com/wiotp-docker-local":{"username":"{{ artifactory_username }}","password":"{{ artifactory_apikey }}","auth":"{{ (artifactory_username ~ ':' ~ artifactory_apikey) | b64encode }}"},
 {% endif %}
 "cp.icr.io/cp":{"username":"{{ icr_username }}","password":"{{ icr_password }}","auth":"{{ (icr_username ~ ':' ~ icr_password) | b64encode }}"}}}

--- a/ibm/mas_devops/roles/install_operator/templates/ibm-entitlement-with-artifactory.json.j2
+++ b/ibm/mas_devops/roles/install_operator/templates/ibm-entitlement-with-artifactory.json.j2
@@ -1,5 +1,6 @@
 {"auths":{
 {% if artifactory_username is defined and artifactory_username != "" %}
 "docker-na-public.artifactory.swg-devops.com/wiotp-docker-local":{"username":"{{ artifactory_username }}","password":"{{ artifactory_apikey }}","auth":"{{ (artifactory_username ~ ':' ~ artifactory_apikey) | b64encode }}"},
+"wiotp-docker-local.artifactory.swg-devops.com":{"username":"{{ artifactory_username }}","password":"{{ artifactory_apikey }}","auth":"{{ (artifactory_username ~ ':' ~ artifactory_apikey) | b64encode }}"},
 {% endif %}
 "cp.icr.io/cp":{"username":"{{ icr_username }}","password":"{{ icr_password }}","auth":"{{ (icr_username ~ ':' ~ icr_password) | b64encode }}"}}}

--- a/ibm/mas_devops/roles/ocp_simulate_disconnected_network/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_simulate_disconnected_network/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Ideally we would add quay.io here as well, but we can't until we mirror all the images used by OCP itself
-airgap_network_exclusions: "icr.io cp.icr.io wiotp-docker-local.artifactory.swg-devops.com"
+airgap_network_exclusions: "icr.io cp.icr.io docker-na-public.artifactory.swg-devops.com/wiotp-docker-local"
 
 registry_private_ca_file: "{{ lookup('env', 'REGISTRY_PRIVATE_CA_FILE') }}"
 registry_private_ca_crt: "{{ lookup('file', registry_private_ca_file) }}"

--- a/ibm/mas_devops/roles/ocp_simulate_disconnected_network/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_simulate_disconnected_network/tasks/main.yml
@@ -41,7 +41,7 @@
 
 # 4. Disable Network access to public repositories
 # -----------------------------------------------------------------------------
-# Set the /etc/hosts file on each cluster node to mis-direct any calls to icr.io, cp.icr.io and wiotp-docker-local.artifactory.swg-devops.com
+# Set the /etc/hosts file on each cluster node to mis-direct any calls to icr.io, cp.icr.io and docker-na-public.artifactory.swg-devops.com/wiotp-docker-local
 - name: Create hosts file
   vars:
     hosts_file_content: |

--- a/ibm/mas_devops/roles/suite_install/README.md
+++ b/ibm/mas_devops/roles/suite_install/README.md
@@ -11,8 +11,8 @@ Role Variables
 - `mas_channel` Defines which channel of MAS to subscribe to
 - `mas_domain` Opitional fact, if not provided the role will use the default cluster subdomain
 - `mas_instance_id` Defines the instance id to be used for MAS installation
-- `mas_icr_cp` Defines the entitled registry from the images should be pulled from. Set this to `cp.icr.io/cp` when installing release version of MAS or `wiotp-docker-local.artifactory.swg-devops.com` for dev
-- `mas_icr_cpopen` Defines the registry for non entitled images, such as operators. Set this to `icr.io/cpopen` when installing release version of MAS or `wiotp-docker-local.artifactory.swg-devops.com/cpopen` for dev
+- `mas_icr_cp` Defines the entitled registry from the images should be pulled from. Set this to `cp.icr.io/cp` when installing release version of MAS or `docker-na-public.artifactory.swg-devops.com/wiotp-docker-local` for dev
+- `mas_icr_cpopen` Defines the registry for non entitled images, such as operators. Set this to `icr.io/cpopen` when installing release version of MAS or `docker-na-public.artifactory.swg-devops.com/wiotp-docker-local/cpopen` for dev
 - `mas_entitlement_username` Username for entitled registry. This username will be used to create the image pull secret. Set to `cp` when installing release or use your `w3Id` for dev.
 - `mas_entitlement_key` API Key for entitled registry. This password will be used to create the image pull secret. Set to with IBM entitlement key when installing release or use your artifactory `apikey` for dev.
 - `mas_config_dir` Directory containing configuration files (`*.yaml` and `*.yml`) to be applied to the MAS installation.  Intended for creating the various MAS custom resources to configure the suite post-install, but can be used to apply any kubernetes resource you need to customize any aspect of your cluster.

--- a/ibm/mas_devops/roles/suite_switch_to_olm/README.md
+++ b/ibm/mas_devops/roles/suite_switch_to_olm/README.md
@@ -29,13 +29,13 @@ Required. The instance ID of Maximo Application Suite. This will be used to look
 - Default Value: None
 
 ### mas_icr_cp
-Defines the entitled registry from the images should be pulled from. Set this to `cp.icr.io/cp` when installing release version of MAS or `wiotp-docker-local.artifactory.swg-devops.com` for dev.
+Defines the entitled registry from the images should be pulled from. Set this to `cp.icr.io/cp` when installing release version of MAS or `docker-na-public.artifactory.swg-devops.com/wiotp-docker-local` for dev.
 
 - Environment Variable: `MAS_ICR_CP`
 - Default: `cp.icr.io/cp`
 
 ### mas_icr_cpopen
-Defines the registry for non entitled images, such as operators. Set this to `icr.io/cpopen` when installing release version of MAS or `wiotp-docker-local.artifactory.swg-devops.com/cpopen` for dev
+Defines the registry for non entitled images, such as operators. Set this to `icr.io/cpopen` when installing release version of MAS or `docker-na-public.artifactory.swg-devops.com/wiotp-docker-local/cpopen` for dev
 
 - Environment Variable: `MAS_ICR_CPOPEN`
 - Default: `icr.io/cpopen`


### PR DESCRIPTION
### Update for artifactory hostname change

All Docker repositories can now be accessed using a path-based mechanism.

for example the Docker URL reference:

```
wiotp-docker-local.artifactory.swg-devops.com
```

should become:

```
docker-na-public.artifactory.swg-devops.com/wiotp-docker-local
```

https://github.com/ibm-mas/ansible-devops/issues/681