### PR TITLE
[patch] Fix Manage JMS related secret names to be consistent with the pattern that MAS UI generates

### DIFF
--- a/ibm/mas_devops/roles/db2/defaults/main.yml
+++ b/ibm/mas_devops/roles/db2/defaults/main.yml
@@ -6,7 +6,7 @@ db2_channel: "{{ lookup('env', 'DB2_CHANNEL') }}"
 
 db2_instance_name: "{{ lookup('env', 'DB2_INSTANCE_NAME') }}" # e.g. db2u-iot or db2u-manage
 db2_dbname: "{{ lookup('env', 'DB2_DBNAME') | default('BLUDB', true) }}"
-db2_version: "{{ lookup('env', 'DB2_VERSION') | default('s11.5.8.0', true)}}"
+db2_version: "{{ lookup('env', 'DB2_VERSION') | default('11.5.7.0-cn4', true)}}"
 db2_jdbc_username: db2inst1
 tls_version: "{{ lookup('env', 'TLS_VERSION') | default('TLSv1.2', true)}}"
 

--- a/ibm/mas_devops/roles/db2/defaults/main.yml
+++ b/ibm/mas_devops/roles/db2/defaults/main.yml
@@ -6,7 +6,7 @@ db2_channel: "{{ lookup('env', 'DB2_CHANNEL') }}"
 
 db2_instance_name: "{{ lookup('env', 'DB2_INSTANCE_NAME') }}" # e.g. db2u-iot or db2u-manage
 db2_dbname: "{{ lookup('env', 'DB2_DBNAME') | default('BLUDB', true) }}"
-db2_version: "{{ lookup('env', 'DB2_VERSION') | default('11.5.7.0-cn4', true)}}"
+db2_version: "{{ lookup('env', 'DB2_VERSION') | default('s11.5.8.0', true)}}"
 db2_jdbc_username: db2inst1
 tls_version: "{{ lookup('env', 'TLS_VERSION') | default('TLSv1.2', true)}}"
 

--- a/ibm/mas_devops/roles/suite_app_config/templates/manage/manage-additional-server-config-secrets.yml.j2
+++ b/ibm/mas_devops/roles/suite_app_config/templates/manage/manage-additional-server-config-secrets.yml.j2
@@ -1,23 +1,9 @@
 ---
+# secret to be linked to ui bundle server
 kind: Secret
 apiVersion: v1
 metadata:
-  name: {{ server_bundles_add_server_config_secret_name }}
-  namespace: mas-{{ mas_instance_id }}-manage
-{% if custom_labels is defined and custom_labels.items() %}
-  labels:
-{% for key, value in custom_labels.items() %}
-    {{ key }}: "{{ value }}"
-{% endfor %}
-{% endif %}
-data:
-  server-custom.xml: >-
-    {{ server_bundles_add_server_config_content | b64encode }}
----
-kind: Secret
-apiVersion: v1
-metadata:
-  name: {{ server_bundles_add_server_config_no_activation_secret_name }}
+  name: {{ mas_workspace_id }}-{{ mas_app_id }}-d--sb0--asc--sn
   namespace: mas-{{ mas_instance_id }}-manage
 {% if custom_labels is defined and custom_labels.items() %}
   labels:
@@ -29,10 +15,59 @@ data:
   server-custom.xml: >-
     {{ server_bundles_add_server_config_no_activation_content | b64encode }}
 ---
+# secret to be linked to mea bundle server
 kind: Secret
 apiVersion: v1
 metadata:
-  name: {{ server_bundles_jms_add_server_config_secret_name }}
+  name: {{ mas_workspace_id }}-{{ mas_app_id }}-d--sb1--asc--sn
+  namespace: mas-{{ mas_instance_id }}-manage
+{% if custom_labels is defined and custom_labels.items() %}
+  labels:
+{% for key, value in custom_labels.items() %}
+    {{ key }}: "{{ value }}"
+{% endfor %}
+{% endif %}
+data:
+  server-custom.xml: >-
+    {{ server_bundles_add_server_config_content | b64encode }}
+---
+# secret to be linked to report bundle server
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ mas_workspace_id }}-{{ mas_app_id }}-d--sb2--asc--sn
+  namespace: mas-{{ mas_instance_id }}-manage
+{% if custom_labels is defined and custom_labels.items() %}
+  labels:
+{% for key, value in custom_labels.items() %}
+    {{ key }}: "{{ value }}"
+{% endfor %}
+{% endif %}
+data:
+  server-custom.xml: >-
+    {{ server_bundles_add_server_config_no_activation_content | b64encode }}
+---
+# secret to be linked to cron bundle server
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ mas_workspace_id }}-{{ mas_app_id }}-d--sb3--asc--sn
+  namespace: mas-{{ mas_instance_id }}-manage
+{% if custom_labels is defined and custom_labels.items() %}
+  labels:
+{% for key, value in custom_labels.items() %}
+    {{ key }}: "{{ value }}"
+{% endfor %}
+{% endif %}
+data:
+  server-custom.xml: >-
+    {{ server_bundles_add_server_config_no_activation_content | b64encode }}
+---
+# secret to be linked to cron jms server
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ mas_workspace_id }}-{{ mas_app_id }}-d--sb4--asc--sn
   namespace: mas-{{ mas_instance_id }}-manage
 {% if custom_labels is defined and custom_labels.items() %}
   labels:

