### PR TITLE
[patch] Airgap mirror workaround for UDS 2.0.9 (#711)

### DIFF
--- a/ibm/mas_devops/roles/mirror_case_prepare/tasks/main.yml
+++ b/ibm/mas_devops/roles/mirror_case_prepare/tasks/main.yml
@@ -127,6 +127,13 @@
   when: case_name == "ibm-uds" and case_version == "2.0.8"
   include_tasks: "tasks/uds-208-fix.yml"
 
+# 9a. IBM UDS 2.0.9 Entitled Image Hack
+# -----------------------------------------------------------------------------
+# The UDS CASE bundle includes one entitled image - cp/uds/uds-submodule:2.0.9
+- name: "IBM UDS 2.0.9 workaround"
+  when: case_name == "ibm-uds" and case_version == "2.0.9"
+  include_tasks: "tasks/uds-209-fix.yml"
+
 
 # 10. IBM Maximo IoT 8.6.0 Bad Digest Hack
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/mirror_case_prepare/tasks/uds-209-fix.yml
+++ b/ibm/mas_devops/roles/mirror_case_prepare/tasks/uds-209-fix.yml
@@ -1,0 +1,16 @@
+---
+# IBM UDS 2.0.9 Entitled Image Hack
+# -----------------------------------------------------------------------------
+# The UDS CASE bundle includes one entitled image - cp/uds/uds-submodule:2.0.9
+
+- template:
+    src: uds209fix/direct.txt.j2
+    dest: "{{ mirror_working_dir }}/manifests/direct/{{ case_name }}_{{ case_version }}.txt"
+
+- template:
+    src: uds209fix/to-filesystem.txt.j2
+    dest: "{{ mirror_working_dir }}/manifests/to-filesystem/{{ case_name }}_{{ case_version }}.txt"
+
+- template:
+    src: uds209fix/from-filesystem.txt.j2
+    dest: "{{ mirror_working_dir }}/manifests/from-filesystem/{{ case_name }}_{{ case_version }}.txt"

--- a/ibm/mas_devops/roles/mirror_case_prepare/templates/uds209fix/direct.txt.j2
+++ b/ibm/mas_devops/roles/mirror_case_prepare/templates/uds209fix/direct.txt.j2
@@ -1,0 +1,15 @@
+icr.io/cpopen/ibm-uds/dataexchange-cli@sha256:c147871fc5913a54855e348db1fcea1c031cb8a59e25e09f6ae32ef23357d26b={{ registry_public_url }}/cpopen/ibm-uds/dataexchange-cli:2.0.9
+icr.io/cpopen/ibm-uds/dataexchange-service@sha256:f7f113950c29da07c0ba74000be3483a80df07fc6334a22ce7abfbb005dbb23a={{ registry_public_url }}/cpopen/ibm-uds/dataexchange-service:2.0.9
+icr.io/cpopen/ibm-uds/event-api@sha256:13c139e2d5dd3e06b298efdc428c7f61d5302c4fdbb672697b6ce78ae1a4af77={{ registry_public_url }}/cpopen/ibm-uds/event-api:2.0.9
+icr.io/cpopen/ibm-uds/event-reader@sha256:d8eb989b7af4bd5b6efe336535e65e4b9ab18ea4a8025d186f987ba949edb7e7={{ registry_public_url }}/cpopen/ibm-uds/event-reader:2.0.9
+icr.io/cpopen/ibm-uds/event-scheduler@sha256:899b5c907503caba65c035c112f0b492966244722f67bb7f0718b1b9821c356f={{ registry_public_url }}/cpopen/ibm-uds/event-scheduler:2.0.9
+icr.io/cpopen/ibm-uds/store-api@sha256:0f4c4dbe5c922d5c46a9f0159c69ca6018b12fcc1e494e3e7c9bf72c15993e51={{ registry_public_url }}/cpopen/ibm-uds/store-api:2.0.9
+icr.io/cpopen/ibm-uds/uds-growth-stack-base@sha256:231c92403d4711027c86ec29cef0fa23452d6c0b46d4a5ac9d269b0743430a06={{ registry_public_url }}/cpopen/ibm-uds/uds-growth-stack-base:2.0.9
+icr.io/cpopen/ibm-user-data-services-catalog@sha256:e54dafa673c43b8af138c5555ba7b6de74ba7ab50a903f4d3d4c67a9b72c5c30={{ registry_public_url }}/cpopen/ibm-user-data-services-catalog:2.0.9
+icr.io/cpopen/ibm-user-data-services-operator-bundle@sha256:3b96dcdad554efea6c3b0a65019d54a1df9065674c769d0ba0812853a22e63d3={{ registry_public_url }}/cpopen/ibm-user-data-services-operator-bundle:2.0.9
+icr.io/cpopen/ibm-user-data-services-operator@sha256:ceb43a0e04d1ba8f87396af0a2012870af8b3f73e55c62e96335ec6fd79d0509={{ registry_public_url }}/cpopen/ibm-user-data-services-operator:2.0.9
+registry.connect.redhat.com/crunchydata/crunchy-pgbackrest@sha256:efe775d3208befb2b7f026ef5fee3b03b306a9ba773709ec5c4c3391880ee60b={{ registry_public_url }}/crunchydata/crunchy-pgbackrest:ubi8-2.38-0
+registry.connect.redhat.com/crunchydata/crunchy-postgres@sha256:6b570ee2922281eedc5c267c50ad30a895fbb4e8a132c3e2c3a38e29fe3d6f6a={{ registry_public_url }}/crunchydata/crunchy-postgres:ubi8-13.6-1
+registry.redhat.io/openshift4/ose-cli@sha256:ccc2d3d593bb4dab980b5483970eb441ede94bbe25972670b37d8890dce7f06f={{ registry_public_url }}/openshift4/ose-cli:v4.8.0-202205121606.p0.g41ff67e.assembly.stream
+registry.redhat.io/rhel8/postgresql-12@sha256:3d805540d777b09b4da6df99e7cddf9598d5ece4af9f6851721a9961df40f5a1={{ registry_public_url }}/rhel8/postgresql-12:1-130
+registry.redhat.io/ubi8/nodejs-14@sha256:881e871f845b9395f5e21cfa45f0d1838dc9af60c4f18ece67bd56a9e44846cc={{ registry_public_url }}/ubi8/nodejs-14:1-75

--- a/ibm/mas_devops/roles/mirror_case_prepare/templates/uds209fix/from-filesystem.txt.j2
+++ b/ibm/mas_devops/roles/mirror_case_prepare/templates/uds209fix/from-filesystem.txt.j2
@@ -1,0 +1,15 @@
+file:///cpopen/ibm-uds/dataexchange-cli@sha256:c147871fc5913a54855e348db1fcea1c031cb8a59e25e09f6ae32ef23357d26b={{ registry_public_url }}/cpopen/ibm-uds/dataexchange-cli:2.0.9
+file:///cpopen/ibm-uds/dataexchange-service@sha256:f7f113950c29da07c0ba74000be3483a80df07fc6334a22ce7abfbb005dbb23a={{ registry_public_url }}/cpopen/ibm-uds/dataexchange-service:2.0.9
+file:///cpopen/ibm-uds/event-api@sha256:13c139e2d5dd3e06b298efdc428c7f61d5302c4fdbb672697b6ce78ae1a4af77={{ registry_public_url }}/cpopen/ibm-uds/event-api:2.0.9
+file:///cpopen/ibm-uds/event-reader@sha256:d8eb989b7af4bd5b6efe336535e65e4b9ab18ea4a8025d186f987ba949edb7e7={{ registry_public_url }}/cpopen/ibm-uds/event-reader:2.0.9
+file:///cpopen/ibm-uds/event-scheduler@sha256:899b5c907503caba65c035c112f0b492966244722f67bb7f0718b1b9821c356f={{ registry_public_url }}/cpopen/ibm-uds/event-scheduler:2.0.9
+file:///cpopen/ibm-uds/store-api@sha256:0f4c4dbe5c922d5c46a9f0159c69ca6018b12fcc1e494e3e7c9bf72c15993e51={{ registry_public_url }}/cpopen/ibm-uds/store-api:2.0.9
+file:///cpopen/ibm-uds/uds-growth-stack-base@sha256:231c92403d4711027c86ec29cef0fa23452d6c0b46d4a5ac9d269b0743430a06={{ registry_public_url }}/cpopen/ibm-uds/uds-growth-stack-base:2.0.9
+file:///cpopen/ibm-user-data-services-catalog@sha256:e54dafa673c43b8af138c5555ba7b6de74ba7ab50a903f4d3d4c67a9b72c5c30={{ registry_public_url }}/cpopen/ibm-user-data-services-catalog:2.0.9
+file:///cpopen/ibm-user-data-services-operator-bundle@sha256:3b96dcdad554efea6c3b0a65019d54a1df9065674c769d0ba0812853a22e63d3={{ registry_public_url }}/cpopen/ibm-user-data-services-operator-bundle:2.0.9
+file:///cpopen/ibm-user-data-services-operator@sha256:ceb43a0e04d1ba8f87396af0a2012870af8b3f73e55c62e96335ec6fd79d0509={{ registry_public_url }}/cpopen/ibm-user-data-services-operator:2.0.9
+file:///crunchydata/crunchy-pgbackrest@sha256:efe775d3208befb2b7f026ef5fee3b03b306a9ba773709ec5c4c3391880ee60b={{ registry_public_url }}/crunchydata/crunchy-pgbackrest:ubi8-2.38-0
+file:///crunchydata/crunchy-postgres@sha256:6b570ee2922281eedc5c267c50ad30a895fbb4e8a132c3e2c3a38e29fe3d6f6a={{ registry_public_url }}/crunchydata/crunchy-postgres:ubi8-13.6-1
+file:///openshift4/ose-cli@sha256:ccc2d3d593bb4dab980b5483970eb441ede94bbe25972670b37d8890dce7f06f={{ registry_public_url }}/openshift4/ose-cli:v4.8.0-202205121606.p0.g41ff67e.assembly.stream
+file:///rhel8/postgresql-12@sha256:3d805540d777b09b4da6df99e7cddf9598d5ece4af9f6851721a9961df40f5a1={{ registry_public_url }}/rhel8/postgresql-12:1-130
+file:///ubi8/nodejs-14@sha256:881e871f845b9395f5e21cfa45f0d1838dc9af60c4f18ece67bd56a9e44846cc={{ registry_public_url }}/ubi8/nodejs-14:1-75

--- a/ibm/mas_devops/roles/mirror_case_prepare/templates/uds209fix/to-filesystem.txt.j2
+++ b/ibm/mas_devops/roles/mirror_case_prepare/templates/uds209fix/to-filesystem.txt.j2
@@ -1,0 +1,15 @@
+iicr.io/cpopen/ibm-uds/dataexchange-cli@sha256:c147871fc5913a54855e348db1fcea1c031cb8a59e25e09f6ae32ef23357d26b=file:///cpopen/ibm-uds/dataexchange-cli:2.0.9
+icr.io/cpopen/ibm-uds/dataexchange-service@sha256:f7f113950c29da07c0ba74000be3483a80df07fc6334a22ce7abfbb005dbb23a=file:///cpopen/ibm-uds/dataexchange-service:2.0.9
+icr.io/cpopen/ibm-uds/event-api@sha256:13c139e2d5dd3e06b298efdc428c7f61d5302c4fdbb672697b6ce78ae1a4af77=file:///cpopen/ibm-uds/event-api:2.0.9
+icr.io/cpopen/ibm-uds/event-reader@sha256:d8eb989b7af4bd5b6efe336535e65e4b9ab18ea4a8025d186f987ba949edb7e7=file:///cpopen/ibm-uds/event-reader:2.0.9
+icr.io/cpopen/ibm-uds/event-scheduler@sha256:899b5c907503caba65c035c112f0b492966244722f67bb7f0718b1b9821c356f=file:///cpopen/ibm-uds/event-scheduler:2.0.9
+icr.io/cpopen/ibm-uds/store-api@sha256:0f4c4dbe5c922d5c46a9f0159c69ca6018b12fcc1e494e3e7c9bf72c15993e51=file:///cpopen/ibm-uds/store-api:2.0.9
+icr.io/cpopen/ibm-uds/uds-growth-stack-base@sha256:231c92403d4711027c86ec29cef0fa23452d6c0b46d4a5ac9d269b0743430a06=file:///cpopen/ibm-uds/uds-growth-stack-base:2.0.9
+icr.io/cpopen/ibm-user-data-services-catalog@sha256:e54dafa673c43b8af138c5555ba7b6de74ba7ab50a903f4d3d4c67a9b72c5c30=file:///cpopen/ibm-user-data-services-catalog:2.0.9
+icr.io/cpopen/ibm-user-data-services-operator-bundle@sha256:3b96dcdad554efea6c3b0a65019d54a1df9065674c769d0ba0812853a22e63d3=file:///cpopen/ibm-user-data-services-operator-bundle:2.0.9
+icr.io/cpopen/ibm-user-data-services-operator@sha256:ceb43a0e04d1ba8f87396af0a2012870af8b3f73e55c62e96335ec6fd79d0509=file:///cpopen/ibm-user-data-services-operator:2.0.9
+registry.connect.redhat.com/crunchydata/crunchy-pgbackrest@sha256:efe775d3208befb2b7f026ef5fee3b03b306a9ba773709ec5c4c3391880ee60b=file:///crunchydata/crunchy-pgbackrest:ubi8-2.38-0
+registry.connect.redhat.com/crunchydata/crunchy-postgres@sha256:6b570ee2922281eedc5c267c50ad30a895fbb4e8a132c3e2c3a38e29fe3d6f6a=file:///crunchydata/crunchy-postgres:ubi8-13.6-1
+registry.redhat.io/openshift4/ose-cli@sha256:ccc2d3d593bb4dab980b5483970eb441ede94bbe25972670b37d8890dce7f06f=file:///openshift4/ose-cli:v4.8.0-202205121606.p0.g41ff67e.assembly.stream
+registry.redhat.io/rhel8/postgresql-12@sha256:3d805540d777b09b4da6df99e7cddf9598d5ece4af9f6851721a9961df40f5a1=file:///rhel8/postgresql-12:1-130
+registry.redhat.io/ubi8/nodejs-14@sha256:881e871f845b9395f5e21cfa45f0d1838dc9af60c4f18ece67bd56a9e44846cc=file:///ubi8/nodejs-14:1-75


### PR DESCRIPTION
Apply the same workaround we delivered for bugs in the packaging of UDS v2.0.8 to UDS v2.0.9, as the same problems exist in it's CASE bundle.