### PR TITLE
[patch] Update all defaults for MAS 8.10

### DIFF
--- a/docs/playbooks/oneclick-update.md
+++ b/docs/playbooks/oneclick-update.md
@@ -35,7 +35,7 @@ Usage
 Only one parameter is required, the new tag of the IBM Maximo Operator Catalog that you wish to use:
 
 ```bash
-export MAS_CATALOG_VERSION=v8-220805-amd64
+export MAS_CATALOG_VERSION=v8-230328-amd64
 oc login --token=xxxx --server=https://myocpserver
 ansible-playbook ibm.mas_devops.oneclick_update
 ```

--- a/ibm/mas_devops/playbooks/mirror_add_assist.yml
+++ b/ibm/mas_devops/playbooks/mirror_add_assist.yml
@@ -12,8 +12,8 @@
   any_errors_fatal: true
 
   vars:
-    catalog_tag: "{{ lookup('env', 'MAS_CATALOG_VERSION') | default ('v8-230314-amd64', True) }}"
-    mas_channel: "{{ lookup('env', 'MAS_CHANNEL') | default ('8.9.x', True) }}"
+    catalog_tag: "{{ lookup('env', 'MAS_CATALOG_VERSION') | default ('v8-230328-amd64', True) }}"
+    mas_channel: "{{ lookup('env', 'MAS_CHANNEL') | default ('8.10.x', True) }}"
     mirror_mode: "{{ lookup('env', 'MIRROR_MODE') | default ('direct', True) }}"
 
     # mirror_cp4d: "{{ lookup('env', 'MIRROR_CP4D') | default ('True', True) | bool }}"

--- a/ibm/mas_devops/playbooks/mirror_add_hputilities.yml
+++ b/ibm/mas_devops/playbooks/mirror_add_hputilities.yml
@@ -13,8 +13,8 @@
   any_errors_fatal: true
 
   vars:
-    catalog_tag: "{{ lookup('env', 'MAS_CATALOG_VERSION') | default ('v8-230314-amd64', True) }}"
-    mas_channel: "{{ lookup('env', 'MAS_CHANNEL') | default ('8.9.x', True) }}"
+    catalog_tag: "{{ lookup('env', 'MAS_CATALOG_VERSION') | default ('v8-230328-amd64', True) }}"
+    mas_channel: "{{ lookup('env', 'MAS_CHANNEL') | default ('8.10.x', True) }}"
     mirror_mode: "{{ lookup('env', 'MIRROR_MODE') | default ('direct', True) }}"
 
     # mirror_appconnect: "{{ lookup('env', 'MIRROR_APPCONNECT') | default ('True', True) | bool }}"

--- a/ibm/mas_devops/playbooks/mirror_add_iot.yml
+++ b/ibm/mas_devops/playbooks/mirror_add_iot.yml
@@ -10,8 +10,8 @@
   any_errors_fatal: true
 
   vars:
-    catalog_tag: "{{ lookup('env', 'MAS_CATALOG_VERSION') | default ('v8-230314-amd64', True) }}"
-    mas_channel: "{{ lookup('env', 'MAS_CHANNEL') | default ('8.9.x', True) }}"
+    catalog_tag: "{{ lookup('env', 'MAS_CATALOG_VERSION') | default ('v8-230328-amd64', True) }}"
+    mas_channel: "{{ lookup('env', 'MAS_CHANNEL') | default ('8.10.x', True) }}"
     mirror_mode: "{{ lookup('env', 'MIRROR_MODE') | default ('direct', True) }}"
 
     mirror_db2u: "{{ lookup('env', 'MIRROR_DB2U') | default ('True', True) | bool }}"

--- a/ibm/mas_devops/playbooks/mirror_add_manage.yml
+++ b/ibm/mas_devops/playbooks/mirror_add_manage.yml
@@ -10,8 +10,8 @@
   any_errors_fatal: true
 
   vars:
-    catalog_tag: "{{ lookup('env', 'MAS_CATALOG_VERSION') | default ('v8-230314-amd64', True) }}"
-    mas_channel: "{{ lookup('env', 'MAS_CHANNEL') | default ('8.9.x', True) }}"
+    catalog_tag: "{{ lookup('env', 'MAS_CATALOG_VERSION') | default ('v8-230328-amd64', True) }}"
+    mas_channel: "{{ lookup('env', 'MAS_CHANNEL') | default ('8.10.x', True) }}"
     mirror_mode: "{{ lookup('env', 'MIRROR_MODE') | default ('direct', True) }}"
 
     mirror_db2u: "{{ lookup('env', 'MIRROR_DB2U') | default ('True', True) | bool }}"

--- a/ibm/mas_devops/playbooks/mirror_add_monitor.yml
+++ b/ibm/mas_devops/playbooks/mirror_add_monitor.yml
@@ -10,8 +10,8 @@
   any_errors_fatal: true
 
   vars:
