### PR TITLE
[patch] Fix amqstreams_manifest.defaultChannel typo

### DIFF
--- a/ibm/mas_devops/roles/kafka/templates/redhat/subscription.yml.j2
+++ b/ibm/mas_devops/roles/kafka/templates/redhat/subscription.yml.j2
@@ -19,7 +19,7 @@ metadata:
   name: amq-streams
   namespace: "{{ kafka_namespace }}"
 spec:
-  channel: "{{ amqstreams_manifest.status.defaultChannel }}"
+  channel: "{{ amqstreams_manifest.defaultChannel }}"
   installPlanApproval: Automatic
   name: amq-streams
   source: "{{ amqstreams_source }}"


### PR DESCRIPTION
Another mistake, we are referencing `amqstreams_manifest.status.defaultChannel` instead of `amqstreams_manifest.defaultChannel`.