### PR TITLE
[patch] More efficient ibm-pak command for MAS Core

### DIFF
--- a/ibm/mas_devops/playbooks/mirror_core.yml
+++ b/ibm/mas_devops/playbooks/mirror_core.yml
@@ -226,17 +226,8 @@
       vars:
         case_name: ibm-mas
         case_version: "{{ mas_core_version[mas_channel] }}"
-        exclude_images:
-          - ibm-mas-assist
-          - ibm-mas-hputilities
-          - ibm-mas-iot
-          - ibm-mas-manage
-          - ibm-mas-monitor
-          - ibm-mas-predict
-          - ibm-mas-safety
-          - ibm-mas-visualinspection
-          - ibm-mas-optimizer
-          - ibm-sls
+        exclude_images: []
+        ibmpak_skip_dependencies: true
 
     - name: ibm.mas_devops.mirror_images
       when: mirror_mas_core

--- a/ibm/mas_devops/playbooks/mirror_core.yml
+++ b/ibm/mas_devops/playbooks/mirror_core.yml
@@ -104,6 +104,7 @@
           - ibm-management-ingress
           - ibm-platform-api-operator
           - ibm-zen
+        ibmpak_skip_dependencies: false
 
     - name: ibm.mas_devops.mirror_images
       when: mirror_common_svcs
@@ -134,6 +135,7 @@
           - ibm-management-ingress
           - ibm-platform-api-operator
           - ibm-zen
+        ibmpak_skip_dependencies: false
 
     - name: ibm.mas_devops.mirror_images
       when:
@@ -156,6 +158,7 @@
         case_name: ibm-uds
         case_version: "{{ uds_version }}"
         exclude_images: []
+        ibmpak_skip_dependencies: false
 
     - name: ibm.mas_devops.mirror_images
       when: mirror_uds
@@ -191,6 +194,7 @@
         case_name: ibm-sls
         case_version: "{{ sls_version }}"
         exclude_images: []
+        ibmpak_skip_dependencies: false
 
     - name: ibm.mas_devops.mirror_images
       when: mirror_sls
@@ -209,6 +213,7 @@
         case_name: ibm-truststore-mgr
         case_version: "{{ tsm_version }}"
         exclude_images: []
+        ibmpak_skip_dependencies: false
 
     - name: ibm.mas_devops.mirror_images
       when: mirror_tsm

--- a/ibm/mas_devops/roles/mirror_case_prepare/README.md
+++ b/ibm/mas_devops/roles/mirror_case_prepare/README.md
@@ -45,6 +45,30 @@ A list of child CASE bundles to exclude from the mirroring process.
 - Default: None
 
 
+Role Variables - IBM Pak
+-------------------------------------------------------------------------------
+### ibmpak_skip_verify
+Skip the certification verification when downloading CASE bundles with `oc ibm-pak get`.
+
+- Optional
+- Environment Variable: `IBMPAK_SKIP_VERIFY`
+- Default: `False`
+
+### ibmpak_skip_dependencies
+Skip downloading CASE bundle dependencies with `oc ibm-pak get`.
+
+- Optional
+- Environment Variable: `IBMPAK_SKIP_DEPENDENCIES`
+- Default: `False`
+
+### ibmpak_insecure
+Skip TLS/SSL verification when downloading CASE bundles with `oc ibm-pak get`.
+
+- Optional
+- Environment Variable: `IBMPAK_INSECURE`
+- Default: `False`
+
+
 Example Playbook
 -------------------------------------------------------------------------------
 

--- a/ibm/mas_devops/roles/mirror_case_prepare/defaults/main.yml
+++ b/ibm/mas_devops/roles/mirror_case_prepare/defaults/main.yml
@@ -12,3 +12,11 @@ case_version: "{{ lookup('env', 'CASE_VERSION') }}"
 
 # Overrides the settings for direct mirroring if defined
 mirror_working_dir: "{{ lookup('env', 'MIRROR_WORKING_DIR') }}"
+
+# These set the following ibm pak flags
+# --skip-dependencies
+# --skip-verify
+# --insecure
+ibmpak_skip_dependencies: "{{ lookup('env', 'IBMPAK_SKIP_DEPENDENCIES') | default('False', True) | bool  }}"
+ibmpak_skip_verify: "{{ lookup('env', 'IBMPAK_SKIP_VERIFY') | default('False', True) | bool  }}"
+ibmpak_insecure: "{{ lookup('env', 'IBMPAK_INSECURE') | default('False', True) | bool }}"

--- a/ibm/mas_devops/roles/mirror_case_prepare/tasks/main.yml
+++ b/ibm/mas_devops/roles/mirror_case_prepare/tasks/main.yml
@@ -26,6 +26,13 @@
 
 # 3. Debug
 # -----------------------------------------------------------------------------
+
+- name: "{{ case_name }} : Configure ibm-pak options"
+  set_fact:
+    ibmpak_flag_insecure: "{{ ibmpak_insecure | ternary('--insecure', '') "
+    ibmpak_flag_skip_verify: "{{ ibmpak_skip_verify | ternary('--skip-verify', '') "
+    ibmpak_flag_skip_dependencies: "{{ ibmpak_skip_dependencies | ternary('--skip-dependencies', '') }}"
+
 - name: "{{ case_name }} : Airgap setup configuration"
   debug:
     msg:
@@ -33,12 +40,16 @@
       - "Case Version ........................... {{ case_version }}"
       - "Registry Public Host ................... {{ registry_public_host }}"
       - "Registry Public Port ................... {{ registry_public_port }}"
+      - "Insecure ............................... {{ ibmpak_insecure }}"
+      - "Skip Verify ............................ {{ ibmpak_skip_verify }}"
+      - "Skip Dependencies ...................... {{ ibmpak_skip_dependencies }}"
+      - "IBM Pak Flags .......................... {{ ibmpak_flag_insecure }} {{ ibmpak_flag_skip_verify }} {{ ibmpak_flag_skip_dependencies }}"
 
 
 # 4. Get the CASE bundle
 # -----------------------------------------------------------------------------
 - name: "{{ case_name }} : Get the CASE bundle"
-  shell: oc ibm-pak get {{ case_name }} --version {{ case_version }}
+  shell: oc ibm-pak get {{ case_name }} --version {{ case_version }} {{ ibmpak_flag_insecure }} {{ ibmpak_flag_skip_verify }} {{ ibmpak_flag_skip_dependencies }}
   register: ibmpak_get_result
 
 

--- a/ibm/mas_devops/roles/mirror_case_prepare/tasks/main.yml
+++ b/ibm/mas_devops/roles/mirror_case_prepare/tasks/main.yml
@@ -29,8 +29,8 @@
 
 - name: "{{ case_name }} : Configure ibm-pak options"
   set_fact:
-    ibmpak_flag_insecure: "{{ ibmpak_insecure | ternary('--insecure', '') "
-    ibmpak_flag_skip_verify: "{{ ibmpak_skip_verify | ternary('--skip-verify', '') "
+    ibmpak_flag_insecure: "{{ ibmpak_insecure | ternary('--insecure', '') }}"
+    ibmpak_flag_skip_verify: "{{ ibmpak_skip_verify | ternary('--skip-verify', '') }}"
     ibmpak_flag_skip_dependencies: "{{ ibmpak_skip_dependencies | ternary('--skip-dependencies', '') }}"
 
 - name: "{{ case_name }} : Airgap setup configuration"


### PR DESCRIPTION
Instead of downloading dependencies, and then deleting them, we will use `--skip-dependencies`.  This also avoids the issue with one of the corrupted dependencies (ibm-mas-assist) blocking mirroring today.