### PR TITLE
[patch] Make opentelemetry an optional part of stack

### DIFF
--- a/ibm/mas_devops/roles/cluster_monitoring/README.md
+++ b/ibm/mas_devops/roles/cluster_monitoring/README.md
@@ -4,7 +4,7 @@ Configures an in-cluster monitoring stack for IBM Maximo Application Suite:
 
 - [OpenShift user defined project monitoring](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/monitoring/enabling-monitoring-for-user-defined-projects) is enabled (`openshift-monitoring` namespace)
 - [OpenShift monitoring stack](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/monitoring/index) is configured to use persistent storage (`openshift-monitoring` namespace)
-- [OpenTelemetry operator](https://github.com/open-telemetry/opentelemetry-operator) is installed (`openshift-operators` namespace)
+- [OpenTelemetry operator](https://github.com/open-telemetry/opentelemetry-operator) is installed (optional, `openshift-operators` namespace)
 - [Grafana](https://grafana.com/) installed using the [community grafana operator](https://github.com/grafana-operator/grafana-operator) (`grafana` namespace)
 
 The credentials for the grafana admin user are stored in `grafana-admin-credentials` secret in the grafana namespace. A route  is created in the grafana namespace to allow access to the grafana UI.
@@ -18,6 +18,13 @@ Inform the role whether to perform an install or an uninstall of cluster monitor
 - Optional
 - Environment Variable: `CLUSTER_MONITORING_ACTION`
 - Default: `install`
+
+### cluster_monitoring_include_opentelemetry
+By default OpenTelemtry is not installed into the cluster, this operator must be enabled by setting this variable to `True`.
+
+- Optional
+- Environment Variable: `CLUSTER_MONITORING_INCLUDE_OPENTELEMETRY`
+- Default: `False`
 
 
 Role Variables - Prometheus

--- a/ibm/mas_devops/roles/cluster_monitoring/defaults/main.yml
+++ b/ibm/mas_devops/roles/cluster_monitoring/defaults/main.yml
@@ -22,5 +22,5 @@ grafana_namespace: "{{ lookup('env', 'GRAFANA_NAMESPACE') | default('grafana', t
 # Whether to perform an install or an uninstall
 cluster_monitoring_action: "{{ lookup('env', 'CLUSTER_MONITORING_ACTION') | default('install', true) }}"
 
-# OpenTelemetry is an optional part of the monitoring stack, but default it is disabled.
+# OpenTelemetry is an optional part of the monitoring stack, by default it is disabled.
 cluster_monitoring_include_opentelemetry: "{{ lookup('env', 'CLUSTER_MONITORING_INCLUDE_OPENTELEMETRY') | default('False', true) | bool }}"

--- a/ibm/mas_devops/roles/cluster_monitoring/defaults/main.yml
+++ b/ibm/mas_devops/roles/cluster_monitoring/defaults/main.yml
@@ -21,3 +21,6 @@ grafana_namespace: "{{ lookup('env', 'GRAFANA_NAMESPACE') | default('grafana', t
 
 # Whether to perform an install or an uninstall
 cluster_monitoring_action: "{{ lookup('env', 'CLUSTER_MONITORING_ACTION') | default('install', true) }}"
+
+# OpenTelemetry is an optional part of the monitoring stack, but default it is disabled.
+cluster_monitoring_include_opentelemetry: "{{ lookup('env', 'CLUSTER_MONITORING_INCLUDE_OPENTELEMETRY') | default('False', true) | bool }}"

--- a/ibm/mas_devops/roles/cluster_monitoring/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/cluster_monitoring/tasks/install/main.yml
@@ -23,7 +23,8 @@
   include_tasks: tasks/install/grafana.yml
 
 
-# 4. Install OpenTelemetry
+# 4. Install OpenTelemetry (optional)
 # -----------------------------------------------------------------------------
-- name: "install : Install OpenTelemetry"
+- name: "install : Install OpenTelemetry (optional)"
+  when: cluster_monitoring_include_opentelemetry
   include_tasks: tasks/install/opentelemetry.yml

--- a/ibm/mas_devops/roles/cluster_monitoring/tasks/uninstall/main.yml
+++ b/ibm/mas_devops/roles/cluster_monitoring/tasks/uninstall/main.yml
@@ -1,8 +1,9 @@
 ---
 
-# 1. Uninstall OpenTelemetry
+# 1. Uninstall OpenTelemetry (optional)
 # -----------------------------------------------------------------------------
-- name: "uninstall : Uninstall OpenTelemetry"
+- name: "uninstall : Uninstall OpenTelemetry (optional)"
+  when: cluster_monitoring_include_opentelemetry
   include_tasks: tasks/uninstall/opentelemetry.yml
 
 


### PR DESCRIPTION
Using `cluster_monitoring_include_opentelemetry` a customer can choose to add OpenTelemetry to the monitoring stack, but by default it will be not included.