### PR TITLE
[patch] Fix cluster_ingress_tls_crt fact assignment

### DIFF
--- a/ibm/mas_devops/common_tasks/get_ingress_cert.yml
+++ b/ibm/mas_devops/common_tasks/get_ingress_cert.yml
@@ -18,4 +18,4 @@
 - name: "Run private ingress cert task"
   when: private_root_ca.stdout_lines[0] != "<none>"
   set_fact:
-    cluster_ingress_tls_crt: private_root_ca.stdout
+    cluster_ingress_tls_crt: "{{ private_root_ca.stdout }}"

--- a/ibm/mas_devops/roles/uds/tasks/install/udscfg.yml
+++ b/ibm/mas_devops/roles/uds/tasks/install/udscfg.yml
@@ -70,6 +70,7 @@
   debug:
     msg:
       - "UDS URL ............................ {{ uds_endpoint_url }}"
+      - "Cluster Ingress TLS Certificate .... {{ cluster_ingress_tls_crt | default('<undefined>', True) }}"
       - "UDS TLS Certificate ................ {{ uds_tls_crt }}"
       - "UDS Contact First Name ............. {{ uds_contact.first_name | default('<undefined>', True) }}"
       - "UDS Contact Last Name .............. {{ uds_contact.last_name | default('<undefined>', True) }}"


### PR DESCRIPTION
`cluster_ingress_tls_crt` is being set to the literal string "private_root_ca.stdout"