### PR TITLE
[patch]fixed mongodb role for action 'none'

### DIFF
--- a/ibm/mas_devops/playbooks/uninstall_core.yml
+++ b/ibm/mas_devops/playbooks/uninstall_core.yml
@@ -6,7 +6,7 @@
     # Flip the default actions for each role to "uninstall"
     cluster_monitoring_action: "{{ lookup('env', 'CLUSTER_MONITORING_ACTION') | default('uninstall', true) }}"
     sls_action: "{{ lookup('env', 'SLS_ACTION') | default('uninstall', true) }}"
-    mongodb_action: "{{ lookup('env', 'MONGODB_ACTION') | default('uninstall', true) }}"
+    mongodb_action: "{{ lookup('env', 'MONGODB_ACTION') | default('deprovision', true) }}"
     uds_action: "{{ lookup('env', 'UDS_ACTION') | default('uninstall', true) }}"
     cert_manager_action: "{{ lookup('env', 'CERT_MANAGER_ACTION') | default('uninstall', true) }}"
     common_services_action: "{{ lookup('env', 'COMMON_SERVICES_ACTION') | default('uninstall', true) }}"

--- a/ibm/mas_devops/roles/mongodb/README.md
+++ b/ibm/mas_devops/roles/mongodb/README.md
@@ -47,7 +47,7 @@ Determines which action needs to be performed w.r.t mongodb for a specfied `prov
   ```
   Following Providers supports below mentioned DB_ACTION values:
   1. Provider : community 
-  Supported DB_ACTION values : provision
+  Supported DB_ACTION values : provision,deprovision
   2. Provider: aws
   Supported DB_ACTION values : provision,deprovision,docdb_secret_rotate
   3. Provider: ibm

--- a/ibm/mas_devops/roles/mongodb/tasks/main.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/main.yml
@@ -8,9 +8,14 @@
 
 # 2. Load default storage classes (if not provided by the user)
 # -----------------------------------------------------------------------------
-- when: mongodb_provider == "community"
-  include_tasks: tasks/determine-storage-classes.yml
+- include_tasks: tasks/determine-storage-classes.yml
+  when: 
+    - mongodb_provider == "community"
+    - mongodb_action != "none"
+  
 
 # 3. Run the provision / deprovision for specified provider
 # -----------------------------------------------------------------------------
 - include_tasks: "tasks/providers/{{ mongodb_provider }}/{{ mongodb_action }}.yml"
+  when:
+    - mongodb_action != "none"


### PR DESCRIPTION
Issue: 1. Playbook uninstall-core was failing when given value `none` for skipping any dependency uninstall

https://ibm-watson-iot.slack.com/archives/C040TETRV2T/p1679677295384159

Changes :
1. Changed default for mongodb_action to `deprovision` in playbook `uninstall-core`
2. Added a condition to skip any mongodb action when `mongodb_action` is set to `none`
