### PR TITLE
[patch] Use correct digest for 230314 catalog image

### DIFF
--- a/ibm/mas_devops/common_vars/casebundles/v8-230314-amd64.yml
+++ b/ibm/mas_devops/common_vars/casebundles/v8-230314-amd64.yml
@@ -5,7 +5,7 @@
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:b9a2cacd889d6ac68b6a30536cc66c851fc8ca04d54ada7397bdd23e123f520a
+catalog_digest: sha256:8d8304e53e67ee6a7aacddee0491e41ac5f725fb80e4e0aa34409c38a363b632
 
 # Dependencies
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Update the digest for the 230314 catalog image. 

https://github.com/ibm-mas/ansible-devops/issues/695