### PR TITLE
[minor] Support for Db2u and AMQ Streams on OCP 4.12

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,6 +1,7 @@
 ## Changes
 Note that links to pull requests prior to public release of the code (4.0) direct to IBM GitHub Enterprise, and will only be accessible to IBM employees.
 
+- `13.1` Support for Db2u and AMQ Streams on OCP 4.12 ([#759](https://github.com/ibm-mas/ansible-devops/pull/759))
 - `13.0` Multiple Updates:
     - Remove SBO support ([#755](https://github.com/ibm-mas/ansible-devops/pull/755))
     - Switch to ARTIFACTORY_TOKEN ([#752](https://github.com/ibm-mas/ansible-devops/pull/752))

--- a/ibm/mas_devops/README.md
+++ b/ibm/mas_devops/README.md
@@ -6,6 +6,7 @@
 ## Change Log
 Note that links to pull requests prior to public release of the code (4.0) direct to IBM GitHub Enterprise, and will only be accessible to IBM employees.
 
+- `13.1` Support for Db2u and AMQ Streams on OCP 4.12 ([#759](https://github.com/ibm-mas/ansible-devops/pull/759))
 - `13.0` Multiple Updates:
     - Remove SBO support ([#755](https://github.com/ibm-mas/ansible-devops/pull/755))
     - Switch to ARTIFACTORY_TOKEN ([#752](https://github.com/ibm-mas/ansible-devops/pull/752))

--- a/ibm/mas_devops/roles/db2/README.md
+++ b/ibm/mas_devops/roles/db2/README.md
@@ -21,6 +21,20 @@ If the `mas_instance_id` and `mas_config_dir` are provided then the role will ge
 
 Role Variables - Installation
 -------------------------------------------------------------------------------
+### db2_namespace
+Name of the namespace where Db2 clusters will be created
+
+- Optional
+- Environment Variable: `DB2_NAMESPACE`
+- Default: `db2u`
+
+### db2_channel
+The subscription channel for the DB2 Universal Operator.
+
+- Optional
+- Environment Variable: `DB2_CHANNEL`
+- Default: The default channel, as defined in the operator package, will be used if this is not set.
+
 ### db2_instance_name
 Name of the database instance, note that this is the instance **name**.
 

--- a/ibm/mas_devops/roles/db2/defaults/main.yml
+++ b/ibm/mas_devops/roles/db2/defaults/main.yml
@@ -1,7 +1,8 @@
 ---
 # Configure Db2 instance
 # -----------------------------------------------------------------------------------------------------------------
-db2_namespace: db2u
+db2_namespace: "{{ lookup('env', 'DB2_NAMESPACE') | default('db2u', True) }}"
+db2_channel: "{{ lookup('env', 'DB2_CHANNEL') }}"
 
 db2_instance_name: "{{ lookup('env', 'DB2_INSTANCE_NAME') }}" # e.g. db2u-iot or db2u-manage
 db2_dbname: "{{ lookup('env', 'DB2_DBNAME') | default('BLUDB', true) }}"

--- a/ibm/mas_devops/roles/db2/tasks/main.yml
+++ b/ibm/mas_devops/roles/db2/tasks/main.yml
@@ -64,6 +64,31 @@
       - "Temp ................................... {{ db2_temp_storage_class }} - {{ db2_temp_storage_size }} @ {{ db2_temp_storage_accessmode }}"
 
 
+
+# Look up the default channel for the db2u-operator package manifest
+- name: Lookup db2u-operator packagemanifest
+  kubernetes.core.k8s_info:
+    api_version: packages.operators.coreos.com/v1
+    kind: PackageManifest
+    name: db2u-operator
+    namespace: ibm-common-services
+  register: db2u_manifest_info
+  until: db2u_manifest_info.resources[0].status.defaultChannel is defined
+  retries: 60 # Approximately 30 minutes before we give up
+  delay: 30 # 30 seconds
+  when: db2u_channel is not defined or db2u_channel == ""
+
+- name: Set db2u-operator channel
+  ansible.builtin.set_fact:
+    db2u_channel: "{{ db2u_manifest_info.resources[0].status.defaultChannel }}"
+  when: db2u_channel is not defined or db2u_channel == ""
+
+- name: Debug Db2 Universal Operator Install
+  ansible.builtin.debug:
+    msg:
+      - "Channel ................................ {{ db2u_channel }}"
+
+
 # 5. Install a Db2u Operator
 # -----------------------------------------------------------------------------
 - name: "Create db2u Namespace"
@@ -96,9 +121,22 @@
         .dockerconfigjson: "{{ new_secret | to_json | b64encode }}"
   register: secretUpdateResult
 
-- name: "Create db2u Operand Request"
+- name: "Create Db2 Universal Operator Operand Request"
   kubernetes.core.k8s:
-    template: templates/db2u_operator.yml.j2
+    state: absent
+    template: templates/db2u_operandrequest.yml.j2
+    wait: yes
+    wait_timeout: 120
+  register: operandrequest_removal
+
+- name: "Wait 2 minutes if we removed an old OperandRequest"
+  when: operandrequest_removal.changed == True
+  pause:
+    minutes: 2
+
+- name: "Create Db2 Universal Operator Subscription"
+  kubernetes.core.k8s:
+    template: templates/db2u_subscription.yml.j2
     wait: yes
     wait_timeout: 120
 

--- a/ibm/mas_devops/roles/db2/templates/db2u_namespace.yaml
+++ b/ibm/mas_devops/roles/db2/templates/db2u_namespace.yaml
@@ -3,3 +3,15 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: "{{ db2_namespace }}"
+---
+apiVersion: operator.ibm.com/v1
+kind: NamespaceScope
+metadata:
+  name: "nss-{{ db2_namespace }}"
+  namespace: ibm-common-services
+spec:
+  csvInjector:
+    enable: false
+  namespaceMembers:
+    - "{{ db2_namespace }}"
+    - ibm-common-services

--- a/ibm/mas_devops/roles/db2/templates/db2u_operandrequest.yml.j2
+++ b/ibm/mas_devops/roles/db2/templates/db2u_operandrequest.yml.j2
@@ -5,7 +5,7 @@ metadata:
   namespace: "{{ db2_namespace }}"
 spec:
   requests:
-  - operands:
-      - name: ibm-db2u-operator
-    registry: common-service
-    registryNamespace: ibm-common-services
+    - operands:
+        - name: ibm-db2u-operator
+      registry: common-service
+      registryNamespace: ibm-common-services

--- a/ibm/mas_devops/roles/db2/templates/db2u_subscription.yml.j2
+++ b/ibm/mas_devops/roles/db2/templates/db2u_subscription.yml.j2
@@ -1,0 +1,12 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ibm-db2u-operator
+  namespace: ibm-common-services
+spec:
+  channel: "{{ db2_channel }}"
+  installPlanApproval: Automatic
+  name: db2u-operator
+  source: ibm-operator-catalog
+  sourceNamespace: openshift-marketplace

--- a/ibm/mas_devops/roles/kafka/README.md
+++ b/ibm/mas_devops/roles/kafka/README.md
@@ -23,7 +23,7 @@ The version of Kafka to deploy by the operator. Before changing the kafka_versio
 by the [amq-streams operator version](https://access.redhat.com/documentation/en-us/red_hat_amq_streams).
 
 - Environment Variable: `KAFKA_VERSION`
-- Default Value: `2.7.0`
+- Default Value: `3.2.0`
 
 ### kafka_namespace
 The namespace where the operator and Kafka cluster will be deployed.
@@ -143,7 +143,7 @@ IBM Cloud Evenstreams Role Variables
 - Environment Variable: `EVENTSTREAMS_RETENTION`
 - Default Value: `1209600000`
 
-### output_kafkacfg 
+### output_kafkacfg
 
 - Optional
 - Environment Variable: `OUTPUT_KAFKACFG`
@@ -194,7 +194,7 @@ To run this role successfully you must have already installed the [AWS CLI](http
 Also, you need to have AWS user credentials configured via `aws configure` command or simply export `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables with your corresponding AWS username credentials prior running this role.
 
 ### kafka_action
-Action to be performed by Kafka role. Valid values are `install` or `uninstall`. To install AWS MSK kafka cluster, set this variable as `install`. To uninstall an existing AWS MSK kafka cluster, set this variable as `uninstall`. 
+Action to be performed by Kafka role. Valid values are `install` or `uninstall`. To install AWS MSK kafka cluster, set this variable as `install`. To uninstall an existing AWS MSK kafka cluster, set this variable as `uninstall`.
 
 - Environment Variable: `KAFKA_ACTION`
 - Default Value: `install`
@@ -253,7 +253,7 @@ The version of Kafka to deploy.
 - Environment Variable: `AWS_MSK_CIDR_AZ2`
 - Default Value: None
 
-### aws_msk_cidr_az3 
+### aws_msk_cidr_az3
 
 - Required
 - Environment Variable: `AWS_MSK_CIDR_AZ3`
@@ -265,37 +265,37 @@ The version of Kafka to deploy.
 - Environment Variable: `AWS_MSK_INGRESS_CIDR`
 - Default Value: None
 
-### aws_msk_egress_cidr 
+### aws_msk_egress_cidr
 
 - Required
 - Environment Variable: `AWS_MSK_EGRESS_CIDR`
 - Default Value: None
 
-### aws_kafka_user_name 
+### aws_kafka_user_name
 
 - Required
 - Environment Variable: `AWS_KAFKA_USER_NAME`
 - Default Value: None
 
-### aws_kafka_user_password 
+### aws_kafka_user_password
 
 - Optional
 - Environment Variable: `AWS_KAFKA_USER_PASSWORD`
 - Default Value: None
 
-### aws_msk_instance_type 
+### aws_msk_instance_type
 
 - Optional
 - Environment Variable: `AWS_MSK_INSTANCE_TYPE`
 - Default Value: `kafka.m5.large`
 
-### aws_msk_volume_size 
+### aws_msk_volume_size
 
 - Optional
 - Environment Variable: `AWS_MSK_VOLUME_SIZE`
 - Default Value: `100`
 
-### aws_msk_instance_number 
+### aws_msk_instance_number
 
 - Optional
 - Environment Variable: `AWS_MSK_INSTANCE_NUMBER`
@@ -335,7 +335,7 @@ Example Playbook to install AWS MSK
     kafka_provider: aws
     kafka_action: install
     kafka_cluster_name: msk-abcd0zyxw
-    kafka_namespace: msk-abcd0zyxw  
+    kafka_namespace: msk-abcd0zyxw
     vpc_id: vpc-07088da510b3c35c5
     aws_kafka_user_name: mskuser-abcd0zyxw
     aws_msk_instance_type: kafka.t3.small
@@ -345,7 +345,7 @@ Example Playbook to install AWS MSK
     aws_msk_cidr_az2: "10.0.144.0/20"
     aws_msk_cidr_az3: "10.0.160.0/20"
     aws_msk_ingress_cidr: "10.0.0.0/16"
-    aws_msk_egress_cidr: "10.0.0.0/16"	
+    aws_msk_egress_cidr: "10.0.0.0/16"
     # Generate a KafkaCfg template
     mas_config_dir: /var/tmp/masconfigdir
     mas_instance_id: abcd0zyxw
@@ -363,7 +363,7 @@ Example Playbook to uninstall AWS MSK
     aws_region: ca-central-1
     aws_access_key_id: *****
     aws_secret_access_key: *****
-    vpc_id: vpc-07088da510b3c35c5	
+    vpc_id: vpc-07088da510b3c35c5
     kafka_provider: aws
     kafka_action: uninstall
     kafka_cluster_name: msk-abcd0zyxw

--- a/ibm/mas_devops/roles/kafka/README.md
+++ b/ibm/mas_devops/roles/kafka/README.md
@@ -23,7 +23,7 @@ The version of Kafka to deploy by the operator. Before changing the kafka_versio
 by the [amq-streams operator version](https://access.redhat.com/documentation/en-us/red_hat_amq_streams).
 
 - Environment Variable: `KAFKA_VERSION`
-- Default Value: `3.2.0`
+- Default Value: `3.2.3`
 
 ### kafka_namespace
 The namespace where the operator and Kafka cluster will be deployed.

--- a/ibm/mas_devops/roles/kafka/defaults/main.yaml
+++ b/ibm/mas_devops/roles/kafka/defaults/main.yaml
@@ -3,7 +3,7 @@ kafka_provider: "{{ lookup('env', 'KAFKA_PROVIDER') | default('redhat', true) }}
 kafka_action: "{{ lookup('env', 'KAFKA_ACTION') | default('install', true) }}"
 
 # vars for red hat amq
-kafka_version: "{{ lookup('env', 'KAFKA_VERSION') | default('3.2.0', true) }}"
+kafka_version: "{{ lookup('env', 'KAFKA_VERSION') | default('3.2.3', true) }}"
 kafka_namespace: "{{ lookup('env', 'KAFKA_NAMESPACE') | default('amq-streams', true) }}"
 kafka_cluster_name: "{{ lookup('env', 'KAFKA_CLUSTER_NAME') | default('maskafka', true)  }}"
 kafka_cluster_size: "{{ lookup('env', 'KAFKA_CLUSTER_SIZE') | default('small', true)  }}"

--- a/ibm/mas_devops/roles/kafka/defaults/main.yaml
+++ b/ibm/mas_devops/roles/kafka/defaults/main.yaml
@@ -3,7 +3,7 @@ kafka_provider: "{{ lookup('env', 'KAFKA_PROVIDER') | default('redhat', true) }}
 kafka_action: "{{ lookup('env', 'KAFKA_ACTION') | default('install', true) }}"
 
 # vars for red hat amq
-kafka_version: "{{ lookup('env', 'KAFKA_VERSION') | default('2.7.0', true) }}"
+kafka_version: "{{ lookup('env', 'KAFKA_VERSION') | default('3.2.0', true) }}"
 kafka_namespace: "{{ lookup('env', 'KAFKA_NAMESPACE') | default('amq-streams', true) }}"
 kafka_cluster_name: "{{ lookup('env', 'KAFKA_CLUSTER_NAME') | default('maskafka', true)  }}"
 kafka_cluster_size: "{{ lookup('env', 'KAFKA_CLUSTER_SIZE') | default('small', true)  }}"

--- a/ibm/mas_devops/roles/kafka/templates/redhat/subscription.yml.j2
+++ b/ibm/mas_devops/roles/kafka/templates/redhat/subscription.yml.j2
@@ -19,9 +19,8 @@ metadata:
   name: amq-streams
   namespace: "{{ kafka_namespace }}"
 spec:
-  channel: amq-streams-1.8.x
+  channel: stable
   installPlanApproval: Automatic
   name: amq-streams
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-


### PR DESCRIPTION
- Db2u operator requires manual subscription management to install with a more appropriate subscription channel.  Using `OperandRequest` will only provide the `v2.2` channel, which is not supported on OCP 4.12
- AMQ Streams Kafka was subscribing to a specific versioned channel (old), that is no longer supported on OCP 4.12.  The subscription has been switched to `stable` channel now, and the version of the Kafka instance provisioned by default has been updated to v3.2.3 (from 2.7.0)