--- a/ibm/mas_devops/roles/suite_app_config/vars/health.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/health.yml
@@ -13,8 +13,6 @@ mas_app_settings_demodata: "{{ lookup('env', 'MAS_APP_SETTINGS_DEMODATA') | defa
 mas_app_settings_tablespace: "{{ lookup('env', 'MAS_APP_SETTINGS_TABLESPACE') | default('MAXDATA', true)}}"
 mas_app_settings_indexspace: "{{ lookup('env', 'MAS_APP_SETTINGS_INDEXSPACE') | default('MAXINDEX', true)}}"
 
-server_bundles_jms_add_server_config_secret_name: "{{ mas_workspace_id }}-manage-jms-additional-server-config"
-server_bundles_add_server_config_secret_name: "{{ mas_workspace_id }}-manage-additional-server-config"
 mas_app_settings_persistent_volumes_flag: "{{ lookup('env', 'MAS_APP_SETTINGS_PERSISTENT_VOLUMES_FLAG') | default('false', true) }}"
 mas_app_settings_server_bundles_size: "{{ lookup('env', 'MAS_APP_SETTINGS_SERVER_BUNDLES_SIZE') | default('dev', true)  }}"
 mas_app_settings_server_bundles:
@@ -60,7 +58,7 @@ mas_app_settings_server_bundles:
   jms:
     serverBundles:
       - additionalServerConfig:
-          secretName: "{{ server_bundles_add_server_config_secret_name }}"
+          secretName: "{{ mas_workspace_id }}-{{ mas_app_id }}-d--sb0--asc--sn"
         bundleType: ui
         isDefault: true
         isMobileTarget: true
@@ -69,7 +67,7 @@ mas_app_settings_server_bundles:
         replica: 1
         routeSubDomain: ui
       - additionalServerConfig:
-          secretName: "{{ server_bundles_add_server_config_secret_name }}"
+          secretName: "{{ mas_workspace_id }}-{{ mas_app_id }}-d--sb1--asc--sn"
         bundleType: mea
         isDefault: false
         isMobileTarget: false
@@ -78,7 +76,7 @@ mas_app_settings_server_bundles:
         replica: 1
         routeSubDomain: mea
       - additionalServerConfig:
-          secretName: "{{ server_bundles_add_server_config_secret_name }}"
+          secretName: "{{ mas_workspace_id }}-{{ mas_app_id }}-d--sb2--asc--sn"
         bundleType: report
         isDefault: false
         isMobileTarget: false
@@ -87,7 +85,7 @@ mas_app_settings_server_bundles:
         replica: 1
         routeSubDomain: rpt
       - additionalServerConfig:
-          secretName: "{{ server_bundles_add_server_config_secret_name }}"
+          secretName: "{{ mas_workspace_id }}-{{ mas_app_id }}-d--sb3--asc--sn"
         bundleType: cron
         isDefault: false
         isMobileTarget: false
@@ -96,7 +94,7 @@ mas_app_settings_server_bundles:
         replica: 1
         routeSubDomain: cron
       - additionalServerConfig:
-          secretName: "{{ server_bundles_jms_add_server_config_secret_name }}"
+          secretName: "{{ mas_workspace_id }}-{{ mas_app_id }}-d--sb4--asc--sn"
         bundleType: standalonejms
         isDefault: false
         isMobileTarget: false

--- a/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
@@ -64,14 +64,12 @@ mas_app_settings_secondary_languages: "{{ lookup('env', 'MAS_APP_SETTINGS_SECOND
 server_bundle_jms_internal_endpoint: "{{ mas_instance_id }}-{{ mas_workspace_id }}-jms.mas-{{ mas_instance_id }}-manage.svc:7276" # maspreivt89-main-jms.mas-maspreivt89-manage.svc:7276
 
 # these settings will be applied to ui, cron and report - these server bundles don't need the activation specification in the JMS config xml
