### PR TITLE
[patch] Fix install_operator role

### DIFF
--- a/ibm/mas_devops/roles/install_operator/templates/ibm-entitlement-with-artifactory.json.j2
+++ b/ibm/mas_devops/roles/install_operator/templates/ibm-entitlement-with-artifactory.json.j2
@@ -2,4 +2,4 @@
 {% if artifactory_username is defined and artifactory_username != "" %}
 "docker-na-public.artifactory.swg-devops.com/wiotp-docker-local":{"username":"{{ artifactory_username }}","password":"{{ artifactory_token }}","auth":"{{ (artifactory_username ~ ':' ~ artifactory_token) | b64encode }}"},
 {% endif %}
-"cp.icr.io/cp":{"username":"{{ mas_entitlement_username }}","password":"{{ mas_entitlement_key }}","auth":"{{ (mas_entitlement_username ~ ':' ~ mas_entitlement_key) | b64encode }}"}}}
+"cp.icr.io/cp":{"username":"{{ icr_username }}","password":"{{ icr_password }}","auth":"{{ (icr_username ~ ':' ~ icr_password) | b64encode }}"}}}


### PR DESCRIPTION
As part of this PR: https://github.com/ibm-mas/ansible-devops/pull/764
I made a change to `install_operator` role that I should not have done and this broke the SLS install while testing the pre-release version of cli. I'm reverting the change back to what it was.