### PR TITLE
[patch] Fix api.optimizer CNAME entries

### DIFF
--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
@@ -40,7 +40,7 @@
 
 - name: "cis : Verify if is there a dedicated certificate already"
   set_fact:
-    hasDedicated: "{{ _cis_certificates.stdout | from_json | selectattr('hosts', 'search', mas_instance_id) | map(attribute='id') | list | length == 1 }}"
+    hasDedicated: "{{ _cis_certificates.stdout | from_json | selectattr('hosts', 'search', mas_instance_id) | map(attribute='id') | list | length > 0 }}"
 
 - name: "cis : Lookup the dedicated certificate id"
   when: hasDedicated

--- a/ibm/mas_devops/roles/suite_dns/templates/dnsentries.yml.j2
+++ b/ibm/mas_devops/roles/suite_dns/templates/dnsentries.yml.j2
@@ -41,7 +41,9 @@ nowildcard:
   - hputilities
   -  {{ mas_workspace_id }}.hputilities
   - optimizer
+  - api.optimizer
   -  {{ mas_workspace_id }}.optimizer
+  -  {{ mas_workspace_id }}.api.optimizer
   - assist
   -  {{ mas_workspace_id }}.assist
   - reportdb

--- a/ibm/mas_devops/roles/suite_dns/templates/edge_certificate_routes.yml.j2
+++ b/ibm/mas_devops/roles/suite_dns/templates/edge_certificate_routes.yml.j2
@@ -43,6 +43,8 @@ edge_cert_routes:
   - {{ mas_workspace_id }}.hputilities.{{mas_domain}}
   - optimizer.{{mas_domain}}
   - {{ mas_workspace_id }}.optimizer.{{mas_domain}}
+  - api.optimizer.{{mas_domain}}
+  - {{ mas_workspace_id }}.api.optimizer.{{mas_domain}}
   - assist.{{mas_domain}}
   - {{ mas_workspace_id }}.assist.{{mas_domain}}
   - reportdb.{{mas_domain}}


### PR DESCRIPTION
During patch testing we found out that Optimizer has a route that was not yet included in the cname entries for suite_dns.
it's the `api.optimizer` and `{{ mas_workspace_id }}.api.optimizer`.. so this PR fixes this problem going forward.