### PR TITLE
721 uds singlecert

### DIFF
--- a/docs/playbooks/cp4d.md
+++ b/docs/playbooks/cp4d.md
@@ -6,7 +6,7 @@ You will need a RedHat OpenShift v4.10 cluster with IBM Maximo Application Suite
 ## Overview
 This playbook will add **Cloud Pak for Data 4.x** to an existing cluster installation. It could also install additional CP4D services.
 
-This playbook can be run against any OCP cluster regardless of it's type; whether it's running in IBM Cloud, Azure, AWS, or your local datacenter.
+This playbook can be run against any OCP cluster regardless of its type; whether it's running in IBM Cloud, Azure, AWS, or your local datacenter.
 
 - Install CP4D ControlPlane (~1 hour)
 - Install CP4D Services (~30 Minutes - 1 hour for each service)

--- a/docs/playbooks/oneclick-core.md
+++ b/docs/playbooks/oneclick-core.md
@@ -1,6 +1,6 @@
 # OneClick Install for MAS Core
 
-This playbook will install and configure IBM Maximo Application Suite Core along with all necessary dependencies.  This can be ran against any OCP cluster regardless of it's type, whether it's running in IBM Cloud, Azure, AWS, or your local datacenter.  It will take approximately 90 minutes to set up MAS core services and all of it's dependencies, at the end of the process you will be able to login to the MAS admin dashboard to install any applications that you wish to use, or you can use our other playbooks to automate the installation of those applications (including any additional dependencies)
+This playbook will install and configure IBM Maximo Application Suite Core along with all necessary dependencies.  This can be ran against any OCP cluster regardless of its type, whether it's running in IBM Cloud, Azure, AWS, or your local datacenter.  It will take approximately 90 minutes to set up MAS core services and all of its dependencies, at the end of the process you will be able to login to the MAS admin dashboard to install any applications that you wish to use, or you can use our other playbooks to automate the installation of those applications (including any additional dependencies)
 
 ## Playbook Content
 1. [Install IBM Operator Catalogs](../roles/ibm_catalogs.md) (1 minute)

--- a/docs/playbooks/oneclick-iot.md
+++ b/docs/playbooks/oneclick-iot.md
@@ -6,7 +6,7 @@ You will need a RedHat OpenShift v4.8 cluster with IBM Maximo Application Suite 
 ## Overview
 This playbook will add **Maximo IoT v8.4** to an existing IBM Maximo Application Suite Core installation.  It will also creatie an in-cluster Db2 instance and Kafka cluster, both of which will be automatically set up as system-level configurations in MAS.  IoT will be configured to accept automatic security updates and bug fixes, but not new feature releases.
 
-This playbook can be ran against any OpenShift cluster regardless of it's type; whether it's running in IBM Cloud, Azure, AWS, or your local datacenter.
+This playbook can be ran against any OpenShift cluster regardless of its type; whether it's running in IBM Cloud, Azure, AWS, or your local datacenter.
 
 - Install dependencies:
     - Install IBM Db2 Universal Operator (2 minutes)

--- a/docs/playbooks/oneclick-manage.md
+++ b/docs/playbooks/oneclick-manage.md
@@ -6,7 +6,7 @@ You will need a RedHat OpenShift v4.8 cluster with IBM Maximo Application Suite 
 ## Overview
 This playbook will add **Maximo Manage v8.3** to an existing IBM Maximo Application Suite Core installation.  It will also creatie an in-cluster Db2 instance, which will be automatically set up as the system-level JDBC configuration in MAS.  Manage will be configured to accept automatic security updates and bug fixes, but not new feature releases.
 
-This playbook can be ran against any OCP cluster regardless of it's type; whether it's running in IBM Cloud, Azure, AWS, or your local datacenter.
+This playbook can be ran against any OCP cluster regardless of its type; whether it's running in IBM Cloud, Azure, AWS, or your local datacenter.
 
 - Install dependencies:
     - Install IBM Db2 Universal Operator (2 minutes)

