### PR TITLE
[patch] Remove quay.io from sim disconnected network

### DIFF
--- a/ibm/mas_devops/roles/ocp_simulate_disconnected_network/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_simulate_disconnected_network/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Ideally we would add quay.io here as well, but we can't until we mirror all the images used by OCP itself
-airgap_network_exclusions: "icr.io cp.icr.io docker-na-public.artifactory.swg-devops.com quay.io"
+airgap_network_exclusions: "icr.io cp.icr.io docker-na-public.artifactory.swg-devops.com"
 
 registry_private_ca_file: "{{ lookup('env', 'REGISTRY_PRIVATE_CA_FILE') }}"
 registry_private_ca_crt: "{{ lookup('file', registry_private_ca_file) }}"


### PR DESCRIPTION
`quay.io` was accidentally added to the block list in the simulated disconnected network role, we're not at the point where the sim airgap environment can block quay.io.