### PR TITLE
[minor] Add support for tuning OCP Ingress

### DIFF
--- a/build/bin/copy-role-docs.sh
+++ b/build/bin/copy-role-docs.sh
@@ -54,6 +54,7 @@ copyDoc ocp_contentsourcepolicy
 copyDoc ocp_deprovision
 copyDoc ocp_disable_updates
 copyDoc ocp_github_oauth
+copyDoc ocp_ingress
 copyDoc ocp_login
 copyDoc ocp_provision
 copyDoc ocp_roks_upgrade_registry_storage

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,6 +1,7 @@
 ## Changes
 Note that links to pull requests prior to public release of the code (4.0) direct to IBM GitHub Enterprise, and will only be accessible to IBM employees.
 
+- `13.7` Add support for OCP Ingress tuning ([#796](https://github.com/ibm-mas/ansible-devops/pull/796))
 - `13.6` Update mongodb to 4.4.21 and mongo operator to 0.7.9 ([#790](https://github.com/ibm-mas/ansible-devops/pull/790))
 - `13.5` Allow db2_dbname to be set rather then hardcode to BLUDB ([#784](https://github.com/ibm-mas/ansible-devops/pull/784))
 - `13.4` Add ability to control whether to create Manage JMS topics in Event Streams ([#783](https://github.com/ibm-mas/ansible-devops/pull/783))

--- a/ibm/mas_devops/README.md
+++ b/ibm/mas_devops/README.md
@@ -6,6 +6,7 @@
 ## Change Log
 Note that links to pull requests prior to public release of the code (4.0) direct to IBM GitHub Enterprise, and will only be accessible to IBM employees.
 
+- `13.7` Add support for OCP Ingress tuning ([#796](https://github.com/ibm-mas/ansible-devops/pull/796))
 - `13.6` Update mongodb to 4.4.21 and mongo operator to 0.7.9 ([#790](https://github.com/ibm-mas/ansible-devops/pull/790))
 - `13.5` Allow db2_dbname to be set rather then hardcode to BLUDB ([#784](https://github.com/ibm-mas/ansible-devops/pull/784))
 - `13.4` Add ability to control whether to create Manage JMS topics in Event Streams ([#783](https://github.com/ibm-mas/ansible-devops/pull/783))

--- a/ibm/mas_devops/roles/ocp_ingress/README.md
+++ b/ibm/mas_devops/roles/ocp_ingress/README.md
@@ -1,0 +1,38 @@
+# ocp_ingress
+This role will tune the Ingress operator in the target OCP cluster. The following Ingress tuning parameters can be modified to avoid request failures due to timeout for long running requests.
+
+## Role Variables
+### ocp_ingress_client_timeout
+Specifies how long a connection is held open while waiting for a client response
+
+- Optional
+- Environment Variable: `OCP_INGRESS_CLIENT_TIMEOUT`
+- Default Value: `30s`
+
+### ocp_ingress_server_timeout
+Specifies how long a connection is held open while waiting for a server response
+
+- Optional
+- Environment Variable: `OCP_INGRESS_SERVER_TIMEOUT`
+- Default Value: `30s`
+
+## Example Playbook
+After installing the Ansible Collection you can include this role in your own custom playbooks.
+
+```yaml
+- hosts: localhost
+  roles:
+    - ibm.mas_devops.ocp_ingress
+```
+
+
+## Run Role Playbook
+After installing the Ansible Collection you can easily run the role standalone using the `run_role` playbook provided.
+
+```bash
+ROLE_NAME=ocp_ingress ansible-playbook ibm.mas_devops.run_role
+```
+
+
+## License
+EPL-2.0

--- a/ibm/mas_devops/roles/ocp_ingress/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_ingress/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+ocp_ingress_client_timeout: "{{ lookup('env', 'OCP_INGRESS_CLIENT_TIMEOUT') | default('30s', true) }}"
+ocp_ingress_server_timeout: "{{ lookup('env', 'OCP_INGRESS_SERVER_TIMEOUT') | default('30s', true) }}"
+

--- a/ibm/mas_devops/roles/ocp_ingress/meta/main.yml
+++ b/ibm/mas_devops/roles/ocp_ingress/meta/main.yml
@@ -1,0 +1,22 @@
+galaxy_info:
+  author: Eric Klingelberger (@cuddlyporcupine)
+  description: Tune the Ingress operator in the target OCP cluster.
+  company: IBM
+
+  license: EPL-2.0
+
+  min_ansible_version: 2.10
+
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+
+  galaxy_tags:
+    - ibm
+    - mas
+    - devops
+    - rhocp
+
+dependencies:
+  - role: ibm.mas_devops.ansible_version_check

--- a/ibm/mas_devops/roles/ocp_ingress/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_ingress/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+
+# 1.0 Apply ingress operator tuning parameters
+- name: "Apply ingress operator tuning parameters"
+  kubernetes.core.k8s:
+    merge_type: merge
+    template: templates/ingress.yml.j2

--- a/ibm/mas_devops/roles/ocp_ingress/templates/ingress.yml.j2
+++ b/ibm/mas_devops/roles/ocp_ingress/templates/ingress.yml.j2
@@ -1,0 +1,10 @@
+---
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+spec:
+  tuningOptions:
+    clientTimeout: "{{ ocp_ingress_client_timeout }}"
+    serverTimeout: "{{ ocp_ingress_server_timeout }}"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
       - "ocp_deprovision": roles/ocp_deprovision.md
       - "ocp_disable_updates": roles/ocp_disable_updates.md
       - "ocp_github_oauth": roles/ocp_github_oauth.md
+      - "ocp_ingress": roles/ocp_ingress.md
       - "ocp_login": roles/ocp_login.md
       - "ocp_provision": roles/ocp_provision.md
       - "ocp_roks_upgrade_registry_storage": roles/ocp_roks_upgrade_registry_storage.md


### PR DESCRIPTION
Add a new role to support tuning the following OCP ingress parameters. This role will tune the Ingress operator in the target OCP cluster. The following Ingress tuning parameters can be modified to avoid request failures due to timeout for long running requests.

- clientTimeout
- serverTimeout