-    catalog_tag: "{{ lookup('env', 'MAS_CATALOG_VERSION') | default ('v8-230314-amd64', True) }}"
-    mas_channel: "{{ lookup('env', 'MAS_CHANNEL') | default ('8.9.x', True) }}"
+    catalog_tag: "{{ lookup('env', 'MAS_CATALOG_VERSION') | default ('v8-230328-amd64', True) }}"
+    mas_channel: "{{ lookup('env', 'MAS_CHANNEL') | default ('8.10.x', True) }}"
     mirror_mode: "{{ lookup('env', 'MIRROR_MODE') | default ('direct', True) }}"
 
     mirror_mas_monitor: "{{ lookup('env', 'MIRROR_MAS_MONITOR') | default ('True', True) | bool }}"

--- a/ibm/mas_devops/playbooks/mirror_add_optimizer.yml
+++ b/ibm/mas_devops/playbooks/mirror_add_optimizer.yml
@@ -9,8 +9,8 @@
   any_errors_fatal: true
 
   vars:
-    catalog_tag: "{{ lookup('env', 'MAS_CATALOG_VERSION') | default ('v8-230314-amd64', True) }}"
-    mas_channel: "{{ lookup('env', 'MAS_CHANNEL') | default ('8.9.x', True) }}"
+    catalog_tag: "{{ lookup('env', 'MAS_CATALOG_VERSION') | default ('v8-230328-amd64', True) }}"
+    mas_channel: "{{ lookup('env', 'MAS_CHANNEL') | default ('8.10.x', True) }}"
     mirror_mode: "{{ lookup('env', 'MIRROR_MODE') | default ('direct', True) }}"
 
     mirror_mas_optimizer: "{{ lookup('env', 'MIRROR_MAS_OPTIMIZER') | default ('True', True) | bool }}"

--- a/ibm/mas_devops/playbooks/mirror_add_predict.yml
+++ b/ibm/mas_devops/playbooks/mirror_add_predict.yml
@@ -14,8 +14,8 @@
   any_errors_fatal: true
 
   vars:
-    catalog_tag: "{{ lookup('env', 'MAS_CATALOG_VERSION') | default ('v8-230314-amd64', True) }}"
-    mas_channel: "{{ lookup('env', 'MAS_CHANNEL') | default ('8.9.x', True) }}"
+    catalog_tag: "{{ lookup('env', 'MAS_CATALOG_VERSION') | default ('v8-230328-amd64', True) }}"
+    mas_channel: "{{ lookup('env', 'MAS_CHANNEL') | default ('8.10.x', True) }}"
     mirror_mode: "{{ lookup('env', 'MIRROR_MODE') | default ('direct', True) }}"
 
     # mirror_cp4d: "{{ lookup('env', 'MIRROR_CP4D') | default ('True', True) | bool }}"

--- a/ibm/mas_devops/playbooks/mirror_add_visualinspection.yml
+++ b/ibm/mas_devops/playbooks/mirror_add_visualinspection.yml
@@ -9,8 +9,8 @@
   any_errors_fatal: true
 
   vars:
-    catalog_tag: "{{ lookup('env', 'MAS_CATALOG_VERSION') | default ('v8-230314-amd64', True) }}"
-    mas_channel: "{{ lookup('env', 'MAS_CHANNEL') | default ('8.9.x', True) }}"
+    catalog_tag: "{{ lookup('env', 'MAS_CATALOG_VERSION') | default ('v8-230328-amd64', True) }}"
+    mas_channel: "{{ lookup('env', 'MAS_CHANNEL') | default ('8.10.x', True) }}"
     mirror_mode: "{{ lookup('env', 'MIRROR_MODE') | default ('direct', True) }}"
 
     mirror_mas_visualinspection: "{{ lookup('env', 'MIRROR_MAS_VISUALINSPECTION') | default ('True', True) | bool }}"

--- a/ibm/mas_devops/playbooks/mirror_core.yml
+++ b/ibm/mas_devops/playbooks/mirror_core.yml
@@ -14,8 +14,8 @@
   any_errors_fatal: true
 
   vars:
-    catalog_tag: "{{ lookup('env', 'MAS_CATALOG_VERSION') | default ('v8-230314-amd64', True) }}"
-    mas_channel: "{{ lookup('env', 'MAS_CHANNEL') | default ('8.9.x', True) }}"
+    catalog_tag: "{{ lookup('env', 'MAS_CATALOG_VERSION') | default ('v8-230328-amd64', True) }}"
+    mas_channel: "{{ lookup('env', 'MAS_CHANNEL') | default ('8.10.x', True) }}"
     mirror_mode: "{{ lookup('env', 'MIRROR_MODE') | default ('direct', True) }}"
 
     mirror_catalog: "{{ lookup('env', 'MIRROR_CATALOG') | default ('True', True) | bool }}"

--- a/ibm/mas_devops/playbooks/oneclick_add_assist.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_assist.yml
@@ -15,7 +15,7 @@
 
     # Application Installation
     mas_app_id: assist
