### PR TITLE
[patch] fix sub name for health in convert_to_olm

### DIFF
--- a/ibm/mas_devops/roles/convert_to_olm/defaults/main.yml
+++ b/ibm/mas_devops/roles/convert_to_olm/defaults/main.yml
@@ -49,7 +49,7 @@ supported_apps:
     name: Health
     crd_kind: HealthApp
     op_name: "{{ mas_core_name }}-manage-operator"
-    sub_name: "{{ mas_core_name }}-health"
+    sub_name: "{{ mas_core_name }}-manage"
     csv_name: "{{ mas_core_name }}-manage"
   hputilities:
     name: HPUtilities


### PR DESCRIPTION
Coreapi actually sets the subscription name for health as ibm-mas-manage.