### PR TITLE
[patch] Fix db2u resource defaults

### DIFF
--- a/ibm/mas_devops/roles/db2/defaults/main.yml
+++ b/ibm/mas_devops/roles/db2/defaults/main.yml
@@ -47,10 +47,10 @@ db2_temp_storage_accessmode: "{{ lookup('env', 'DB2_TEMP_STORAGE_ACCESSMODE') | 
 
 # Request/limit defaults
 # -----------------------------------------------------------------------------
-db2_cpu_requests: "{{ lookup('env', 'DB2_CPU_REQUESTS')  | default('3000m', true) }}"
-db2_cpu_limits: "{{ lookup('env', 'DB2_CPU_LIMITS')  | default('3000m', true) }}"
-db2_memory_requests: "{{ lookup('env', 'DB2_MEMORY_REQUESTS')  | default('12Gi', true) }}"
-db2_memory_limits: "{{ lookup('env', 'DB2_MEMORY_LIMITS')  | default('12Gi', true) }}"
+db2_cpu_requests: "{{ lookup('env', 'DB2_CPU_REQUESTS')  | default('4000m', true) }}"
+db2_cpu_limits: "{{ lookup('env', 'DB2_CPU_LIMITS')  | default('6000m', true) }}"
+db2_memory_requests: "{{ lookup('env', 'DB2_MEMORY_REQUESTS')  | default('8Gi', true) }}"
+db2_memory_limits: "{{ lookup('env', 'DB2_MEMORY_LIMITS')  | default('16Gi', true) }}"
 
 
 # Node affinity and tolerations


### PR DESCRIPTION
Previous bad merge resulted in a change to the default values for CPU & memory resource requests & limits.