-    mas_app_channel: "{{ lookup('env', 'MAS_APP_CHANNEL') | default('8.6.x', true) }}"
+    mas_app_channel: "{{ lookup('env', 'MAS_APP_CHANNEL') | default('8.7.x', true) }}"
 
     mas_app_spec:
       bindings:

--- a/ibm/mas_devops/playbooks/oneclick_add_iot.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_iot.yml
@@ -13,7 +13,7 @@
 
     # Application Installation
     mas_app_id: iot
-    mas_app_channel: "{{ lookup('env', 'MAS_APP_CHANNEL') | default('8.6.x', true) }}"
+    mas_app_channel: "{{ lookup('env', 'MAS_APP_CHANNEL') | default('8.7.x', true) }}"
 
     # Application Configuration
     mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') | default('masdev', true) }}"

--- a/ibm/mas_devops/playbooks/oneclick_add_manage.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_manage.yml
@@ -14,7 +14,7 @@
     # Application Installation
     # mas_app_id can be set to "health" to install manage in the "Health standalone" mode from this same playbook.
     mas_app_id: "{{ lookup('env', 'MAS_APP_ID') | default('manage', true) }}"
-    mas_app_channel: "{{ lookup('env', 'MAS_APP_CHANNEL') | default('8.5.x', true) }}"
+    mas_app_channel: "{{ lookup('env', 'MAS_APP_CHANNEL') | default('8.6.x', true) }}"
 
     # Application Configuration
     mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') | default('masdev', true) }}"

--- a/ibm/mas_devops/playbooks/oneclick_add_monitor.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_monitor.yml
@@ -13,7 +13,7 @@
   vars:
     # Application Installation
     mas_app_id: monitor
-    mas_app_channel: "{{ lookup('env', 'MAS_APP_CHANNEL') | default('8.9.x', true) }}"
+    mas_app_channel: "{{ lookup('env', 'MAS_APP_CHANNEL') | default('8.10.x', true) }}"
 
     # Application Configuration
     mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') | default('masdev', true) }}"

--- a/ibm/mas_devops/playbooks/oneclick_add_optimizer.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_optimizer.yml
@@ -9,7 +9,7 @@
   vars:
 
     # Application Installation
-    mas_app_channel: "{{ lookup('env', 'MAS_APP_CHANNEL') | default('8.3.x', true) }}"
+    mas_app_channel: "{{ lookup('env', 'MAS_APP_CHANNEL') | default('8.4.x', true) }}"
     mas_app_id: optimizer
 
     # Application Configuration

--- a/ibm/mas_devops/playbooks/oneclick_add_predict.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_predict.yml
@@ -16,7 +16,7 @@
     # Application Installation
     # -------------------------------------------------------------------------
     mas_app_id: predict
-    mas_app_channel: "{{ lookup('env', 'MAS_APP_CHANNEL') | default('8.7.x', true) }}"
+    mas_app_channel: "{{ lookup('env', 'MAS_APP_CHANNEL') | default('8.8.x', true) }}"
 
     # Application Configuration
     # -------------------------------------------------------------------------

--- a/ibm/mas_devops/playbooks/oneclick_add_visualinspection.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_visualinspection.yml
@@ -11,7 +11,7 @@
     # Application Installation
     # mas_app_id can be set to "health" to install manage in the "Health standalone" mode from this same playbook.
     mas_app_id: visualinspection
-    mas_app_channel: "{{ lookup('env', 'MAS_APP_CHANNEL') | default('8.7.x', true) }}"
+    mas_app_channel: "{{ lookup('env', 'MAS_APP_CHANNEL') | default('8.8.x', true) }}"
     mas_app_spec: {}
 
     # Application Configuration

--- a/ibm/mas_devops/playbooks/oneclick_core.yml
+++ b/ibm/mas_devops/playbooks/oneclick_core.yml
@@ -11,7 +11,7 @@
     sls_mongodb_cfg_file: "{{ mas_config_dir }}/mongo-{{ mongodb_namespace }}.yml"
 
     # Core Services Configuration
-    mas_channel: "{{ lookup('env', 'MAS_CHANNEL') | default('8.9.x', true) }}"
+    mas_channel: "{{ lookup('env', 'MAS_CHANNEL') | default('8.10.x', true) }}"
 
     # Workspace Configuration
     mas_workspace_name: "{{ lookup('env', 'MAS_WORKSPACE_NAME') | default('MAS Development', true) }}"

--- a/ibm/mas_devops/roles/ibm_catalogs/README.md
+++ b/ibm/mas_devops/roles/ibm_catalogs/README.md
@@ -10,7 +10,7 @@ Version of the IBM Maximo Operator Catalog to install.
 
 - Optional
 - Environment Variable: `MAS_CATALOG_VERSION`
-- Default Value: `v8`
+- Default Value: `v8-amd64`
 
 ### artifactory_username
 Use to enable the install of development catalog sources for pre-release installation.


### PR DESCRIPTION
- Update all default channels in install playbooks for MAS 8.10 release
- Update default catalog choice in mirror playbooks to `v8-230328-amd64`