### PR TITLE
[patch] check for exisitng user + supports integreatly

### DIFF
--- a/ibm/mas_devops/roles/kafka/tasks/provider/redhat/install.yml
+++ b/ibm/mas_devops/roles/kafka/tasks/provider/redhat/install.yml
@@ -13,7 +13,7 @@
 
 - name: Determine cluster capabilities
   set_fact:
-    supports_integreatly_org: "{{ 
+    supports_integreatly_org: "{{
       api_status is defined and
       api_status.apis is defined and
       api_status.apis['integreatly.org/v1alpha1'] is defined

--- a/ibm/mas_devops/roles/kafka/tasks/provider/redhat/install.yml
+++ b/ibm/mas_devops/roles/kafka/tasks/provider/redhat/install.yml
@@ -22,7 +22,7 @@
 
 # 3. Lookup any existing kafka user in the kafka namespace to use the same password
 # -----------------------------------------------------------------------------
-- name: "Lookup any exiting Kafka user Secret"
+- name: "Lookup any existing Kafka User Secret"
   kubernetes.core.k8s_info:
     api_version: v1
     kind: Secret

--- a/ibm/mas_devops/roles/kafka/tasks/provider/redhat/install.yml
+++ b/ibm/mas_devops/roles/kafka/tasks/provider/redhat/install.yml
@@ -4,7 +4,40 @@
 - include_tasks: tasks/determine-storage-classes.yml
 
 
-# 2. Provide debug
+# 2. Delete if the cluster supports 'integreatly.org/v1' for GrafanaDashboards
+# -----------------------------------------------------------------------------
+- name: Get cluster info
+  kubernetes.core.k8s_cluster_info:
+  register: api_status
+  no_log: true
+
+- name: Determine cluster capabilities
+  set_fact:
+    supports_integreatly_org: "{{ 
+      api_status is defined and
+      api_status.apis is defined and
+      api_status.apis['integreatly.org/v1alpha1'] is defined
+    }}"
+
+
+# 3. Lookup any existing kafka user in the kafka namespace to use the same password
+# -----------------------------------------------------------------------------
+- name: "Lookup any exiting Kafka user Secret"
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: "{{ kafka_user_name }}"
+    namespace: "{{ kafka_namespace }}"
+  register: kafka_user_secret_lookup
+
+- name: "Set kafka user password fact based on any existing secret"
+  set_fact:
+    kafka_user_password: "{{ kafka_user_secret_lookup.resources[0].data.password | b64decode }}"
+  when:
+    - kafka_user_secret_lookup is defined
+    - kafka_user_secret_lookup.resources[0].data.password is defined
+
+# 4. Provide debug
 # -----------------------------------------------------------------------------
 - name: "Debug information"
   debug:
@@ -18,8 +51,9 @@
       - "AMQ Streams zookeeper storage class ... {{ zookeeper_storage_class }}"
       - "AMQ Streams zookeeper storage size .... {{ zookeeper_storage_size }}"
       - "AMQ Streams MAS user .................. {{ kafka_user_name }}"
+      - "Cluster supports integreatly .......... {{ supports_integreatly_org }}"
 
-# 3. Install AMQ Streams operator
+# 5. Install AMQ Streams operator
 # -----------------------------------------------------------------------------
 - name: "Install AMQ Streams Operator"
   kubernetes.core.k8s:
@@ -27,7 +61,7 @@
     template: templates/{{ kafka_provider }}/subscription.yml.j2
 
 
-# 4. Wait until the Kafka CRD is available
+# 6. Wait until the Kafka CRD is available
 # -----------------------------------------------------------------------------
 - name: "Wait until the Kafka CRD is available"
   kubernetes.core.k8s_info:
@@ -48,7 +82,7 @@
     - kafka_crd_info.resources | length > 0
 
 
-# 5 Create logging/monitoring configmaps and PodMonitor custom resources
+# 7. Create logging/monitoring configmaps and PodMonitor custom resources
 # -----------------------------------------------------------------------------
 - name: "Create Kafka logging configmap"
   kubernetes.core.k8s:
@@ -65,7 +99,7 @@
     apply: yes
     template: "templates/{{ kafka_provider }}/podmonitor.yml.j2"
 
-# 6. Deploy the cluster
+# 8. Deploy the cluster
 # -----------------------------------------------------------------------------
 - name: "Create Kafka Cluster"
   kubernetes.core.k8s:
@@ -73,7 +107,7 @@
     template: "templates/{{ kafka_provider }}/clusters/{{ kafka_cluster_size }}.yml.j2"
 
 
-# 7. Wait until the KafkaUser CRD is available
+# 9. Wait until the KafkaUser CRD is available
 # -----------------------------------------------------------------------------
 - name: "Wait until the KafkaUser CRD is available"
   kubernetes.core.k8s_info:
@@ -94,14 +128,15 @@
     - kafkauser_crd_info.resources | length > 0
 
 
-# 8. Create the MAS user
+# 10. Create the MAS user
 # -----------------------------------------------------------------------------
 - name: "Create Kafka User"
   kubernetes.core.k8s:
     apply: yes
     template: templates/{{ kafka_provider }}/masuser.yml.j2
 
-# 9. Create Grafana dashboards for Kafka monitoring
+
+# 11. Create Grafana dashboards for Kafka monitoring
 # -----------------------------------------------------------------------------
 - name: "Create Kafka monitoring dashboards"
   kubernetes.core.k8s:
@@ -109,8 +144,10 @@
     template: "{{ item }}"
   with_fileglob:
     - "templates/{{ kafka_provider }}/dashboards/*.yml.j2"
+  when: supports_integreatly_org
 
-# 10. Lookup details
+
+# 12. Lookup details
 # -----------------------------------------------------------------------------
 # We have seen instances where the Kafka cluster is reported as Ready but
 # the necessary fields in the status resource are not set yet so we retry until
@@ -161,7 +198,7 @@
       - "MAS user password ............ {{ kafka_user_password }}"
 
 
-# 11. Create KafkaCfg for MAS (if mas_instance_id & mas_config_dir are set)
+# 13. Create KafkaCfg for MAS (if mas_instance_id & mas_config_dir are set)
 # -----------------------------------------------------------------------------
 - name: Debug KafkaCfg creation properties
   when:


### PR DESCRIPTION
Fixes https://github.com/ibm-mas/ansible-devops/issues/781 to make the kafka role idempotent. Now if you run the kafka role again on an existing environment then it will detect the maskafka-credentials secret in the kafka namespace, and if there is a password it will use that rather than create a new random password.

Also fixes https://github.com/ibm-mas/ansible-devops/issues/546 which now checks the cluster to see if it supports the api `integreatly.org/v1alpha1` and if it does then the grafanadashboard resources are installed.

This is the output from a rerun of the kafka role (you can see that it checked the cluster supported the `integreatly.org/v1alpha1` api, and that the kafka user was not modified) :

![image](https://user-images.githubusercontent.com/6817894/233987108-b886a0c1-36a3-4d5f-bf6f-1e83e2deac67.png)

![image](https://user-images.githubusercontent.com/6817894/233987254-54ae799a-3c86-4345-9327-222409c57269.png)
