### PR TITLE
[patch] fix cpd custom route

### DIFF
--- a/ibm/mas_devops/roles/suite_dns/README.md
+++ b/ibm/mas_devops/roles/suite_dns/README.md
@@ -238,6 +238,34 @@ AWS Route53 contact e-mail. Will be set in the cluster issuer created in order t
 - Environment Variable: `ROUTE53_EMAIL`
 - Default Value: None.
 
+Role Variables - CloudPak for Data
+------------------------------------------------------------
+
+### cpd_instance_namespace
+Namespace where the Cloud Pak for Data is installed and the `cpd` route exists.
+If set, then this role will also attempt to configure public certificates to the CPD route using the DNS provider defined.
+
+- Optional
+- Environment Variable: `CPD_INSTANCE_NAMESPACE`
+- Default Value: None.
+
+### cpd_prod_issuer_name
+Define the certificate issuer responsible for generating the public certificate for your CPD route.
+If not set, then it will use same issuer set for MAS instance.
+
+
+- Optional
+- Environment Variable: `CPD_PROD_ISSUER_NAME`
+- Default Value: Same certificate issuer used for MAS instance.
+
+### cpd_custom_domain
+Define the custom domain for your CPD route.
+If not set, then it will use same domain set for MAS instance.
+
+- Optional
+- Environment Variable: `CPD_CUSTOM_DOMAIN`
+- Default Value: `cp4d.{{ mas_domain }}`.
+
 Example Playbook - CIS or Cloudflare
 ----------------
 

--- a/ibm/mas_devops/roles/suite_dns/defaults/main.yaml
+++ b/ibm/mas_devops/roles/suite_dns/defaults/main.yaml
@@ -90,6 +90,9 @@ route53_cname_json_file_path_local: "{{ role_path }}/templates/route53"
 
 # CP4D Integration
 # -----------------------------------------------------------------------------
+cpd_prod_issuer_name_default: "{{ mas_instance_id }}-{{ dns_provider }}-le-prod" # this will be the same production issuer used to setup mas instance
+cpd_prod_issuer_name: "{{ lookup('env', 'CPD_PROD_ISSUER_NAME') | default(cpd_prod_issuer_name_default, true) }}"
+cpd_custom_domain: "{{ lookup('env', 'CPD_CUSTOM_DOMAIN') | default(mas_domain, true) }}" # if not set, we'll use same mas domain
 cpd_instance_namespace: "{{ lookup('env', 'CPD_INSTANCE_NAMESPACE') }}"
 
 # Custom Labels

--- a/ibm/mas_devops/roles/suite_dns/tasks/cp4d.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/cp4d.yml
@@ -1,4 +1,11 @@
 ---
+- name: "Debug CPD certificate details"
+  debug:
+    msg:
+      - "CPD namespace .................. {{ cpd_instance_namespace }}"
+      - "CPD cluster issuer name ........ {{ cpd_prod_issuer_name }}"
+      - "CPD custom domain .............. cp4d.{{ cpd_custom_domain }}"
+
 - name: "Create certificate to be used for suite cp4d route"
   kubernetes.core.k8s:
     apply: yes
@@ -14,7 +21,7 @@
     api_version: v1
     kind: Secret
     name: "suite-cp4d-certificate"
-    namespace: "{{ cpd_services_namespace }}"
+    namespace: "{{ cpd_instance_namespace }}"
   register: suiteCp4dCrtSecret
   retries: 120 # 5 minutes
   delay: 5 # seconds
@@ -29,7 +36,7 @@
     api_version: v1
     kind: Secret
     name: "external-tls-secret"
-    namespace: "{{ cpd_services_namespace }}"
+    namespace: "{{ cpd_instance_namespace }}"
   register: cp4dCrtSecret
 
 - name: "Lookup default internal CP4D CA certificate if no external-tls-secret"
@@ -37,7 +44,7 @@
     api_version: v1
     kind: Secret
     name: "ibm-nginx-internal-tls-ca"
-    namespace: "{{ cpd_services_namespace }}"
+    namespace: "{{ cpd_instance_namespace }}"
   register: cp4dCrtSecret
   when:
     - cp4dCrtSecret.resources | length == 0

--- a/ibm/mas_devops/roles/suite_dns/tasks/run.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/run.yml
@@ -30,8 +30,20 @@
 
 # 3. Set custom cp4d route based on the custom cluster issuer
 # -----------------------------------------------------------------------------
-- name: "Set up CP4D route under the appsuite domain"
+- block:
+
+  - name: Check if custom CP4D route is already configured # if it is, then we skip it to avoid override
+    kubernetes.core.k8s_info:
+      api_version: v1
+      name: suite-cp4d-route
+      namespace: "{{ cpd_instance_namespace }}"
+      kind: Route
+    register: _suite_cp4d_route
+
+  - name: "Set up CP4D route under the appsuite domain"
+    include_tasks: tasks/cp4d.yml
+    when: _suite_cp4d_route.resources is defined and _suite_cp4d_route.resources | length == 0
+
   when:
     - dns_provider != ""
     - cpd_instance_namespace is defined and cpd_instance_namespace != ""
-  include_tasks: tasks/cp4d.yml

--- a/ibm/mas_devops/roles/suite_dns/templates/cp4d/cp4d-certificate.yml.j2
+++ b/ibm/mas_devops/roles/suite_dns/templates/cp4d/cp4d-certificate.yml.j2
@@ -11,10 +11,10 @@ metadata:
 {% endif %}
 spec:
   dnsNames:
-    - "cp4d.{{ custom_domain }}"
+    - "cp4d.{{ cpd_custom_domain }}"
   issuerRef:
     kind: ClusterIssuer
-    name: "{{ custom_cluster_issuer }}"
+    name: "{{ cpd_prod_issuer_name }}"
   secretName: "suite-cp4d-certificate"
   renewBefore: 720h0m0s # 30 days
   duration: 8760h0m0s # 1 year

--- a/ibm/mas_devops/roles/suite_dns/templates/cp4d/cp4d-route.yml.j2
+++ b/ibm/mas_devops/roles/suite_dns/templates/cp4d/cp4d-route.yml.j2
@@ -12,7 +12,7 @@ metadata:
   annotations:
     haproxy.router.openshift.io/balance=roundrobin
 spec:
-  host: "cp4d.{{ custom_domain }}"
+  host: "cp4d.{{ cpd_custom_domain }}"
   to:
     kind: Service
     name: ibm-nginx-svc


### PR DESCRIPTION
This fixes the issue while configuring public well-known certs for CPD within the `suite_dns` role. We had many undefined references in the task that sets the CPD route, so I'm fixing that based on recent feedback.

Expected results to have public certs added to the CPD route:
<img width="333" alt="image" src="https://github.com/ibm-mas/ansible-devops/assets/31037381/11189f9a-96c8-4165-b696-3c69f164379e">
