### PR TITLE
[patch] Set local storage operator channel to stable

### DIFF
--- a/ibm/mas_devops/roles/ocs/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocs/tasks/main.yml
@@ -20,8 +20,8 @@
     storage_operator: "{{ (ocp_release is version('4.11.0', '>=')) | ternary('odf', 'ocs') }}"
     storage_operator_channel: "stable-{{ ocp_release | regex_search('^([0-9]+)\\.([0-9]+)') }}" # extract the ocp minor version
 
-    # The lso operator channel subscription differs depending on the OCP version
-    local_storage_operator_channel: "{{ (ocp_release is version('4.11.0', '>=')) | ternary('stable', ocp_release) }}"
+    # The lso operator channel subscription can be set to stable for all the versions
+    local_storage_operator_channel: "stable"
 
 # 1. Debug configuration
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Set the local storage operator channel to `stable` for all OCP releases. The `stable` channel can be used for all OCP releases as it is the same as the stable-{ocpversion} channel