### PR TITLE
[patch] Fix for Data Dictionary Image map creation

### DIFF
--- a/ibm/mas_devops/roles/suite_app_install/tasks/install_digest_cm.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/install_digest_cm.yml
@@ -47,7 +47,15 @@
     case_name: "ibm-mas-{{ mas_app_id }}"
     case_version: "{{ mas_app_operator_version }}"
 
-# 4. Lookup the OperatorCondition for Truststore Manager
+
+# 4. Create Data Dictionary Image Digest Map if installing Monitor (special case)
+# ---------------------------------------------------------------------------------
+- name: "Create ibm-data-dictionary Image Digest Map"
+  when: mas_app_id == "monitor"
+  include_tasks: "tasks/{{ mas_app_id }}.yml"
+
+
+# 5. Lookup the OperatorCondition for Truststore Manager
 # -----------------------------------------------------------------------------
 # Note that Visual Inspection does not use/need the IBM Truststore Manager
 - name: "Lookup Truststore Manager operator version"
@@ -70,7 +78,7 @@
     - tsm_opcon.resources[0].metadata.name is defined
 
 
-# 5. If TSM is installed, determine at which version
+# 6. If TSM is installed, determine at which version
 # -----------------------------------------------------------------------------
 # Note that Visual Inspection does not use/need the IBM Truststore Manager
 - name: "Lookup Truststore Manager operator version"
@@ -82,7 +90,7 @@
     tsm_operator_version: "{{ tsm_opcon.resources[0].metadata.name.split('.v')[1] }}"
 
 
-# 6. If TSM is installed, install its digest map
+# 7. If TSM is installed, install its digest map
 # -----------------------------------------------------------------------------
 # Note that Visual Inspection does not use/need the IBM Truststore Manager
 - name: "Create ibm-truststore-mgr Image Digest Map"

--- a/ibm/mas_devops/roles/suite_app_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/main.yml
@@ -164,13 +164,7 @@
     - app_cr_result.resources | json_query('[*].status.conditions[?type==`Ready`][].status') | select ('match','True') | list | length == 1
 
 
-# 10. Create Data Dictionary Image Digest Map for Monitor (special case work around)
-# ---------------------------------------------------------------------------------
-- name: "Create ibm-data-dictionary Image Digest Map"
-  when: mas_app_id == "monitor" and airgap_install
-  include_tasks: "tasks/{{ mas_app_id }}.yml"
-
-# 11. Apply final security context constraints
+# 10. Apply final security context constraints
 # -----------------------------------------------------------------------------
 - name: "Apply final security context constraints"
   when: mas_app_id == "visualinspection"

--- a/ibm/mas_devops/roles/suite_app_install/tasks/monitor.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/monitor.yml
@@ -1,42 +1,43 @@
 ---
 
-# 1. Determine the version of the application operator that is running
+# 1. Lookup Suite Cr to get override version of Data Dictionary
 # -----------------------------------------------------------------------------
-- name: "Lookup Application operator version"
+- name: "Lookup Suite Cr to get override version"
   kubernetes.core.k8s_info:
-    api_version: operators.coreos.com/v2
-    kind: OperatorCondition
-    namespace: "mas-{{ mas_instance_id }}-add"
-    label_selectors:
-      - "operators.coreos.com/ibm-data-dictionary.mas-{{ mas_instance_id }}-add"
-  register: app_opcon
-  retries: 10
-  delay: 1 # minutes
-  until:
-    - app_opcon.resources is defined
-    - app_opcon.resources | length == 1
-    - app_opcon.resources[0].metadata.name is defined
+    api_version: core.mas.ibm.com/v1
+    kind: Suite
+    namespace: "mas-{{ mas_instance_id }}-core"
+  register: suite_lookup
 
-
-# 2. Set the application operator version
-# -----------------------------------------------------------------------------
-# OperatorCondition names are in the format {packageName}.{packageVersion}
-# We want to strip off the "v" prefix from the version while we do this
-- name: "Lookup operator version"
+- name: "Get the channel of Data Dictionary from the Suite lookup"
   set_fact:
-    mas_app_operator_version: "{{ app_opcon.resources[0].metadata.name.split('.v')[1] }}"
+    dd_channel: "{{ suite_lookup.resources[0].staus.settings.dataDictionary.channel }}"
+
+# 2. Lookup package manifest to get version for the Data Dictionary channel
+# -----------------------------------------------------------------------------
+- name: Lookup datadictionary packagemanifest
+  kubernetes.core.k8s_info:
+    api_version: packages.operators.coreos.com/v1
+    kind: PackageManifest
+    name: ibm-data-dictionary
+    namespace: openshift-marketplace
+  register: dd_manifest_info
+
+- name: "Lookup version of Data Dictionary using the channel"
+  set_fact:
+    dd_version: "{{ dd_manifest_info.resources[0].staus.channels | selectattr('name', 'equalto', dd_channel) | map(attribute='version') }}"
 
 - name: Debug
   debug:
     msg:
-      - "Application operator condition ......... {{ app_opcon.resources[0].metadata.name }}"
-      - "Application operator version ........... {{ mas_app_operator_version }}"
+      - "Data Dictionary Channel ........... {{ dd_channel }}"
+      - "Data Dictionary Version ........... {{ dd_version }}"
 
 
 # 3. Create the Image Digest Map for Data Dictionary v1.1.3
 # -----------------------------------------------------------------------------
 - name: "Create ibm-data-dictionary Image Digest Map"
-  when: mas_app_operator_version is version('1.1.3', '>=')
+  when: mas_app_operator_version is version('1.1.3', '==')
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   vars:

--- a/ibm/mas_devops/roles/suite_app_install/tasks/monitor.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/monitor.yml
@@ -26,7 +26,7 @@
 
 - name: "Lookup version of Data Dictionary using the channel"
   set_fact:
-    dd_version: "{{ dd_manifest_info.resources[0].status.channels | selectattr('name', 'equalto', dd_channel) | map(attribute='version') }}"
+    dd_version: "{{ dd_manifest_info.resources[0].status.channels | selectattr('name', 'equalto', dd_channel) | map(attribute='currentCSVDesc') | map(attribute='version') }}"
 
 - name: Debug
   debug:

--- a/ibm/mas_devops/roles/suite_app_install/tasks/monitor.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/monitor.yml
@@ -26,7 +26,7 @@
 
 - name: "Lookup version of Data Dictionary using the channel"
   set_fact:
-    dd_version: "{{ dd_manifest_info.resources[0].status.channels | selectattr('name', 'equalto', dd_channel) | map(attribute='currentCSVDesc') | map(attribute='version') }}"
+    dd_version: "{{ dd_manifest_info.resources[0].status.channels | selectattr('name', 'equalto', dd_channel) | map(attribute='currentCSVDesc') | jq -r '.version' }}"
 
 - name: Debug
   debug:
@@ -38,17 +38,17 @@
 # 3. Create the Image Digest Map for Data Dictionary v1.1.3
 # -----------------------------------------------------------------------------
 - name: "Create data-dictionary namespace"
-  when: mas_app_operator_version[0] is version('1.1.3', '==')
+  when: mas_app_operator_version is version('1.1.3', '==')
   kubernetes.core.k8s:
     api_version: v1
     kind: Namespace
     name: 'mas-{{ mas_instance_id }}-add'
 
 - name: "Create ibm-data-dictionary Image Digest Map"
-  when: mas_app_operator_version[0] is version('1.1.3', '==')
+  when: mas_app_operator_version is version('1.1.3', '==')
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   vars:
     digest_image_map_namespace: "mas-{{ mas_instance_id }}-add"
     case_name: "ibm-data-dictionary"
-    case_version: "{{ dd_version[0] }}"
+    case_version: "{{ dd_version }}"

--- a/ibm/mas_devops/roles/suite_app_install/tasks/monitor.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/monitor.yml
@@ -26,7 +26,7 @@
 
 - name: "Lookup version of Data Dictionary using the channel"
   set_fact:
-    dd_version: "{{ dd_manifest_info.resources[0].status.channels | selectattr('name', 'equalto', dd_channel) | map(attribute='currentCSVDesc') | jq -r '.version' }}"
+    dd_version: "{{ dd_manifest_info.resources[0].status.channels | selectattr('name', 'equalto', dd_channel) | map(attribute='currentCSVDesc') | map(attribute='version') | first }}"
 
 - name: Debug
   debug:

--- a/ibm/mas_devops/roles/suite_app_install/tasks/monitor.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/monitor.yml
@@ -38,14 +38,14 @@
 # 3. Create the Image Digest Map for Data Dictionary v1.1.3
 # -----------------------------------------------------------------------------
 - name: "Create data-dictionary namespace"
-  when: mas_app_operator_version is version('1.1.3', '==')
+  when: dd_version is version('1.1.3', '==')
   kubernetes.core.k8s:
     api_version: v1
     kind: Namespace
     name: 'mas-{{ mas_instance_id }}-add'
 
 - name: "Create ibm-data-dictionary Image Digest Map"
-  when: mas_app_operator_version is version('1.1.3', '==')
+  when: dd_version is version('1.1.3', '==')
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   vars:

--- a/ibm/mas_devops/roles/suite_app_install/tasks/monitor.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/monitor.yml
@@ -11,7 +11,8 @@
 
 - name: "Get the channel of Data Dictionary from the Suite lookup"
   set_fact:
