### PR TITLE
[patch] Exclusive workaround for Monitor mirroring

### DIFF
--- a/ibm/mas_devops/common_vars/digests/ibm-data-dictionary/1.1.4.yaml
+++ b/ibm/mas_devops/common_vars/digests/ibm-data-dictionary/1.1.4.yaml
@@ -1,0 +1,7 @@
+cp.icr.io/cp/datadictionary/kitt-v3-file-store:3.2.27: cp.icr.io/cp/datadictionary/kitt-v3-file-store@sha256:fb7063c37b5419a16285f96a31d2ce7b1558e411d25ec1e38d0e234c1acd6926
+cp.icr.io/cp/datadictionary/kitt-v3-graph-service:3.2.27: cp.icr.io/cp/datadictionary/kitt-v3-graph-service@sha256:1e7b4d2c8209d3aeede14f13895703dfdba332da79d45af90297bf82b69380a9
+cp.icr.io/cp/datadictionary/kitt-v3-json-store:3.2.27: cp.icr.io/cp/datadictionary/kitt-v3-json-store@sha256:01937dd78603e45572ac8e17f6c9a45f2617e594530b392bdd863897f3ef8ceb
+cp.icr.io/cp/datadictionary/kitt-v3-maximo-connector:3.2.27: cp.icr.io/cp/datadictionary/kitt-v3-maximo-connector@sha256:2c4e3395e8853b8175c158443c17b4392dee04ad5bd36f367083a7bc0a3213a2
+cp.icr.io/cp/datadictionary/kitt-v3-router:3.2.27: cp.icr.io/cp/datadictionary/kitt-v3-router@sha256:40e1145192b89b2382b198b56421ee628bdc3c3a84e74c1444be72f6ddec74fb
+cp.icr.io/cp/datadictionary/kitt-v3-series-store:3.2.27: cp.icr.io/cp/datadictionary/kitt-v3-series-store@sha256:f8f477159a76b2326cd8b90342681aa3334a24de53e3caf79a3dca85992678df
+cp.icr.io/cp/datadictionary/kitt-v3-user-store:3.2.27: cp.icr.io/cp/datadictionary/kitt-v3-user-store@sha256:ede986985a3b00e852e146c069190b1bd01b825b26c8701daafd89c6189479c4

--- a/ibm/mas_devops/playbooks/mirror_add_monitor.yml
+++ b/ibm/mas_devops/playbooks/mirror_add_monitor.yml
@@ -65,18 +65,21 @@
         manifest_name: ibm-mas-monitor
         manifest_version: "{{ mas_monitor_version[mas_channel] }}"
 
-    # 2.2. IBM Maximo Monitor image fix (there are two digests and catalog uses one and case bundle uses the other)
+    # 2.2. IBM Maximo Monitor image fix in version 8.10.0 (there are two digests and catalog uses one and case bundle uses the other)
     # -------------------------------------------------------------------------
     - name: ibm.mas_devops.mirror_extras_prepare
       when:
         - mirror_mas_monitor
         - mirror_mode != "from-filesystem"
+        - mas_monitor_version[mas_channel] == "8.10.0"
       vars:
         extras_name: monitor
         extras_version: "{{ mas_monitor_version[mas_channel] }}"
 
     - name: ibm.mas_devops.mirror_images
-      when: mirror_mas_monitor
+      when:
+        - mirror_mas_monitor
+        - mas_monitor_version[mas_channel] == "8.10.0"
       vars:
         manifest_name: extras_monitor
         manifest_version: "{{ mas_monitor_version[mas_channel] }}"

--- a/ibm/mas_devops/roles/suite_app_install/tasks/monitor.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/monitor.yml
@@ -38,14 +38,14 @@
 # 3. Create the Image Digest Map for Data Dictionary v1.1.3
 # -----------------------------------------------------------------------------
 - name: "Create data-dictionary namespace"
-  when: dd_version is version('1.1.3', '==')
+  when: (dd_version is version('1.1.3', '==')) or (dd_version is version('1.1.4', '=='))
   kubernetes.core.k8s:
     api_version: v1
     kind: Namespace
     name: 'mas-{{ mas_instance_id }}-add'
 
 - name: "Create ibm-data-dictionary Image Digest Map"
-  when: dd_version is version('1.1.3', '==')
+  when: (dd_version is version('1.1.3', '==')) or (dd_version is version('1.1.4', '=='))
   include_role:
     name: ibm.mas_devops.suite_install_digest_cm
   vars:


### PR DESCRIPTION
For Monitor 8.10.0, there were extra images that we needed to make it work. We had a workaround that assumed that all consecutive versions would apply but that is not the case so I added a condition to only apply this workaround for 8.10.0 only leaving the newer versions out until we need it again. This is causing a false fail in fvt810x airgap mirroring at the moment. Here is the fix. I tested and it passed for both new and old version except for 8.10.1 which had an unfixable bug.

Also added digest for DD 1.1.4. It turned out that it was not fully supported in OM 1.6