### PR TITLE
[patch] Add link to product uninstall documentation

### DIFF
--- a/docs/playbooks/uninstall-core.md
+++ b/docs/playbooks/uninstall-core.md
@@ -15,6 +15,14 @@ The following will be removed from the cluster.
 
 When using this playbook be sure that nothing else in your cluster is using any of the dependencies that will be removed.  If you wish to skip the removal of one or more dependencies use the optional environment variables documented below to control exactly what is uninstalled.
 
+!!! warning
+    This playbook will try to gracefully uninstall a target MAS instance by removing MAS related resources in the expected order.
+    Therefore, make sure your MAS operator is up and running in a healthy state, and no errors are reported in your `Suite` custom resource.  
+    
+    If there are any error reported in the logs of your MAS operator pod, or in your `Suite` custom resource, the uninstall process might get stuck and not complete successfully. In this case, you will need to debug and fix what is preventing your MAS operator to properly process the uninstall, or ultimately, forcibly uninstall MAS instance. 
+    
+    For more information regarding MAS uninstall process, refer to [Uninstalling Maximo Application Suite](https://www.ibm.com/docs/en/mas-cd/continuous-delivery?topic=uninstalling) documentation.
+
 
 Usage
 -------------------------------------------------------------------------------


### PR DESCRIPTION
This just adds official MAS uninstall documentation link to our automation documentation as per customer feedback:
https://github.ibm.com/wiotp/tracker/issues/12684#issuecomment-58176587

It seems there was an understanding that MAS uninstall playbook was going to take care of the uninstall without any type of debug or intervention, which ideally is what we expect, but sometimes if the MAS instance is not healthy for whatever reasons, the uninstall might not gracefully complete.