### PR TITLE
[patch] Fix amqstreams_defauilt_channel typo

### DIFF
--- a/ibm/mas_devops/roles/kafka/tasks/provider/redhat/install.yml
+++ b/ibm/mas_devops/roles/kafka/tasks/provider/redhat/install.yml
@@ -70,7 +70,7 @@
     msg:
       - "Catalog source  ....................... {{ amqstreams_source }}"
       - "Catalog source namespace .............. {{ amqstreams_source_namespace }}"
-      - "Default channel ....................... {{ amqstreams_defauilt_channel }}"
+      - "Default channel ....................... {{ amqstreams_default_channel }}"
 
       - "AMQ Streams namespace ................. {{ kafka_namespace }}"
       - "AMQ Streams kafka version ............. {{ kafka_version }}"


### PR DESCRIPTION
Fix for: 

```
TASK [ibm.mas_devops.kafka : Debug information] ********************************
Saturday 03 June 2023  20:49:03 +0000 (0:00:00.029)       0:00:04.794 ********* 
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'amqstreams_defauilt_channel' is undefined\n\nThe error appears to be in '/opt/app-root/lib64/python3.9/site-packages/ansible_collections/ibm/mas_devops/roles/kafka/tasks/provider/redhat/install.yml': line 68, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n# -----------------------------------------------------------------------------\n- name: \"Debug information\"\n  ^ here\n"}
```