-    dd_channel: "{{ suite_lookup.resources[0].staus.settings.dataDictionary.channel }}"
+    dd_channel: "{{ suite_lookup.resources[0].status.settings.dataDictionary.channel }}"
+
 
 # 2. Lookup package manifest to get version for the Data Dictionary channel
 # -----------------------------------------------------------------------------
@@ -36,6 +37,12 @@
 
 # 3. Create the Image Digest Map for Data Dictionary v1.1.3
 # -----------------------------------------------------------------------------
+- name: "Create data-dictionary namespace"
+  kubernetes.core.k8s:
+    api_version: v1
+    kind: Namespace
+    name: 'mas-{{ mas_instance_id }}-add'
+
 - name: "Create ibm-data-dictionary Image Digest Map"
   when: mas_app_operator_version is version('1.1.3', '==')
   include_role:

--- a/ibm/mas_devops/roles/suite_app_install/tasks/monitor.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/monitor.yml
@@ -26,7 +26,7 @@
 
 - name: "Lookup version of Data Dictionary using the channel"
   set_fact:
-    dd_version: "{{ dd_manifest_info.resources[0].status.channels | selectattr('name', 'equalto', dd_channel) | map(attribute='currentCSVDesc') | map(attribute='version')[0] }}"
+    dd_version: "{{ dd_manifest_info.resources[0].status.channels | selectattr('name', 'equalto', dd_channel) | map(attribute='currentCSVDesc') | map(attribute='version') }}"
 
 - name: Debug
   debug:
@@ -38,17 +38,17 @@
 # 3. Create the Image Digest Map for Data Dictionary v1.1.3
 # -----------------------------------------------------------------------------
 - name: "Create data-dictionary namespace"
-  when: mas_app_operator_version is version('1.1.3', '==')
+  when: mas_app_operator_version[0] is version('1.1.3', '==')
   kubernetes.core.k8s:
     api_version: v1
     kind: Namespace
     name: 'mas-{{ mas_instance_id }}-add'
 
 - name: "Create ibm-data-dictionary Image Digest Map"
-  when: mas_app_operator_version is version('1.1.3', '==')
+  when: mas_app_operator_version[0] is version('1.1.3', '==')
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   vars:
     digest_image_map_namespace: "mas-{{ mas_instance_id }}-add"
     case_name: "ibm-data-dictionary"
-    case_version: "{{ dd_version }}"
+    case_version: "{{ dd_version[0] }}"

--- a/ibm/mas_devops/roles/suite_app_install/tasks/monitor.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/monitor.yml
@@ -26,7 +26,7 @@
 
 - name: "Lookup version of Data Dictionary using the channel"
   set_fact:
-    dd_version: "{{ dd_manifest_info.resources[0].staus.channels | selectattr('name', 'equalto', dd_channel) | map(attribute='version') }}"
+    dd_version: "{{ dd_manifest_info.resources[0].status.channels | selectattr('name', 'equalto', dd_channel) | map(attribute='version') }}"
 
 - name: Debug
   debug:

--- a/ibm/mas_devops/roles/suite_app_install/tasks/monitor.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/monitor.yml
@@ -38,6 +38,7 @@
 # 3. Create the Image Digest Map for Data Dictionary v1.1.3
 # -----------------------------------------------------------------------------
 - name: "Create data-dictionary namespace"
+  when: mas_app_operator_version is version('1.1.3', '==')
   kubernetes.core.k8s:
     api_version: v1
     kind: Namespace
@@ -50,4 +51,4 @@
   vars:
     digest_image_map_namespace: "mas-{{ mas_instance_id }}-add"
     case_name: "ibm-data-dictionary"
-    case_version: "{{ mas_app_operator_version }}"
+    case_version: "{{ dd_version }}"

--- a/ibm/mas_devops/roles/suite_app_install/tasks/monitor.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/monitor.yml
@@ -26,7 +26,7 @@
 
 - name: "Lookup version of Data Dictionary using the channel"
   set_fact:
-    dd_version: "{{ dd_manifest_info.resources[0].status.channels | selectattr('name', 'equalto', dd_channel) | map(attribute='currentCSVDesc') | map(attribute='version') }}"
+    dd_version: "{{ dd_manifest_info.resources[0].status.channels | selectattr('name', 'equalto', dd_channel) | map(attribute='currentCSVDesc') | map(attribute='version')[0] }}"
 
 - name: Debug
   debug:


### PR DESCRIPTION
Before, the image map for Data Dictionary was created after Monitor app was installed. This change is to create the Data Dictionary image map before the monitor image map and also do this for version 1.1.3 only. 
We also need to increase the CPU for the clusters since the number of apps we are installing are increasing adding visual inspection to the equation.