### PR TITLE
[patch] Create working dir if missing

### DIFF
--- a/ibm/mas_devops/roles/mirror_extras_prepare/tasks/extras.yml
+++ b/ibm/mas_devops/roles/mirror_extras_prepare/tasks/extras.yml
@@ -27,6 +27,24 @@
 
 # 3. Generate mirror-manifest
 # -----------------------------------------------------------------------------
+- name: "{{ extras_name }} : Ensure manifests/to-filesystem directory exists"
+  file:
+    path: "{{ mirror_working_dir }}/manifests/to-filesystem"
+    state: directory
+    recurse: yes
+
+- name: "{{ extras_name }} : Ensure manifests/from-filesystem directory exists"
+  file:
+    path: "{{ mirror_working_dir }}/manifests/from-filesystem"
+    state: directory
+    recurse: yes
+
+- name: "{{ extras_name }} : Ensure manifests/direct directory exists"
+  file:
+    path: "{{ mirror_working_dir }}/manifests/direct"
+    state: directory
+    recurse: yes
+
 - name: "{{ extras_name }} : Generate the mirror manifest (to filesystem)"
   template:
     src: to-filesystem.txt.j2


### PR DESCRIPTION
MIrror extras does not create the directories required, it assumes this has been done outside the role.  Simple update to correct this.