### PR TITLE
[patch] Fix docDb role readme and remove unrequired vars

### DIFF
--- a/ibm/mas_devops/roles/aws_documentdb_user/README.md
+++ b/ibm/mas_devops/roles/aws_documentdb_user/README.md
@@ -13,12 +13,6 @@ Required.The instance ID of Maximo Application Suite required for creating docdb
 
 - Environment Variable: `MAS_INSTANCE_ID`
 
-
-### docdb_cluster_name
-Required. AWS DocumentDB Cluster Name
-
-- Environment Variable: `DOCDB_CLUSTER_NAME`
-
 ### docdb_host
 Required. AWS DocumentDB Instance Host Address
 
@@ -48,7 +42,6 @@ Required. AWS DocumentDB Master Password
     docdb_master_password: test-pass-***
     docdb_host: test1.aws-01....
     docdb_port: 27017
-    docdb_cluster_name: test-db-cluster
 
   roles:
     - ibm.mas_devops.aws_documentdb_user

--- a/ibm/mas_devops/roles/aws_documentdb_user/defaults/main.yml
+++ b/ibm/mas_devops/roles/aws_documentdb_user/defaults/main.yml
@@ -3,7 +3,6 @@
 docdb_instance_credentials_secret_name: "docdb-{{ mas_instance_id }}-instance-credentials"
 # Vars and flags for MAS
 mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
-docdb_cluster_name: "{{ lookup('env', 'DOCDB_CLUSTER_NAME') }}"
 
 #docdb
 docdb_host: "{{ lookup('env', 'DOCDB_HOST') }}"

--- a/ibm/mas_devops/roles/aws_documentdb_user/tasks/main.yml
+++ b/ibm/mas_devops/roles/aws_documentdb_user/tasks/main.yml
@@ -3,7 +3,6 @@
 - name: "Debug information"
   debug:
     msg:
-    - "DocumentDB Name ............................... {{ docdb_cluster_name }}"
     - "DocumentDB Host:Port .......................... {{ docdb_host }}:{{docdb_port}}"
     - "DocumentDB Master Username .................... {{ docdb_master_username }}"
     - "MAS Instance ID ............................... {{ mas_instance_id }}"

--- a/ibm/mas_devops/roles/mongodb/README.md
+++ b/ibm/mas_devops/roles/mongodb/README.md
@@ -410,7 +410,7 @@ Number of instances required for DocumentDB
 - Default Value: `3`
 
 ### docdb_instance_identifier_prefix
-Prefix for DocumentDB Instance name
+Required. Prefix for DocumentDB Instance name
 
 - Environment variable: `DOCDB_INSTANCE_IDENTIFIER_PREFIX`
 
@@ -420,12 +420,30 @@ e.g Provide IPv4 CIDR address of VPC where ROSA cluster is installed
 
 - Environment variable: `DOCDB_INGRESS_CIDR`
 
-
 ### docdb_egress_cidr
 Required. IPv4 Address at which outgoing connection requests will be allowed to DocumentDB cluster
 e.g Provide IPv4 CIDR address of VPC where ROSA cluster is installed
 
 - Environment variable: `DOCDB_EGRESS_CIDR`
+
+### docdb_cidr_az1:
+
+Required. Provide IPv4 CIDR address for the subnet to be created in one of the 3 availabilty zones of your VPC. If the subnet exists already then it must contain the tag of Name: {{ docdb_cluster_name }}, if the subnet doesn't exist already then one is created.
+
+- Environment variable: `DOCDB_CIDR_AZ1`
+
+### docdb_cidr_az2:
+
+Required. Provide IPv4 CIDR address for the subnet to be created in one of the 3 availabilty zones of your VPC. If the subnet exists already then it must contain the tag of Name: {{ docdb_cluster_name }}, if the subnet doesn't exist already then one is created.
+
+- Environment variable: `DOCDB_CIDR_AZ2`
+
+### docdb_cidr_az3:
+
+Required. Provide IPv4 CIDR address for the subnet to be created in one of the 3 availabilty zones of your VPC. If the subnet exists already then it must contain the tag of Name: {{ docdb_cluster_name }}, if the subnet doesn't exist already then one is created.
+
+- Environment variable: `DOCDB_CIDR_AZ3`
+
 
 Example Playbook
 ----------------
@@ -442,6 +460,9 @@ Example Playbook
     docdb_cluster_name: test-db
     docdb_ingress_cidr: 10.0.0.0/16
     docdb_egress_cidr: 10.0.0.0/16
+    docdb_cidr_az1: 10.0.0.0/26
+    docdb_cidr_az2: 10.0.0.64/26
+    docdb_cidr_az3: 10.0.0.128/26
     docdb_instance_identifier_prefix: test-db-instance
     vpc_id: test-vpc-id
     aws_access_key_id: aws-key

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/aws/install.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/aws/install.yml
@@ -15,11 +15,12 @@
       - docdb_cidr_az1 is defined and docdb_cidr_az1 != ''
       - docdb_cidr_az2 is defined and docdb_cidr_az2 != ''
       - docdb_cidr_az3 is defined and docdb_cidr_az3 != ''
+      - docdb_instance_identifier_prefix is defined and docdb_instance_identifier_prefix != ''
       - docdb_ingress_cidr is defined and docdb_ingress_cidr != ''
       - docdb_egress_cidr is defined and docdb_egress_cidr != ''
       - mas_instance_id is defined and mas_instance_id != ''
       - mas_config_dir is defined and mas_config_dir != ''
-    fail_msg: "Missing one or more of following properties: docdb_ingress_cidr,docdb_egress_cidr,docdb_cidr_az1,docdb_cidr_az2,docdb_cidr_az3,mas_instance_id,mas_config_dir"
+    fail_msg: "Missing one or more of following properties: docdb_ingress_cidr,docdb_egress_cidr,docdb_cidr_az1,docdb_cidr_az2,docdb_cidr_az3,docdb_instance_identifier_prefix,mas_instance_id,mas_config_dir"
 
 - name: Initialize Facts for provisioning
   set_fact:


### PR DESCRIPTION
The mongodb role has the `aws` provider which installs DocDB. The readme for this was missing variables that are required, and a variable that is required but not marked as required. The associated role `aws_documentdb_user` also had a variable marked as required but it isn't needed at all so it was removed.

I tested both these roles when deploying docDb

This resolves https://github.com/ibm-mas/ansible-devops/issues/818