### PR TITLE
[patch] Fix OT subscription template name

### DIFF
--- a/ibm/mas_devops/roles/cluster_monitoring/tasks/install/opentelemetry.yml
+++ b/ibm/mas_devops/roles/cluster_monitoring/tasks/install/opentelemetry.yml
@@ -2,14 +2,9 @@
 
 # 1. Install OpenTelemetry Operator
 # -------------------------------------------------------------------------------------
-- name: "install: opentelemetry: Apply OpenTelemetry operatorgroup"
-  kubernetes.core.k8s:
-    apply: yes
-    definition: "{{ lookup('template', 'templates/operator-group.yaml') }}"
-
 - name: "install: opentelemetry: Create OpenTelemetry Operator Subscription"
   kubernetes.core.k8s:
-    definition: "{{ lookup('template', 'templates/subscription.yaml') }}"
+    definition: "{{ lookup('template', 'templates/opentelemetry-subscription.yaml') }}"
     wait: yes
     wait_timeout: 120
 


### PR DESCRIPTION
As part of my refactoring to consolidate monitoring stack management into a single role I missed a re-name of the OpenTelemetry subscription template.