### PR TITLE
[patch] Document UDS_ACTION values for suds (un)install

### DIFF
--- a/ibm/mas_devops/roles/uds/README.md
+++ b/ibm/mas_devops/roles/uds/README.md
@@ -7,7 +7,7 @@ Installs [IBM User Data Services](https://www.ibm.com/docs/en/cpfs?topic=service
 Role Variables - Installation
 -------------------------------------------------------------------------------
 ### uds_action
-Inform the role whether to perform an install or uninstall of IBM User Data Services.
+Inform the role whether to perform an install or uninstall of IBM User Data Services or the Slim User Data Services. Supported values are `install`, `uninstall`, `install_suds` or `uninstall_suds`
 
 - Optional
 - Environment Variable: `UDS_ACTION`


### PR DESCRIPTION
Document the fact that `install_suds` or `uninstall_suds` can be defined for the `UDS_ACTION` environment variable