### PR TITLE
[patch] Change to use rosa cmd with --replicas

### DIFF
--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/rosa.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/rosa.yml
@@ -67,7 +67,7 @@
     rosa create cluster \
       --cluster-name {{ cluster_name }} \
       --version {{ ocp_version }} \
-      --compute-nodes {{ rosa_compute_nodes }} \
+      --replicas {{ rosa_compute_nodes }} \
       --sts \
       --mode auto \
       --yes


### PR DESCRIPTION
Resolves https://github.com/ibm-mas/ansible-devops/issues/788

The rosa cli deprecated the use of `--compute-nodes` last year and have now removed the option completely in the lastest rosa cli version (1.2.21). The replacement is to use `--replicas` which has the same meaning/fiunction just with a different name.

![image](https://github.com/ibm-mas/ansible-devops/assets/6817894/011c0b1a-60f8-49eb-950b-1649cc7a0587)
