### PR TITLE
[patch] Only add the first certificate in the chain to BasCfg

### DIFF
--- a/ibm/mas_devops/common_tasks/get_ingress_cert.yml
+++ b/ibm/mas_devops/common_tasks/get_ingress_cert.yml
@@ -7,15 +7,23 @@
     oc get configmap -n openshift-config $(oc get proxy/cluster -o yaml -o custom-columns=":.spec.trustedCA.name" --no-headers) -o yaml -o custom-columns=":.data.ca-bundle\.crt" --no-headers
   register: private_root_ca
 
-# 2. If no private CA is found then run the get__signed_ingress task
+# 2. If no private CA is found then run the get_signed_ingress task
 # -----------------------------------------------------------------------------
-- name: "Run default ingress cert task - no private CA found"
+- name: "Get signed ingress certificates (no private CA found)"
   when: private_root_ca.stdout_lines[0] == "<none>"
   include_tasks: "get_signed_ingress_cert.yml"
 
+
 # 3. If private CA is found then run then use it instead of a signed one
 # -----------------------------------------------------------------------------
-- name: "Run private ingress cert task"
+# Break up the certificate into an array
+- name: "Get private ingress certificate (full)"
   when: private_root_ca.stdout_lines[0] != "<none>"
   set_fact:
-    cluster_ingress_tls_crt: "{{ private_root_ca.stdout }}"
+    cluster_ingress_tls_crt_full: "{{ private_root_ca.stdout | regex_findall('(?s)(-----BEGIN .+?-----.+?-----END .+?-----)', multiline=True, ignorecase=True) }}"
+
+# We only want the first part of this certificate, I don't know why, but this is what works
+- name: "Get private ingress certificate"
+  when: private_root_ca.stdout_lines[0] != "<none>"
+  set_fact:
+    cluster_ingress_tls_crt: "{{ cluster_ingress_tls_crt_full[0] }}"

--- a/ibm/mas_devops/roles/uds/tasks/install/udscfg.yml
+++ b/ibm/mas_devops/roles/uds/tasks/install/udscfg.yml
@@ -57,7 +57,7 @@
   include_tasks: "{{ role_path }}/../../common_tasks/get_ingress_cert.yml"
 
 # Break up the certificate into an array
-- name: "udscfg : Set uds_tls_crt"
+- name: "udscfg : Set UDS cert variable"
   set_fact:
     uds_tls_crt: "{{ cluster_ingress_tls_crt | regex_findall('(?s)(-----BEGIN .+?-----.+?-----END .+?-----)', multiline=True, ignorecase=True) }}"
 

--- a/ibm/mas_devops/roles/uds/tasks/install/udscfg.yml
+++ b/ibm/mas_devops/roles/uds/tasks/install/udscfg.yml
@@ -57,15 +57,9 @@
   include_tasks: "{{ role_path }}/../../common_tasks/get_ingress_cert.yml"
 
 # Break up the certificate into an array
-- name: "udscfg : Set uds_tls_crt_full"
-  set_fact:
-    uds_tls_crt_full: "{{ cluster_ingress_tls_crt | regex_findall('(?s)(-----BEGIN .+?-----.+?-----END .+?-----)', multiline=True, ignorecase=True) }}"
-
-# We only want the first part of this certificate, I don't know why, but this is what works!
 - name: "udscfg : Set uds_tls_crt"
   set_fact:
-    uds_tls_crt: [ "{{ uds_tls_crt_full[0] }}" ]
-
+    uds_tls_crt: "{{ cluster_ingress_tls_crt | regex_findall('(?s)(-----BEGIN .+?-----.+?-----END .+?-----)', multiline=True, ignorecase=True) }}"
 
 # 5. Debug
 # -----------------------------------------------------------------------------
@@ -74,7 +68,6 @@
     msg:
       - "UDS URL ............................ {{ uds_endpoint_url }}"
       - "Cluster Ingress TLS Certificate .... {{ cluster_ingress_tls_crt | default('<undefined>', True) }}"
-      - "UDS TLS Certificate (full) ......... {{ uds_tls_crt_full }}"
       - "UDS TLS Certificate ................ {{ uds_tls_crt }}"
       - "UDS Contact First Name ............. {{ uds_contact.first_name | default('<undefined>', True) }}"
       - "UDS Contact Last Name .............. {{ uds_contact.last_name | default('<undefined>', True) }}"

--- a/ibm/mas_devops/roles/uds/tasks/install/udscfg.yml
+++ b/ibm/mas_devops/roles/uds/tasks/install/udscfg.yml
@@ -56,12 +56,15 @@
 - name: "udscfg : Lookup the default cluster ingress secret"
   include_tasks: "{{ role_path }}/../../common_tasks/get_ingress_cert.yml"
 
-# Not sure why we do this manipulation on the certificate content, whoever wrote
-# this originally should really have put a comment in here explaining why this
-# is necessary :)
-- name: "udscfg : Set UDS cert variable"
+# Break up the certificate into an array
+- name: "udscfg : Set uds_tls_crt_full"
   set_fact:
-    uds_tls_crt: "{{ cluster_ingress_tls_crt | regex_findall('(?s)(-----BEGIN .+?-----.+?-----END .+?-----)', multiline=True, ignorecase=True) }}"
+    uds_tls_crt_full: "{{ cluster_ingress_tls_crt | regex_findall('(?s)(-----BEGIN .+?-----.+?-----END .+?-----)', multiline=True, ignorecase=True) }}"
+
+# We only want the first part of this certificate, I don't know why, but this is what works!
+- name: "udscfg : Set uds_tls_crt"
+  set_fact:
+    uds_tls_crt: [ "{{ uds_tls_crt_full[0] }}" ]
 
 
 # 5. Debug
@@ -71,6 +74,7 @@
     msg:
       - "UDS URL ............................ {{ uds_endpoint_url }}"
       - "Cluster Ingress TLS Certificate .... {{ cluster_ingress_tls_crt | default('<undefined>', True) }}"
+      - "UDS TLS Certificate (full) ......... {{ uds_tls_crt_full }}"
       - "UDS TLS Certificate ................ {{ uds_tls_crt }}"
       - "UDS Contact First Name ............. {{ uds_contact.first_name | default('<undefined>', True) }}"
       - "UDS Contact Last Name .............. {{ uds_contact.last_name | default('<undefined>', True) }}"

--- a/ibm/mas_devops/roles/uds/templates/bascfg.yml.j2
+++ b/ibm/mas_devops/roles/uds/templates/bascfg.yml.j2
@@ -49,7 +49,7 @@ spec:
       crt: |
         {{ uds_tls_crt[1] | indent(8) }}
 {% endif %}
-    - alias: part3
+    - alias: isrg-root-x1
       crt: |
         -----BEGIN CERTIFICATE-----
         MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw


### PR DESCRIPTION
Not really sure why we need to do this, but in testing on TechZone cluster it appears to do the trick, and this code path was completely broken before I delivered #831 anyway so low risk anyone was using this successfully the way it worked before anyway.