### PR TITLE
[patch] Fix use of mongosh in aws_documentdb_user and mongodb roles

### DIFF
--- a/ibm/mas_devops/roles/aws_documentdb_user/tasks/main.yml
+++ b/ibm/mas_devops/roles/aws_documentdb_user/tasks/main.yml
@@ -9,7 +9,20 @@
     - "MAS Instance ID ............................... {{ mas_instance_id }}"
     - "DocumentDB instance credential name ........... {{ docdb_instance_credentials_secret_name }}"
 
-# 1. create docdb user for MAS instance
+# 1. Check for required software
+# -----------------------------------------------------------------------------
+- name: "Test if mongosh is installed"
+  shell: mongosh version
+  register: mongosh_version
+  ignore_errors: true
+
+- name: "Fail if mongosh is not installed"
+  assert:
+    that: ( mongosh_version.rc == 0 )
+    fail_msg: "mongosh must be installed (https://www.mongodb.com/docs/mongodb-shell/install/)"
+
+
+# 2. create docdb user for MAS instance
 # -----------------------------------------------------------------------------
 - name: set fact for document DB host, port and user name
   # get both from env var
@@ -33,10 +46,10 @@
 
 - name: Create docdb user for MAS instance
   shell: |
-    mongo --ssl --host {{ docdb_host }}:{{ docdb_port }} --sslCAFile /tmp/rds-combined-ca-bundle.pem --username {{ docdb_master_username }}  --password {{ docdb_master_password }} /tmp/create_user.js
+    mongosh --ssl --host {{ docdb_host }}:{{ docdb_port }} --sslCAFile /tmp/rds-combined-ca-bundle.pem --username {{ docdb_master_username }}  --password {{ docdb_master_password }} /tmp/create_user.js
   register: creating_user_output
 
-# 2. Save docdb user credentials into k8s Secret
+# 3. Save docdb user credentials into k8s Secret
 # -----------------------------------------------------------------------------
 - name: Create k8s Secret for docdb user credentials
   ansible.builtin.template:

--- a/ibm/mas_devops/roles/aws_documentdb_user/tasks/main.yml
+++ b/ibm/mas_devops/roles/aws_documentdb_user/tasks/main.yml
@@ -12,7 +12,7 @@
 # 1. Check for required software
 # -----------------------------------------------------------------------------
 - name: "Test if mongosh is installed"
-  shell: mongosh version
+  shell: mongosh --version
   register: mongosh_version
   ignore_errors: true
 
@@ -46,7 +46,7 @@
 
 - name: Create docdb user for MAS instance
   shell: |
-    mongosh --ssl --host {{ docdb_host }}:{{ docdb_port }} --sslCAFile /tmp/rds-combined-ca-bundle.pem --username {{ docdb_master_username }}  --password {{ docdb_master_password }} /tmp/create_user.js
+    mongosh --tls --host {{ docdb_host }}:{{ docdb_port }} --tlsCAFile /tmp/rds-combined-ca-bundle.pem --username {{ docdb_master_username }}  --password {{ docdb_master_password }} /tmp/create_user.js
   register: creating_user_output
 
 # 3. Save docdb user credentials into k8s Secret

