### PR TITLE
[patch] scc workaround for mvi cephfs

### DIFF
--- a/ibm/mas_devops/roles/suite_app_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/main.yml
@@ -44,13 +44,18 @@
       - "App Subscription Upgrade ... {{ mas_app_upgrade_strategy }}"
 
 
-# 4. Apply security context constraints
+# 4. Apply initial security context constraints
 # -----------------------------------------------------------------------------
-- name: "Apply security context constraints"
+- name: "Apply initial security context constraints"
   when: mas_app_id == "visualinspection"
   kubernetes.core.k8s:
     apply: yes
-    definition: "{{ lookup('template', 'templates/customscc.yml.j2') }}"
+    definition: "{{ lookup('template', 'templates/customsccinit.yml.j2') }}"
+
+- name: "Add anyuid permissions to visualinspection service account"
+  when: mas_app_id == "visualinspection"
+  shell: |
+    oc adm policy add-scc-to-user anyuid system:serviceaccount:{{ mas_app_namespace }}:ibm-mas-visualinspection-operator
 
 
 # 5. Install the operator
@@ -165,3 +170,16 @@
 - name: "Create ibm-data-dictionary Image Digest Map"
   when: mas_app_id == "monitor" and airgap_install
   include_tasks: "tasks/{{ mas_app_id }}.yml"
+
+# 11. Apply final security context constraints
+# -----------------------------------------------------------------------------
+- name: "Apply final security context constraints"
+  when: mas_app_id == "visualinspection"
+  kubernetes.core.k8s:
+    apply: yes
+    definition: "{{ lookup('template', 'templates/customscc.yml.j2') }}"
+
+- name: "Remove anyuid permissions from visualinspection service account"
+  when: mas_app_id == "visualinspection"
+  shell: |
+    oc adm policy remove-scc-from-user anyuid system:serviceaccount:{{ mas_app_namespace }}:ibm-mas-visualinspection-operator

--- a/ibm/mas_devops/roles/suite_app_install/templates/customsccinit.yml.j2
+++ b/ibm/mas_devops/roles/suite_app_install/templates/customsccinit.yml.j2
@@ -1,0 +1,54 @@
+---
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+- CHOWN
+- DAC_OVERRIDE
+- FOWNER
+- FSETID
+- KILL
+- SETGID
+- SETUID
+- SETPCAP
+- NET_BIND_SERVICE
+- NET_RAW
+- SYS_CHROOT
+allowedUnsafeSysctls: null
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: "This policy is the most restrictive for IBM Maximo Visual Inspection."
+  name: ibm-mas-visualinspection-scc
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- ALL
+runAsUser:
+  type: MustRunAsRange
+  uidRangeMax: 65535
+  uidRangeMin: 0
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles: null
+supplementalGroups:
+  type: MustRunAs
+  ranges:
+  - max: 65535
+    min: 1
+users: []
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret


### PR DESCRIPTION
This commit implements a workaround to allow MVI PVCs using cephfs storage classes to be initialized. The workaround is described [here](https://ibm-ai-apps.slack.com/archives/C015YC89LVC/p1655128557085279?thread_ts=1652278875.829829&cid=C015YC89LVC).

