### PR TITLE
[patch] Add edgeconfig.iot and edgeconfigapi.iot routes

### DIFF
--- a/ibm/mas_devops/roles/suite_certs/templates/dnsentries.yml.j2
+++ b/ibm/mas_devops/roles/suite_certs/templates/dnsentries.yml.j2
@@ -18,6 +18,10 @@ nowildcard:
   -  {{ mas_workspace_id }}.iot
   - messaging.iot
   -  {{ mas_workspace_id }}.messaging.iot
+  - edgeconfig.iot
+  -  {{ mas_workspace_id }}.edgeconfig.iot
+  - edgeconfigapi.iot
+  -  {{ mas_workspace_id }}.edgeconfigapi.iot
   - manage
   -  {{ mas_workspace_id }}.manage
   -  {{ mas_workspace_id }}-all.manage
@@ -52,6 +56,8 @@ wildcard:
   - "*"
   - "*.api.monitor"
   - "*.assist"
+  - "*.edgeconfig.iot"
+  - "*.edgeconfigapi.iot"
   - "*.health"
   - "*.home"
   - "*.hputilities"

--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cloudflare/main.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cloudflare/main.yml
@@ -76,6 +76,8 @@
       # IoT
       - "*.iot"
       - "*.messaging.iot"
+      - "*.edgeconfig.iot"
+      - "*.edgeconfigapi.iot"
       # Health
       - "*.health"
       # Manage

--- a/ibm/mas_devops/roles/suite_dns/templates/dnsentries.yml.j2
+++ b/ibm/mas_devops/roles/suite_dns/templates/dnsentries.yml.j2
@@ -18,6 +18,10 @@ nowildcard:
   -  {{ mas_workspace_id }}.iot
   - messaging.iot
   -  {{ mas_workspace_id }}.messaging.iot
+  - edgeconfig.iot
+  -  {{ mas_workspace_id }}.edgeconfig.iot
+  - edgeconfigapi.iot
+  -  {{ mas_workspace_id }}.edgeconfigapi.iot
   - manage
   -  {{ mas_workspace_id }}.manage
   -  {{ mas_workspace_id }}-all.manage
@@ -53,6 +57,8 @@ wildcard:
   - "*"
   - "*.api.monitor"
   - "*.assist"
+  - "*.edgeconfig.iot"
+  - "*.edgeconfigapi.iot"
   - "*.health"
   - "*.home"
   - "*.hputilities"

--- a/ibm/mas_devops/roles/suite_dns/templates/edge_certificate_routes.yml.j2
+++ b/ibm/mas_devops/roles/suite_dns/templates/edge_certificate_routes.yml.j2
@@ -19,6 +19,10 @@ edge_cert_routes:
   - {{ mas_workspace_id }}.iot.{{mas_domain}}
   - messaging.iot.{{mas_domain}}
   - {{ mas_workspace_id }}.messaging.iot.{{mas_domain}}
+  - edgeconfig.iot.{{mas_domain}}
+  - {{ mas_workspace_id }}.edgeconfig.iot.{{mas_domain}}
+  - edgeconfigapi.iot.{{mas_domain}}
+  - {{ mas_workspace_id }}.edgeconfigapi.iot.{{mas_domain}}
   - manage.{{mas_domain}}
   - {{ mas_workspace_id }}.manage.{{mas_domain}}
   - {{ mas_workspace_id }}-all.manage.{{mas_domain}}


### PR DESCRIPTION
Newer versions of MAS have new routes. We should add the DNS settings for them - they won't do any harm on releases that do not need them. 