### PR TITLE
[patch] Fix incorrect mongo 4.4.21 digest

### DIFF
--- a/ibm/mas_devops/roles/mirror_extras_prepare/vars/mongoce_4.4.21.yml
+++ b/ibm/mas_devops/roles/mirror_extras_prepare/vars/mongoce_4.4.21.yml
@@ -23,4 +23,4 @@ extra_images:
   - name: ibmmas/mongo
     registry: quay.io
     tag: 4.4.21
-    digest: sha256:67954c380ff06271b472b7eff70100b0831601cb2e932fdef7bb50bbec66bb85
+    digest: sha256:e1b43604ed1b54804f15c421de666e8be6c6d1ebf57e5825dff22493f9bd5f1e


### PR DESCRIPTION
The wrong digest was added for the mongo 4.4.21 (it was copied from the 4.2.23 image digest). Without this change then the default MongoDb install on airgap can not work as the image is not mirrored.

This was missed in testing as we can't currently block quay.io https://github.com/ibm-mas/ansible-devops/blob/master/ibm/mas_devops/roles/ocp_simulate_disconnected_network/defaults/main.yml#L3

Resolves https://github.com/ibm-mas/ansible-devops/issues/835