### PR TITLE
[minor] Update API Server tlsSecurityProfile to support IBM Java Semeru

### DIFF
--- a/build/bin/copy-role-docs.sh
+++ b/build/bin/copy-role-docs.sh
@@ -57,6 +57,7 @@ copyDoc ocp_login
 copyDoc ocp_provision
 copyDoc ocp_roks_upgrade_registry_storage
 copyDoc ocp_simulate_disconnected_network
+copyDoc ocp_update_apiserver
 copyDoc ocp_upgrade
 copyDoc ocp_verify
 copyDoc ocs

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -3,7 +3,7 @@ Note that links to pull requests prior to public release of the code (4.0) direc
 
 - `13.0` Multiple Updates:
     - Switch to ARTIFACTORY_TOKEN ([#752](https://github.com/ibm-mas/ansible-devops/pull/752))
-    - Update API Server tlsSecurityProfile to support by IBM Java Semeru ([#749](https://github.com/ibm-mas/ansible-devops/pull/749))
+    - Update API Server tlsSecurityProfile to support by IBM Java Semeru ([#754](https://github.com/ibm-mas/ansible-devops/pull/754))
 - `12.18` Support March 28th Catalog Update ([#738](https://github.com/ibm-mas/ansible-devops/pull/738))
 - `12.17` Multiple Updates:
     - Add MongoDb clean option to suite_uninstall role ([#706](https://github.com/ibm-mas/ansible-devops/pull/706))

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,6 +1,9 @@
 ## Changes
 Note that links to pull requests prior to public release of the code (4.0) direct to IBM GitHub Enterprise, and will only be accessible to IBM employees.
 
+- `13.0` Multiple Updates:
+    - Switch to ARTIFACTORY_TOKEN ([#752](https://github.com/ibm-mas/ansible-devops/pull/752))
+    - Update API Server tlsSecurityProfile to support by IBM Java Semeru runtime ([#749](https://github.com/ibm-mas/ansible-devops/pull/749))
 - `12.18` Support March 28th Catalog Update ([#738](https://github.com/ibm-mas/ansible-devops/pull/738))
 - `12.17` Multiple Updates:
     - Add MongoDb clean option to suite_uninstall role ([#706](https://github.com/ibm-mas/ansible-devops/pull/706))

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -3,7 +3,7 @@ Note that links to pull requests prior to public release of the code (4.0) direc
 
 - `13.0` Multiple Updates:
     - Switch to ARTIFACTORY_TOKEN ([#752](https://github.com/ibm-mas/ansible-devops/pull/752))
-    - Update API Server tlsSecurityProfile to support by IBM Java Semeru ([#754](https://github.com/ibm-mas/ansible-devops/pull/754))
+    - Update API Server tlsSecurityProfile to support IBM Java Semeru ([#754](https://github.com/ibm-mas/ansible-devops/pull/754))
 - `12.18` Support March 28th Catalog Update ([#738](https://github.com/ibm-mas/ansible-devops/pull/738))
 - `12.17` Multiple Updates:
     - Add MongoDb clean option to suite_uninstall role ([#706](https://github.com/ibm-mas/ansible-devops/pull/706))

--- a/ibm/mas_devops/README.md
+++ b/ibm/mas_devops/README.md
@@ -8,7 +8,7 @@ Note that links to pull requests prior to public release of the code (4.0) direc
 
 - `13.0` Multiple Updates:
     - Switch to ARTIFACTORY_TOKEN ([#752](https://github.com/ibm-mas/ansible-devops/pull/752))
-    - Update API Server tlsSecurityProfile to support by IBM Java Semeru ([#749](https://github.com/ibm-mas/ansible-devops/pull/749))
+    - Update API Server tlsSecurityProfile to support by IBM Java Semeru ([#754](https://github.com/ibm-mas/ansible-devops/pull/754))
 - `12.18` Support March 28th Catalog Update ([#738](https://github.com/ibm-mas/ansible-devops/pull/738))
 - `12.17` Multiple Updates:
     - Add MongoDb clean option to suite_uninstall role ([#706](https://github.com/ibm-mas/ansible-devops/pull/706))

--- a/ibm/mas_devops/README.md
+++ b/ibm/mas_devops/README.md
@@ -6,6 +6,9 @@
 ## Change Log
 Note that links to pull requests prior to public release of the code (4.0) direct to IBM GitHub Enterprise, and will only be accessible to IBM employees.
 
+- `13.0` Multiple Updates:
+    - Switch to ARTIFACTORY_TOKEN ([#752](https://github.com/ibm-mas/ansible-devops/pull/752))
+    - Update API Server tlsSecurityProfile to support by IBM Java Semeru runtime ([#749](https://github.com/ibm-mas/ansible-devops/pull/749))
 - `12.18` Support March 28th Catalog Update ([#738](https://github.com/ibm-mas/ansible-devops/pull/738))
 - `12.17` Multiple Updates:
     - Add MongoDb clean option to suite_uninstall role ([#706](https://github.com/ibm-mas/ansible-devops/pull/706))

--- a/ibm/mas_devops/README.md
+++ b/ibm/mas_devops/README.md
@@ -8,7 +8,7 @@ Note that links to pull requests prior to public release of the code (4.0) direc
 
 - `13.0` Multiple Updates:
     - Switch to ARTIFACTORY_TOKEN ([#752](https://github.com/ibm-mas/ansible-devops/pull/752))
-    - Update API Server tlsSecurityProfile to support by IBM Java Semeru ([#754](https://github.com/ibm-mas/ansible-devops/pull/754))
+    - Update API Server tlsSecurityProfile to support IBM Java Semeru ([#754](https://github.com/ibm-mas/ansible-devops/pull/754))
 - `12.18` Support March 28th Catalog Update ([#738](https://github.com/ibm-mas/ansible-devops/pull/738))
 - `12.17` Multiple Updates:
     - Add MongoDb clean option to suite_uninstall role ([#706](https://github.com/ibm-mas/ansible-devops/pull/706))

--- a/ibm/mas_devops/playbooks/ocp_fyre_provision.yml
+++ b/ibm/mas_devops/playbooks/ocp_fyre_provision.yml
@@ -23,5 +23,8 @@
     - ibm.mas_devops.ocp_login
     - ibm.mas_devops.ocp_verify
 
-    # 3. Install OpenShift Container Storage
+    # 3. Update the APIServer to custom for fips compatibility
+    - ibm.mas_devops.ocp_update_apiserver
+
+    # 4. Install OpenShift Container Storage
     - ibm.mas_devops.ocs

--- a/ibm/mas_devops/roles/ocp_provision/README.md
+++ b/ibm/mas_devops/roles/ocp_provision/README.md
@@ -181,9 +181,12 @@ Provide a description for the cluster.
 - Environment Variable: `FYRE_CLUSTER_DESCRIPTION`
 - Default Value: None
 
+### ocp_fips_enabled
+Set to true to provision a FIPS enabled cluster.
+
 - Optional
-- Environment Variable: `OCP_FIPS`
-- Default Value: false
+- Environment Variable: `OCP_FIPS_ENABLED`
+- Default Value: `false`
 
 ### fyre_cluster_size
 The name of one of Fyre's pre-defined cluster sizes to use for the new cluster.

--- a/ibm/mas_devops/roles/ocp_provision/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/defaults/main.yml
@@ -6,7 +6,7 @@ cluster_type: "{{ lookup('env', 'CLUSTER_TYPE')}}"
 cluster_platform: "{{lookup('env', 'CLUSTER_PLATFORM') | default('x',true)}}"
 
 ocp_version: "{{ lookup('env', 'OCP_VERSION') }}"
-ocp_fips: "{{ lookup('env', 'OCP_FIPS') | default('false', true) | bool }}"
+ocp_fips_enabled: "{{ lookup('env', 'OCP_FIPS_ENABLED') | default('false', true) | bool }}"
 
 supported_cluster_types:
   - fyre

--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/fyre.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/fyre.yml
@@ -29,7 +29,7 @@
       - "Username ..................... {{ fyre_username }}"
       - "Fyre product ID .............. {{ fyre_product_id }}"
       - "Fyre Quota Type .............. {{ fyre_quota_type }}"
-      - "fips enabled ................. {{ ocp_fips }}"
+      - "fips enabled ................. {{ ocp_fips_enabled }}"
       # Quickburn specific
       - "Fyre cluster size ............ {{ fyre_cluster_size | default('<undefined>', true) }}"
       # Product Group specific

--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/ipi.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/ipi.yml
@@ -78,7 +78,7 @@
       - ""
       - "OpenShift Installer Directory .......... {{ ocp_installer_dir }}"
       - "OpenShift Installer Executable ......... {{ ocp_installer_exe }}"
-      - "fips enabled ........................... {{ ocp_fips }}"
+      - "fips enabled ........................... {{ ocp_fips_enabled }}"
 
 - name: "ipi : Debug information (AWS)"
   when: ipi_platform == "aws"

--- a/ibm/mas_devops/roles/ocp_provision/templates/fyre/product_group.json.j2
+++ b/ibm/mas_devops/roles/ocp_provision/templates/fyre/product_group.json.j2
@@ -16,7 +16,7 @@
             "check": "10s"
         }
     },
-    "fips":"{{'yes' if ocp_fips else 'no'}}",
+    "fips":"{{'yes' if ocp_fips_enabled else 'no'}}",
     "worker":  [
         {
             "count": "{{ fyre_worker_count }}",

--- a/ibm/mas_devops/roles/ocp_provision/templates/fyre/quick_burn.json.j2
+++ b/ibm/mas_devops/roles/ocp_provision/templates/fyre/quick_burn.json.j2
@@ -18,5 +18,5 @@
             "check": "10s"
         }
     },
-    "fips":"{{'yes' if ocp_fips else 'no'}}"
+    "fips":"{{'yes' if ocp_fips_enabled else 'no'}}"
 }

--- a/ibm/mas_devops/roles/ocp_provision/templates/ipi/install-config.yaml.j2
+++ b/ibm/mas_devops/roles/ocp_provision/templates/ipi/install-config.yaml.j2
@@ -20,7 +20,7 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
-  networkType: {{'OVNKubernetes' if ocp_fips else 'OpenShiftSDN'}}
+  networkType: {{'OVNKubernetes' if ocp_fips_enabled else 'OpenShiftSDN'}}
   serviceNetwork:
   - 172.30.0.0/16
 platform:
@@ -29,7 +29,7 @@ platform:
 {% if ipi_platform == "gcp" %}
     projectID: {{ipi_gcp_projectid}}
 {% endif %}
-fips: {{ ocp_fips }}
+fips: {{ ocp_fips_enabled }}
 publish: External
 pullSecret: '{{ lookup('file', ipi_pull_secret_file) | regex_replace('\'', '"') }}'
 {% if sshKey != "" %}

--- a/ibm/mas_devops/roles/ocp_update_apiserver/README.md
+++ b/ibm/mas_devops/roles/ocp_update_apiserver/README.md
@@ -1,0 +1,38 @@
+ocp_update_apiserver
+====================
+
+This role will update APIServer custom resource to custom tlsSecurityProfile to accommodate ciphers supported by IBM Java Semeru runtime. This is required for allowing the Java applications using Semeru runtime to run in FIPS mode.
+
+
+Role Variables
+--------------
+
+### cluster_type
+Specify the cluster type, supported values are `fyre`, `roks`, `rosa`, and `ipi`.
+
+- Required
+- Environment Variable: `CLUSTER_TYPE`
+- Default Value: None
+
+### ocp_fips_enabled
+Specify the cluster is fips enabled or not.
+
+- Required
+- Environment Variable: `OCP_FIPS_ENABLED`
+- Default Value: false
+
+
+Example Playbook
+----------------
+
+```yaml
+- hosts: localhost
+  roles:
+    - ibm.mas_devops.ocp_update_apiserver
+```
+
+
+License
+-------
+
+EPL-2.0

--- a/ibm/mas_devops/roles/ocp_update_apiserver/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_update_apiserver/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# We will use the IBM Cloud CLI to update ocp cluster
+cluster_type: "{{ lookup('env', 'CLUSTER_TYPE') }}"
+ocp_fips_enabled: "{{ lookup('env', 'OCP_FIPS_ENABLED') | default('false', true) | bool }}"

--- a/ibm/mas_devops/roles/ocp_update_apiserver/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_update_apiserver/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+# 1. Update API Server
+# -----------------------------------------------------------------------------
+
+# https://github.ibm.com/wiotp/tracker/issues/11556
+
+- name: "Backwards compatability for 'quickburn' cluster type"
+  when: cluster_type == "quickburn"
+  set_fact:
+    cluster_type: "fyre"
+
+# 2. Debug Info
+# -----------------------------------------------------------------------------
+- name: "fyre : Debug information"
+  debug:
+    msg:
+      - "Cluster type ................. {{ cluster_type }}"
+      - "ocp_fips_enabled ............. {{ ocp_fips_enabled }}"
+
+# Update API Server to custom tlsprofile to include semeru compatible ciphers
+- include_tasks: tasks/update-apiserver.yml
+  when:
+      - cluster_type in ['fyre', 'ipi']
+      - ocp_fips_enabled

--- a/ibm/mas_devops/roles/ocp_update_apiserver/tasks/update-apiserver.yml
+++ b/ibm/mas_devops/roles/ocp_update_apiserver/tasks/update-apiserver.yml
@@ -1,0 +1,35 @@
+---
+# 1. update : APISever to custom tlsprofile to include semeru ciphers for fips support
+# -----------------------------------------------------------------------------
+- name: "update : APISever to custom"
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: config.openshift.io/v1
+      kind: APIServer
+      metadata:
+        name: cluster
+      spec:
+        tlsSecurityProfile:
+          custom:
+            ciphers:
+              - TLS_AES_128_GCM_SHA256
+              - TLS_AES_256_GCM_SHA384
+              - TLS_CHACHA20_POLY1305_SHA256
+              - ECDHE-ECDSA-AES128-GCM-SHA256
+              - ECDHE-RSA-AES128-GCM-SHA256
+              - ECDHE-ECDSA-AES256-GCM-SHA384
+              - ECDHE-RSA-AES256-GCM-SHA384
+              - ECDHE-ECDSA-CHACHA20-POLY1305
+              - ECDHE-RSA-CHACHA20-POLY1305
+              - DHE-RSA-AES128-GCM-SHA256
+              - DHE-RSA-AES256-GCM-SHA384
+              - ECDHE-RSA-AES128-SHA256
+              - ECDHE-RSA-AES128-SHA
+              - ECDHE-RSA-AES256-SHA
+          type: Custom
+  register: _changed_apiserver
+
+- name: "Debug information"
+  debug:
+    msg:
+      - "APIServer Changed ............... {{ _changed_apiserver.changed }}"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
       - "ocp_login": roles/ocp_login.md
       - "ocp_provision": roles/ocp_provision.md
       - "ocp_roks_upgrade_registry_storage": roles/ocp_roks_upgrade_registry_storage.md
+      - "ocp_update_apiserver": roles/ocp_update_apiserver.md
       - "ocp_upgrade": roles/ocp_upgrade.md
       - "ocp_verify": roles/ocp_verify.md
   - "Roles: Dependency Mgmt":


### PR DESCRIPTION
https://github.com/ibm-mas/ansible-devops/pull/749 was raised in a forked repo, and don't have any permissions in that fork to address the merge, so porting the changes into a development branch here.


## Description

When invoking Kubernetes APIs from IBM Java Semeru runtimes an error indicating no cipher suites in common can be observed. This is because currently (as of IBM Java Semeru 11.0.16.1) the JVM has a limited set of ciphers available in FIPS mode. It is suggested to simply extend the default by three ciphers to accommodate the IBM Java Semeru runtime. This can be done by create a custom tls profile.

## Related Issues
- https://github.ibm.com/wiotp/tracker/issues/11556

## How Has This Been Tested?
Have created the cluster in fips mode on fyre and tested the Core and SLS are fine in fips mode.
