### PR TITLE
[minor] Add support for tuning OCP ingress

### DIFF
--- a/ibm/mas_devops/roles/ingress/README.md
+++ b/ibm/mas_devops/roles/ingress/README.md
@@ -1,0 +1,38 @@
+# ingress
+This role will tune the Ingress operator in the target OCP cluster.
+
+## Role Variables
+### ingress_client_timeout
+specifies how long a connection is held open while waiting for a client response
+
+- Optional
+- Environment Variable: `INGRESS_CLIENT_TIMEOUT`
+- Default Value: `30s`
+
+### ingress_server_timeout
+specifies how long a connection is held open while waiting for a server response
+
+- Optional
+- Environment Variable: `INGRESS_SERVER_TIMEOUT`
+- Default Value: `30s`
+
+## Example Playbook
+After installing the Ansible Collection you can include this role in your own custom playbooks.
+
+```yaml
+- hosts: localhost
+  roles:
+    - ibm.mas_devops.ingress
+```
+
+
+## Run Role Playbook
+After installing the Ansible Collection you can easily run the role standalone using the `run_role` playbook provided.
+
+```bash
+ROLE_NAME=ingress ansible-playbook ibm.mas_devops.run_role
+```
+
+
+## License
+EPL-2.0

--- a/ibm/mas_devops/roles/ingress/defaults/main.yml
+++ b/ibm/mas_devops/roles/ingress/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+ingress_client_timeout: "{{ lookup('env', 'INGRESS_CLIENT_TIMEOUT') | default('30s', true) }}"
+ingress_server_timeout: "{{ lookup('env', 'INGRESS_SERVER_TIMEOUT') | default('30s', true) }}"
+

--- a/ibm/mas_devops/roles/ingress/meta/main.yml
+++ b/ibm/mas_devops/roles/ingress/meta/main.yml
@@ -1,0 +1,22 @@
+galaxy_info:
+  author: Eric Klingelberger (@cuddlyporcupine)
+  description: Tune the Ingress operator in the target OCP cluster.
+  company: IBM
+
+  license: EPL-2.0
+
+  min_ansible_version: 2.10
+
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+
+  galaxy_tags:
+    - ibm
+    - mas
+    - devops
+    - rhocp
+
+dependencies:
+  - role: ibm.mas_devops.ansible_version_check

--- a/ibm/mas_devops/roles/ingress/tasks/main.yml
+++ b/ibm/mas_devops/roles/ingress/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+
+# 1.0 Apply ingress operator tuning parameters
+- name: "Apply ingress operator tuning parameters"
+  kubernetes.core.k8s:
+    merge_type: merge
+    template: templates/ingress.yml.j2

--- a/ibm/mas_devops/roles/ingress/templates/ingress.yml.j2
+++ b/ibm/mas_devops/roles/ingress/templates/ingress.yml.j2
@@ -1,0 +1,10 @@
+---
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+spec:
+  tuningOptions:
+    clientTimeout: "{{ ingress_client_timeout }}"
+    serverTimeout: "{{ ingress_server_timeout }}"


### PR DESCRIPTION
Add support for tuning the following OCP ingress parameters
- clientTimeout
- serverTimeout