--- a/ibm/mas_devops/roles/mongodb/README.md
+++ b/ibm/mas_devops/roles/mongodb/README.md
@@ -18,6 +18,9 @@ If selected provider is `community` [MongoDb CE operator](https://github.com/mon
 To run this role with providers as `ibm` or `aws` you must have already installed the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
 Also, you need to have AWS user credentials configured via `aws configure` command or simply export `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables with your corresponding AWS username credentials prior running this role when provider is either `ibm` or `aws`.
 
+To run the `docdb_secret_rotate` MONGODB_ACTION when the provider is `aws` you must have already installed the [Mongo Shell](https://www.mongodb.com/docs/mongodb-shell/install/).
+
+
 Common Role Variables for all providers 
 ----------------------------------------
 ### mas_instance_id

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/aws/docdb_secret_rotate.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/aws/docdb_secret_rotate.yml
@@ -34,7 +34,21 @@
       - "DocumentDB Port ........................ {{ docdb_port }}"
       - "DocumentDB Instance Username ........... {{ docdb_instance_username }}"
 
-# 2. Get the secret of documentdb from vault
+
+# 2. Check for required software
+# -----------------------------------------------------------------------------
+- name: "Test if mongosh is installed"
+  shell: mongosh version
+  register: mongosh_version
+  ignore_errors: true
+
+- name: "Fail if mongosh is not installed"
+  assert:
+    that: ( mongosh_version.rc == 0 )
+    fail_msg: "mongosh must be installed (https://www.mongodb.com/docs/mongodb-shell/install/)"
+
+
+# 3. Get the secret of documentdb from vault
 # -----------------------------------------------------------------------------
 - name: "Download Amazon DocumentDB Certificate Authority (CA) certificate"
   shell: |
@@ -43,7 +57,7 @@
 - name: "check if user already exists"
   ignore_errors: true
   shell: |
-    mongo --ssl --host {{ docdb_host }}:{{ docdb_port }} --sslCAFile /tmp/rds-combined-ca-bundle.pem --username {{ docdb_instance_username }}  --password {{ docdb_instance_password_old }}
+    mongosh --ssl --host {{ docdb_host }}:{{ docdb_port }} --sslCAFile /tmp/rds-combined-ca-bundle.pem --username {{ docdb_instance_username }}  --password {{ docdb_instance_password_old }}
   register: check_docdb_user
 
 - name: "Fail if docdb user does not exists"
@@ -65,20 +79,20 @@
 
 - name: Change docdb user password for MAS instance
   shell: |
-    mongo --ssl --host {{ docdb_host }}:{{ docdb_port }} --sslCAFile /tmp/rds-combined-ca-bundle.pem --username {{ docdb_master_username }}  --password {{ docdb_master_password }} /tmp/change_password.js
+    mongosh --ssl --host {{ docdb_host }}:{{ docdb_port }} --sslCAFile /tmp/rds-combined-ca-bundle.pem --username {{ docdb_master_username }}  --password {{ docdb_master_password }} /tmp/change_password.js
   register: change_password_output
 
 # 5. Test that the newly created user can connect to docdb
 # -----------------------------------------------------------------------------
 - name: "Test that the newly created user can connect to docdb"
   shell: |
-    mongo --ssl --host {{ docdb_host }}:{{ docdb_port }} --sslCAFile /tmp/rds-combined-ca-bundle.pem --username {{ docdb_instance_username }}  --password {{ docdb_final_instance_password }}
+    mongosh --ssl --host {{ docdb_host }}:{{ docdb_port }} --sslCAFile /tmp/rds-combined-ca-bundle.pem --username {{ docdb_instance_username }}  --password {{ docdb_final_instance_password }}
   register: docdb_connect_result
   retries: 6
   delay: 20
   until: docdb_connect_result.rc == 0
 
-# 7. Update new password to Cluster Secret
+# 6. Update new password to Cluster Secret
 # -----------------------------------------------------------------------------
 - name: update k8s Secret for docdb user credentials
   no_log: false
@@ -90,7 +104,7 @@
     - docdb_connect_result.rc is defined
     - docdb_connect_result.rc == 0
 
-# 8. Restart the pod entitymgr-coreidp
+# 7. Restart the pod entitymgr-coreidp
 # -----------------------------------------------------------------------------
 - name: "Lookup entitymgr-coreidp pods"
   kubernetes.core.k8s_info:

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/aws/docdb_secret_rotate.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/aws/docdb_secret_rotate.yml
@@ -38,7 +38,7 @@
 # 2. Check for required software
 # -----------------------------------------------------------------------------
 - name: "Test if mongosh is installed"
-  shell: mongosh version
+  shell: mongosh --version
   register: mongosh_version
   ignore_errors: true
 
@@ -57,7 +57,7 @@
 - name: "check if user already exists"
   ignore_errors: true
   shell: |
-    mongosh --ssl --host {{ docdb_host }}:{{ docdb_port }} --sslCAFile /tmp/rds-combined-ca-bundle.pem --username {{ docdb_instance_username }}  --password {{ docdb_instance_password_old }}
+    mongosh --tls --host {{ docdb_host }}:{{ docdb_port }} --tlsCAFile /tmp/rds-combined-ca-bundle.pem --username {{ docdb_instance_username }}  --password {{ docdb_instance_password_old }}
   register: check_docdb_user
 
 - name: "Fail if docdb user does not exists"
@@ -79,14 +79,14 @@
 
 - name: Change docdb user password for MAS instance
   shell: |
-    mongosh --ssl --host {{ docdb_host }}:{{ docdb_port }} --sslCAFile /tmp/rds-combined-ca-bundle.pem --username {{ docdb_master_username }}  --password {{ docdb_master_password }} /tmp/change_password.js
+    mongosh --tls --host {{ docdb_host }}:{{ docdb_port }} --tlsCAFile /tmp/rds-combined-ca-bundle.pem --username {{ docdb_master_username }}  --password {{ docdb_master_password }} /tmp/change_password.js
   register: change_password_output
 
 # 5. Test that the newly created user can connect to docdb
 # -----------------------------------------------------------------------------
 - name: "Test that the newly created user can connect to docdb"
   shell: |
-    mongosh --ssl --host {{ docdb_host }}:{{ docdb_port }} --sslCAFile /tmp/rds-combined-ca-bundle.pem --username {{ docdb_instance_username }}  --password {{ docdb_final_instance_password }}
+    mongosh --tls --host {{ docdb_host }}:{{ docdb_port }} --tlsCAFile /tmp/rds-combined-ca-bundle.pem --username {{ docdb_instance_username }}  --password {{ docdb_final_instance_password }}
   register: docdb_connect_result
   retries: 6
   delay: 20


### PR DESCRIPTION
Resolves issue https://github.com/ibm-mas/ansible-devops/issues/787

The role aws_documentdb_user states that the mongosh cli should be installed but then doesn't use it. Instead it just used a `mongo` command rather than the expected `mongosh`. Also found the same issue in the mongodb role when it calls the `docdb_secret_rotate` action. I then found that this `docdb_secret_rotate` was spelt wrong so would never work anyway. Updated readme to say mongosh needs to be installed if using mongodb_action `docdb_secret_rotate`. Added check for `mongosh` is installed.

Lastly replaced the deprecated `--ssl` and `--sslCAFile` options with the `tls` replacements.