### PR TITLE
[patch] Fix role name in configure_manage_eventstreams README

### DIFF
--- a/ibm/mas_devops/roles/configure_manage_eventstreams/README.md
+++ b/ibm/mas_devops/roles/configure_manage_eventstreams/README.md
@@ -1,4 +1,4 @@
-configure_manage_cfg
+configure_manage_eventstreams
 ===
 
 This role configures manage to use IBM Cloud Eventstreams.


### PR DESCRIPTION
The name of the role is wrong in the documentation. Fixing it.