--- a/docs/playbooks/oneclick-monitor.md
+++ b/docs/playbooks/oneclick-monitor.md
@@ -6,7 +6,7 @@ You will need a RedHat OpenShift v4.8 cluster with IBM Maximo Application Suite 
 ## Overview
 This playbook will add **Maximo Monitor v8.7** to an existing IBM Maximo Application Suite Core installation.  Monitor will be configured to accept automatic security updates and bug fixes, but not new feature releases.
 
-This playbook can be ran against any OpenShift cluster regardless of it's type; whether it's running in IBM Cloud, Azure, AWS, or your local datacenter.
+This playbook can be ran against any OpenShift cluster regardless of its type; whether it's running in IBM Cloud, Azure, AWS, or your local datacenter.
 
 - Install Maximo Monitor application:
     - Install application (60 minutes)

--- a/docs/playbooks/oneclick-optimizer.md
+++ b/docs/playbooks/oneclick-optimizer.md
@@ -6,7 +6,7 @@ You will need a RedHat OpenShift v4.8 cluster with IBM Maximo Application Suite 
 ## Overview
 This playbook will add **Maximo Optimizer v8.3** to an existing IBM Maximo Application Suite Core installation.  Optimizer will be configured to accept automatic security updates and bug fixes, but not new feature releases.
 
-This playbook can be ran against any OpenShift cluster regardless of it's type; whether it's running in IBM Cloud, Azure, AWS, or your local datacenter.
+This playbook can be ran against any OpenShift cluster regardless of its type; whether it's running in IBM Cloud, Azure, AWS, or your local datacenter.
 
 - Install Maximo Optimizer application:
     - Install application (10 minutes)

--- a/docs/playbooks/oneclick-predict.md
+++ b/docs/playbooks/oneclick-predict.md
@@ -6,7 +6,7 @@ You will need a RedHat OpenShift v4.8 cluster with IBM Maximo Application Suite 
 ## Overview
 This playbook will add **Predict v8.6** to an existing IBM Maximo Application Suite Core installation. It will also install CloudPak for Data + CP4D services.
 
-This playbook can be ran against any OCP cluster regardless of it's type; whether it's running in IBM Cloud, Azure, AWS, or your local datacenter.
+This playbook can be ran against any OCP cluster regardless of its type; whether it's running in IBM Cloud, Azure, AWS, or your local datacenter.
 
 - Install dependencies:
     - Install CP4D (~1 1/2 hours)

--- a/docs/playbooks/oneclick-visualinspection.md
+++ b/docs/playbooks/oneclick-visualinspection.md
@@ -6,7 +6,7 @@ You will need a RedHat OpenShift v4.8 cluster with IBM Maximo Application Suite 
 ## Overview
 This playbook will add **Maximo Visual Inspection v8.7** to an existing IBM Maximo Application Suite Core installation.  MVI will be configured to accept automatic security updates and bug fixes, but not new feature releases.
 
-This playbook can be ran against any OpenShift cluster regardless of it's type; whether it's running in IBM Cloud, Azure, AWS, or your local datacenter.
+This playbook can be ran against any OpenShift cluster regardless of its type; whether it's running in IBM Cloud, Azure, AWS, or your local datacenter.
 
 - Install dependencies:
     - Install NVIDIA Graphical Processing Unit (GPU) (10 minutes)

--- a/docs/playbooks/uninstall-core.md
+++ b/docs/playbooks/uninstall-core.md
@@ -1,7 +1,7 @@
 Uninstall for MAS Core
 ===============================================================================
 