-server_bundles_add_server_config_no_activation_secret_name: "{{ mas_workspace_id }}-manage-additional-server-config-no-activation"
 server_bundles_add_server_config_no_activation_content: "{{ lookup('file', '{{ role_path }}/files/manage/manage-additional-server-config-no-activation.xml.j2') }}"
 
-# these settings will be applied to mea - this server bundles will need the activation specification in the JMS config xml
-server_bundles_add_server_config_secret_name: "{{ mas_workspace_id }}-manage-additional-server-config"
+# this setting will be applied to mea - this server bundles will need the activation specification in the JMS config xml
 server_bundles_add_server_config_content: "{{ lookup('file', '{{ role_path }}/files/manage/manage-additional-server-config.xml.j2') }}"
 
-# these settings will be applied to jms - this server bundle will have special config for JMS queues in the xml
+# this setting will be applied to jms - this server bundle will have special config for JMS queues in the xml
 server_bundles_jms_add_server_config_secret_name: "{{ mas_workspace_id }}-manage-jms-additional-server-config"
 server_bundles_jms_add_server_config_content: "{{ lookup('file', '{{ role_path }}/files/manage/manage-jms-additional-server-config.xml.j2') }}"
 
@@ -120,7 +118,7 @@ mas_app_settings_server_bundles:
   jms:
     serverBundles:
       - additionalServerConfig:
-          secretName: "{{ server_bundles_add_server_config_no_activation_secret_name }}"
+          secretName: "{{ mas_workspace_id }}-{{ mas_app_id }}-d--sb0--asc--sn"
         bundleType: ui
         isDefault: true
         isMobileTarget: true
@@ -129,7 +127,7 @@ mas_app_settings_server_bundles:
         replica: 1
         routeSubDomain: ui
       - additionalServerConfig:
-          secretName: "{{ server_bundles_add_server_config_secret_name }}"
+          secretName: "{{ mas_workspace_id }}-{{ mas_app_id }}-d--sb1--asc--sn"
         bundleType: mea
         isDefault: false
         isMobileTarget: false
@@ -138,7 +136,7 @@ mas_app_settings_server_bundles:
         replica: 1
         routeSubDomain: mea
       - additionalServerConfig:
-          secretName: "{{ server_bundles_add_server_config_no_activation_secret_name }}"
+          secretName: "{{ mas_workspace_id }}-{{ mas_app_id }}-d--sb2--asc--sn"
         bundleType: report
         isDefault: false
         isMobileTarget: false
@@ -147,7 +145,7 @@ mas_app_settings_server_bundles:
         replica: 1
         routeSubDomain: rpt
       - additionalServerConfig:
-          secretName: "{{ server_bundles_add_server_config_no_activation_secret_name }}"
+          secretName: "{{ mas_workspace_id }}-{{ mas_app_id }}-d--sb3--asc--sn"
         bundleType: cron
         isDefault: false
         isMobileTarget: false
@@ -156,7 +154,7 @@ mas_app_settings_server_bundles:
         replica: 1
         routeSubDomain: cron
       - additionalServerConfig:
-          secretName: "{{ server_bundles_jms_add_server_config_secret_name }}"
+          secretName: "{{ mas_workspace_id }}-{{ mas_app_id }}-d--sb4--asc--sn"
         bundleType: standalonejms
         isDefault: false
         isMobileTarget: false


### PR DESCRIPTION
Currently when Manage is activated with `mas_app_settings_server_bundles_size : jms`, by default we create custom secret names that contain the xml config to setup JMS pre-reqs for queues and linked them in the ManageWorkspace CR.

These secrets are named:
```
main-manage-additional-server-config-no-activation
main-manage-additional-server-config
main-manage-jms-additional-server-config
```

The problem here is that when someone make any change to Manage Workspace via UI, the UI checks that these secret are setup with a different secret name pattern than it expects and renames all these secrets to following pattern:

```
main-manage-d--sb0--asc--sn
main-manage-d--sb1--asc--sn
main-manage-d--sb2--asc--sn
main-manage-d--sb3--asc--sn
main-manage-d--sb4--asc--sn
```

This causes a mismatch in the JMS configuration as the ManageWorkspace CR does not look for the right secrets anymore once this happens. 
This PR aligns the secret names created by the Manage JMS setup automation to what the MAS UI expects, to avoid messing up with the Manage bundles server configurations.