### PR TITLE
[patch] Update Kafka default to 3.3.1

### DIFF
--- a/ibm/mas_devops/roles/kafka/README.md
+++ b/ibm/mas_devops/roles/kafka/README.md
@@ -23,7 +23,7 @@ The version of Kafka to deploy by the operator. Before changing the kafka_versio
 by the [amq-streams operator version](https://access.redhat.com/documentation/en-us/red_hat_amq_streams).
 
 - Environment Variable: `KAFKA_VERSION`
-- Default Value: `3.2.3`
+- Default Value: `3.3.1`
 
 ### kafka_namespace
 The namespace where the operator and Kafka cluster will be deployed.

--- a/ibm/mas_devops/roles/kafka/defaults/main.yaml
+++ b/ibm/mas_devops/roles/kafka/defaults/main.yaml
@@ -4,7 +4,7 @@ kafka_action: "{{ lookup('env', 'KAFKA_ACTION') | default('install', true) }}"
 supports_integreatly_org: False
 
 # vars for red hat amq
-kafka_version: "{{ lookup('env', 'KAFKA_VERSION') | default('3.2.3', true) }}"
+kafka_version: "{{ lookup('env', 'KAFKA_VERSION') | default('3.3.1', true) }}"
 kafka_namespace: "{{ lookup('env', 'KAFKA_NAMESPACE') | default('amq-streams', true) }}"
 kafka_cluster_name: "{{ lookup('env', 'KAFKA_CLUSTER_NAME') | default('maskafka', true)  }}"
 kafka_cluster_size: "{{ lookup('env', 'KAFKA_CLUSTER_SIZE') | default('small', true)  }}"


### PR DESCRIPTION
The AMQ Streams stable operator 2.4.0 was released yesterday which brings the minimum level of kafka to above the default kafka that the ansible-devops collection tries to use. The result is that the kafka cr fails with:
```
Unsupported Kafka.spec.kafka.version: 3.2.3. Supported versions are: [3.3.1, 3.4.0]
```

This PR updates the kafka default version from 3.2.3 to 3.3.1. The release notes for 3.3.0 https://archive.apache.org/dist/kafka/3.3.0/RELEASE_NOTES.html don't indicate breaking changes.