### PR TITLE
[patch] Enable useCommonServices in Appconnect Dashboard by default

### DIFF
--- a/ibm/mas_devops/roles/appconnect/templates/dashboard.yml.j2
+++ b/ibm/mas_devops/roles/appconnect/templates/dashboard.yml.j2
@@ -35,7 +35,7 @@ spec:
           requests:
             cpu: 50m
             memory: 125Mi
-  useCommonServices: false
+  useCommonServices: true
   version: "{{ appconnect_dashboard_version }}"
   storage:
     class: "{{ appconnect_storage_class }}"

--- a/ibm/mas_devops/roles/appconnect/templates/dashboard.yml.j2
+++ b/ibm/mas_devops/roles/appconnect/templates/dashboard.yml.j2
@@ -1,6 +1,7 @@
 ---
 # Check the supported dashboard version and license according to the appconnect operator version.
 # https://www.ibm.com/support/knowledgecenter/SSTTDS_11.0.0/com.ibm.ace.icp.doc/certc_licensingreference.html
+#
 apiVersion: appconnect.ibm.com/v1beta1
 kind: Dashboard
 metadata:

--- a/ibm/mas_devops/roles/appconnect/templates/dashboard.yml.j2
+++ b/ibm/mas_devops/roles/appconnect/templates/dashboard.yml.j2
@@ -1,7 +1,6 @@
 ---
 # Check the supported dashboard version and license according to the appconnect operator version.
 # https://www.ibm.com/support/knowledgecenter/SSTTDS_11.0.0/com.ibm.ace.icp.doc/certc_licensingreference.html
-#
 apiVersion: appconnect.ibm.com/v1beta1
 kind: Dashboard
 metadata:


### PR DESCRIPTION
Update AppConnect dashboard deployment to enable useCommonServices by default.

CLI PR to disable appconnect in the tekton pipeline: https://github.com/ibm-mas/cli/pull/216