### PR TITLE
[patch] Fix document link and titles

### DIFF
--- a/ibm/mas_devops/roles/gencfg_jdbc/README.md
+++ b/ibm/mas_devops/roles/gencfg_jdbc/README.md
@@ -1,7 +1,7 @@
-suite_config
+gencfg_jdbc
 ============
 
-This role is used to configure db in Maximo Application Suite. It will use the database SSL certificate if ssl_enabled flag is true. The`db_pem-file` defines the location of the pem file used for JDBC connection in MAS installation.
+This role is used to configure database in Maximo Application Suite. It will use the database SSL certificate if ssl_enabled flag is true. The`db_pem-file` defines the location of the pem file used for JDBC connection in MAS installation.
 
 Role Variables
 --------------

--- a/ibm/mas_devops/roles/gencfg_watsonstudio/README.md
+++ b/ibm/mas_devops/roles/gencfg_watsonstudio/README.md
@@ -1,4 +1,4 @@
-suite_config
+gencfg_watsonstudio
 ============
 
 This role is used to configure WatsonStudio in Maximo Application Suite.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,7 +97,7 @@ nav:
   - "Roles: Utilities":
       - "ansible_version_check": roles/ansible_version_check.md
       - "entitlement_key_rotation": roles/entitlement_key_rotation.md
-      - "gencfg_jdbc": roles/entitlement_key_rotation.md
+      - "gencfg_jdbc": roles/gencfg_jdbc.md
       - "gencfg_watsonstudio": roles/gencfg_watsonstudio.md
       - "gencfg_workspace": roles/gencfg_workspace.md
       - "install_operator": roles/install_operator.md


### PR DESCRIPTION
The link for gencfg_jdbc role at https://ibm-mas.github.io/ansible-devops/ opens contents for the entitlement_key_rotation role. 
A correction was made in the mkdocs to point to the right role. The document heading was changed to reflect what the role was about to avoid confusion since two roles had suite-config as their titles