-This playbook will remove MAS Core Platform and it's dependencies from your cluster.  If you have installed any MAS applications you should uninstall them first.  This playbook will effectively undo everything done in the [oneclick-core](oneclick-core.md) playbook.
+This playbook will remove MAS Core Platform and its dependencies from your cluster.  If you have installed any MAS applications you should uninstall them first.  This playbook will effectively undo everything done in the [oneclick-core](oneclick-core.md) playbook.
 
 The following will be removed from the cluster.
 - MAS Core Platform for the specified instance ID

--- a/ibm/mas_devops/common_vars/compatibility_matrix.yml
+++ b/ibm/mas_devops/common_vars/compatibility_matrix.yml
@@ -24,7 +24,7 @@ compatibility_matrix:
     iot: [8.4.x, 8.5.x]
     manage: [8.3.x, 8.4.x]
     monitor: [8.7.x, 8.8.x]
-    optimizer: [8.2.x] # New in MAS 8.8, versioning starts at 8.2.0 due to wierdness with it's predecessor (MSO)
+    optimizer: [8.2.x] # New in MAS 8.8, versioning starts at 8.2.0 due to wierdness with its predecessor (MSO)
     predict: [8.5.x, 8.6.x]
     safety: [8.2.x, 8.3.x]
     visualinspection: [8.5.x, 8.6.x]

--- a/ibm/mas_devops/playbooks/mirror_add_hputilities.yml
+++ b/ibm/mas_devops/playbooks/mirror_add_hputilities.yml
@@ -3,7 +3,7 @@
 # Maximo Application Suite Core Services installation:
 # 0. Common services (make sure to mirror MAS Core with common services)
 # 1. CP4D
-# 2. Watson Studio and it's dependencies
+# 2. Watson Studio and its dependencies
 # 3. App connect
 # 4. IBM Maximo Health and Predict Utilties
 #

--- a/ibm/mas_devops/playbooks/mirror_add_predict.yml
+++ b/ibm/mas_devops/playbooks/mirror_add_predict.yml
@@ -3,7 +3,7 @@
 # Maximo Application Suite Core Services installation:
 # 0. Common services (make sure to mirror MAS Core with common services)
 # 1. CP4D
-# 2. Watson Studio and it's dependencies
+# 2. Watson Studio and its dependencies
 # 3. Watson Machine Learning
 # 4. Analytics Engine
 # 5. IBM Maximo Predict

--- a/ibm/mas_devops/playbooks/run_role.yml
+++ b/ibm/mas_devops/playbooks/run_role.yml
@@ -1,5 +1,5 @@
 ---
-# This playbook can be used to execute any role in this collection.  It's
+# This playbook can be used to execute any role in this collection.  Its
 # primary purpose is as the driver for our tekton pipeline Tasks, each
 # task will call ibm.mas_devops.run_role with a specific ROLE_NAME set.
 #

--- a/ibm/mas_devops/roles/cert_manager_upgrade/tasks/cert_manager_upgrade/copy_cluster_issuer.yml
+++ b/ibm/mas_devops/roles/cert_manager_upgrade/tasks/cert_manager_upgrade/copy_cluster_issuer.yml
@@ -1,5 +1,5 @@
 ---
-# ClusterIssuers don't need to be moved, but we do need to copy it's CA secret into
+# ClusterIssuers don't need to be moved, but we do need to copy its CA secret into
 # the new namespace because the CA secret must reside in the namespace where the
 # cert-manager operator is installed.
 # If ClusterIssuer was set for Let's Encrypt then we don't copy CA secret
@@ -22,7 +22,7 @@
     fail_msg: "Unable to copy secret, the source ClusterIssuer does not exist: {{ cluster_issuer_info }}"
 
 - name: "Copy ClusterIssuer : {{ source_cluster_issuer_name }} : Copy ClusterIssuer's Secret"
-  # just copy the secret when there's a secret to be copied, if it's let's encrypt, no 'spec.ca,secretName' will be present
+  # just copy the secret when there's a secret to be copied, if its let's encrypt, no 'spec.ca,secretName' will be present
   when: cluster_issuer_info.resources[0].spec.ca.secretName is defined
   include_tasks: tasks/cert_manager_upgrade/copy_secret.yml
   vars:

--- a/ibm/mas_devops/roles/entitlement_key_rotation/tasks/rotate-clusters.yml
+++ b/ibm/mas_devops/roles/entitlement_key_rotation/tasks/rotate-clusters.yml
@@ -47,7 +47,7 @@
 
 - name: "Cluster {{ cluster_item }} - Rotate entitlement key in 'wiotp-docker-local' secret"
   include_tasks: rotate-wiotp-docker-local.yml
-  when: # we just rotate 'wiotp-docker-local' if it's openshift-marketplace namespace and artifactory credentials are defined
+  when: # we just rotate 'wiotp-docker-local' if its openshift-marketplace namespace and artifactory credentials are defined
     - artifactory_token is defined
     - artifactory_token != ''
     - artifactory_username is defined

--- a/ibm/mas_devops/roles/ibm_catalogs/tasks/install/development-catalog.yml
+++ b/ibm/mas_devops/roles/ibm_catalogs/tasks/install/development-catalog.yml
@@ -28,7 +28,7 @@
 # 2. Create the service accounts in openshift-marketplace so that it is able to pull from Artifactory
 # ---------------------------------------------------------------------------------------------------------------------
 # The default service account is used in OCP 4.6
-# In OCP 4.8+ each catalog source uses it's own ServiceAccount
+# In OCP 4.8+ each catalog source uses its own ServiceAccount
 - name: "Create service accounts on openshift-marketplace"
   vars:
     catalog_sa: "{{ item }}"

--- a/ibm/mas_devops/roles/ocp_deprovision/README.md
+++ b/ibm/mas_devops/roles/ocp_deprovision/README.md
@@ -61,7 +61,7 @@ Role Variables - IPI
 The following variables are only used when `cluster_type = ipi`.
 
 ### ipi_install_dir
-The directory that is used to store the `openshift-install` executable, it's configuration, & generated log files.
+The directory that is used to store the `openshift-install` executable, its configuration, & generated log files.
 
 - Optional when `cluster_type = aws-ipi`
 - Environment Variable: `IPI_DIR`

--- a/ibm/mas_devops/roles/ocp_disable_updates/README.md
+++ b/ibm/mas_devops/roles/ocp_disable_updates/README.md
@@ -1,7 +1,7 @@
 ocp_disable_updates
 ===================
 
-This role will disable automatic updates in the cluster.  It's use is not recommended.
+This role will disable automatic updates in the cluster.  Its use is not recommended.
 
 Example Playbook
 ----------------

--- a/ibm/mas_devops/roles/ocp_provision/README.md
+++ b/ibm/mas_devops/roles/ocp_provision/README.md
@@ -254,7 +254,7 @@ Location of the file containing your Redhat OpenShift pull secret.  This file ca
 - Default Value: None
 
 ### ipi_dir
-The working directory that is used to perform the installation, it will contain the `openshift-install` executable, it's configuration files, & any generated logs.
+The working directory that is used to perform the installation, it will contain the `openshift-install` executable, its configuration files, & any generated logs.
 
 - Optional when `cluster_type = ipi`
 - Environment Variable: `IPI_DIR`

--- a/ibm/mas_devops/roles/sls/tasks/install/install_digest_cm.yml
+++ b/ibm/mas_devops/roles/sls/tasks/install/install_digest_cm.yml
@@ -62,7 +62,7 @@
     - tsm_opcon.resources | length == 1
     - tsm_opcon.resources[0].metadata.name is defined
 
-# 6. If TSM is installed, install it's digest map
+# 6. If TSM is installed, install its digest map
 # -----------------------------------------------------------------------------
 - name: "Create ibm-truststore-mgr Image Digest Map"
   ansible.builtin.include_role:

--- a/ibm/mas_devops/roles/suite_app_install/tasks/install_digest_cm.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/install_digest_cm.yml
@@ -82,7 +82,7 @@
     tsm_operator_version: "{{ tsm_opcon.resources[0].metadata.name.split('.v')[1] }}"
 
 
-# 6. If TSM is installed, install it's digest map
+# 6. If TSM is installed, install its digest map
 # -----------------------------------------------------------------------------
 # Note that Visual Inspection does not use/need the IBM Truststore Manager
 - name: "Create ibm-truststore-mgr Image Digest Map"

--- a/ibm/mas_devops/roles/suite_install/tasks/install_digest_cm.yml
+++ b/ibm/mas_devops/roles/suite_install/tasks/install_digest_cm.yml
@@ -67,7 +67,7 @@
     tsm_operator_version: "{{ tsm_opcon.resources[0].metadata.name.split('.v')[1] }}"
 
 
-# 6. If TSM is installed, install it's digest map
+# 6. If TSM is installed, install its digest map
 # -----------------------------------------------------------------------------
 - name: "Create ibm-truststore-mgr Image Digest Map"
   when:

--- a/ibm/mas_devops/roles/uds/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/uds/tasks/install/main.yml
@@ -140,7 +140,7 @@
 
 # 11. MAS Config
 # -----------------------------------------------------------------------------
-# Note that the MAS config resource still refers to UDS by it's
+# Note that the MAS config resource still refers to UDS by its
 # original name (BAS).  It would be a breaking change to re-name the MAS CRD
 - name: "Create MAS BasCfg resource definition"
   include_tasks: tasks/install/udscfg.yml

--- a/ibm/mas_devops/roles/uds/tasks/install_suds/main.yml
+++ b/ibm/mas_devops/roles/uds/tasks/install_suds/main.yml
@@ -9,7 +9,7 @@
 # 2. Generate BASCfg for MAS
 # All we need to do is create the relevant config, the BASCfg entity manager will
 # install SUDS as a result.
-# Note that the MAS config resource still refers to UDS by it's
+# Note that the MAS config resource still refers to UDS by its
 # original name (BAS).
 # -----------------------------------------------------------------------------
 - name: "install_suds : Copy SUDS BASCfg to filesytem"

--- a/ibm/mas_devops/roles/uds/tasks/uninstall_suds/main.yml
+++ b/ibm/mas_devops/roles/uds/tasks/uninstall_suds/main.yml
@@ -9,7 +9,7 @@
 # 2. Update BASCfg for MAS
 # All we need to do is to set "suds: false" in the relevant config, the BASCfg entity
 # manager will uninstall SUDS as a result.
-# Note that the MAS config resource still refers to UDS by it's
+# Note that the MAS config resource still refers to UDS by its
 # original name (BAS).
 # -----------------------------------------------------------------------------
 - name: "uninstall_suds: Update BasCfg CR with SUDS - False"

--- a/ibm/mas_devops/roles/uds/templates/bascfg.yml.j2
+++ b/ibm/mas_devops/roles/uds/templates/bascfg.yml.j2
@@ -44,9 +44,11 @@ spec:
     - alias: part1
       crt: |
         {{ uds_tls_crt[0] | indent(8) }}
+{% if uds_tls_crt | length > 1 %}
     - alias: part2
       crt: |
         {{ uds_tls_crt[1] | indent(8) }}
+{% endif }
     - alias: part3
       crt: |
         -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
## Description
Adding the option to flexibly set UDS certs accordingly to the number of certs found in the secret that is passed as argument. Previously it always expected at least two but and was causing failures when 2 weren't found - now it will not break if a second cert is not found.

## Related Issues
- https://github.com/ibm-mas/ansible-devops/issues/721
- https://github.ibm.com/wiotp/tracker/issues/11722 [IBM Internal]

## Relevant internal slack thread
- https://ibm-watson-iot.slack.com/archives/C0LQ9CT38/p1679061674305049
