### PR TITLE
[patch] fix FIPS fyre cluster provision failure on Travis

### DIFF
--- a/ibm/mas_devops/playbooks/ocp_fyre_provision.yml
+++ b/ibm/mas_devops/playbooks/ocp_fyre_provision.yml
@@ -4,7 +4,7 @@
     cluster_type: fyre
     ocp_version: "{{ lookup('env', 'OCP_VERSION') | default('4.10', True) }}"
     ocp_fips_enabled: "{{ lookup('env', 'OCP_FIPS_ENABLED') | default('false', true) | bool }}"
-    
+
   pre_tasks:
     # For the full set of supported environment variables refer to the playbook documentation
     - name: Check for required environment variables

--- a/ibm/mas_devops/playbooks/ocp_fyre_provision.yml
+++ b/ibm/mas_devops/playbooks/ocp_fyre_provision.yml
@@ -3,7 +3,8 @@
   vars:
     cluster_type: fyre
     ocp_version: "{{ lookup('env', 'OCP_VERSION') | default('4.10', True) }}"
-
+    ocp_fips_enabled: "{{ lookup('env', 'OCP_FIPS_ENABLED') | default('false', true) | bool }}"
+    
   pre_tasks:
     # For the full set of supported environment variables refer to the playbook documentation
     - name: Check for required environment variables

--- a/ibm/mas_devops/roles/ocp_login/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_login/tasks/main.yml
@@ -6,6 +6,10 @@
     that: (cluster_type is defined and cluster_type != "" and cluster_name is defined and cluster_name != "") or (ocp_token is defined and ocp_token != "" and  ocp_server is defined and ocp_server != "")
     fail_msg: "cluster_type & cluster_name, or ocp_token and ocp_server properties must be provided"
 
+- name: "Backwards compatability for 'quickburn' cluster type"
+  when: cluster_type == "quickburn"
+  set_fact:
+    cluster_type: "fyre"
 
 # 2. Provide debug info
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/fyre.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/fyre.yml
@@ -29,7 +29,7 @@
       - "Username ..................... {{ fyre_username }}"
       - "Fyre product ID .............. {{ fyre_product_id }}"
       - "Fyre Quota Type .............. {{ fyre_quota_type }}"
-      - "fips enabled ................. {{ ocp_fips_enabled }}"
+      - "FIPS enabled ................. {{ ocp_fips_enabled }}"
       # Quickburn specific
       - "Fyre cluster size ............ {{ fyre_cluster_size | default('<undefined>', true) }}"
       # Product Group specific


### PR DESCRIPTION
There are two fixes in this PR:

**1. OCP_FIPS_ENABLEDenv variable not taken issue:**

The `OCP_FIPS_ENABLED` environment variable was not taken when run ibm.mas_devops.ocp_fyre_provision playbook on Travis. We need to set the variable in playbook to pass the value to role. 

For example,  https://travis.ibm.com/maximoappsuite/fvt-personal/jobs/90018134
We set the OCP_FIPS_ENABLED  env variable on line 200 and on line 460 (in Provision stage), but it always shows "fips enabled ................. False" on line 554. 

Variable ocp_fips_enabled should get from env https://github.com/ibm-mas/ansible-devops/blob/83077845ca226b6885516699741d319aa9240d8f/ibm/mas_devops/roles/ocp_provision/defaults/main.yml#L9
but it shows different at https://github.com/ibm-mas/ansible-devops/blob/83077845ca226b6885516699741d319aa9240d8f/ibm/mas_devops/roles/ocp_provision/tasks/providers/fyre.yml#L32

The issue can be resolved by adding the variable in playbook. 


**2. quickburn login issue:**

ocp_login looks for `login-quickburn.yml` but should go `login-fyre.yml`, so set cluster_type to fypr when it is quickburn

```
TASK [ibm.mas_devops.ocp_login : include_tasks] ********************************

Wednesday 10 May 2023  10:30:04 +0000 (0:00:00.114)       0:00:02.330 ********* 

fatal: [localhost]: FAILED! => {"reason": "Could not find or access '/home/travis/.ansible/collections/ansible_collections/ibm/mas_devops/playbooks/tasks/login-quickburn.yml' on the Ansible Controller."}
```