### PR TITLE
[patch] Don't duplicate mongo airgap image name

### DIFF
--- a/ibm/mas_devops/roles/mirror_extras_prepare/vars/mongoce_4.4.21.yml
+++ b/ibm/mas_devops/roles/mirror_extras_prepare/vars/mongoce_4.4.21.yml
@@ -5,11 +5,6 @@ extra_images:
     tag: 0.7.9
     digest: sha256:2d5339dab49c3b9523ca97b53580db0f3a291a671a60f5882c5ed18a66073520
 
-  - name: ibmmas/mongodb-kubernetes-operator
-    registry: quay.io
-    tag: 0.7.8
-    digest: sha256:34779add4e076e5182acba1abe7970ec5a07695ea90bcc9dadf00bc86bfb5675
-
   - name: mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook
     registry: quay.io
     tag: 1.0.6


### PR DESCRIPTION
The airgap for mongo have two entries for the mongo kubernetes operator (0.7.8 and 0.7.9) however the oc mirror can only cope with one named image, so we have to set this to be the default of 0.7.9. There is no logically reason why anyone would choose 0.7.8 over 0.7.9 anyway.