### PR TITLE
[patch] Reinstate the airgap uds 209 fix

### DIFF
--- a/ibm/mas_devops/roles/mirror_case_prepare/tasks/prepare-released.yml
+++ b/ibm/mas_devops/roles/mirror_case_prepare/tasks/prepare-released.yml
@@ -116,9 +116,16 @@
   include_tasks: "tasks/uds-208-fix.yml"
 
 
+# 8a. IBM UDS 2.0.9 Entitled Image Hack
+# -----------------------------------------------------------------------------
+# The UDS CASE bundle includes one entitled image - cp/uds/uds-submodule:2.0.9
+- name: "IBM UDS 2.0.9 workaround"
+  when: case_name == "ibm-uds" and case_version == "2.0.9"
+  include_tasks: "tasks/uds-209-fix.yml"
+
 # 9. IBM Maximo IoT 8.6.0 Bad Digest Hack
 # -----------------------------------------------------------------------------
 # The IoT CASE bundle for 8.6.0 has an incorrect image digest in it
-- name: "IBM UDS 2.0.8 workaround"
+- name: "IBM IoT 8.6.0 workaround"
   when: case_name == "ibm-mas-iot" and case_version == "8.6.0"
   include_tasks: "tasks/iot-860-fix.yml"


### PR DESCRIPTION
Invocation of the UDS 2.0.9 fix was accidentally deleted during the recent restructure of the mirror case prepare role.