### PR TITLE
[patch] Fix typo in nvidia_gpu role's set_fact

### DIFF
--- a/ibm/mas_devops/roles/nvidia_gpu/tasks/main.yml
+++ b/ibm/mas_devops/roles/nvidia_gpu/tasks/main.yml
@@ -51,7 +51,7 @@
   set_fact:
     gpu_source: "{{ gpu_manifest.resources[0].status.catalogSource }}"
     gpu_source_namespace: "{{ gpu_manifest.resources[0].status.catalogSourceNamespace }}"
-    gpu_default_channel: "{{ gpu_manifest.resources[0].status.defaultChannel: }}"
+    gpu_default_channel: "{{ gpu_manifest.resources[0].status.defaultChannel }}"
 
 
 # 3. Provide Debug information


### PR DESCRIPTION
A rogue ":" is appended to "status.defaultChannel" that needs to be removed