### PR TITLE
[patch] Fix READY / NOTREADY debug msgs

### DIFF
--- a/ibm/mas_devops/plugins/action/verify_workloads.py
+++ b/ibm/mas_devops/plugins/action/verify_workloads.py
@@ -54,11 +54,11 @@ class ActionModule(ActionBase):
             else:
               msg = f"{resource.metadata.namespace}/{resource.metadata.name} = {resource.status.replicas} replicas/{resource.status.readyReplicas} ready/{resource.status.updatedReplicas} updated/{resource.status.availableReplicas} available"
               if resource.status.replicas != resource.status.readyReplicas or resource.status.replicas != resource.status.updatedReplicas or resource.status.replicas != resource.status.availableReplicas:
-                display.v(f"[READY]    {msg}")
+                display.v(f"[NOTREADY] {msg}")
                 notReady.append(msg)
                 allResourcesHealthyThisLoop = False
               else:
-                display.v(f"[NOTREADY] {msg}")
+                display.v(f"[READY]   {msg}")
                 ready.append(msg)
 
           display.vvv(f"Finished loop: allResourcesHealthyThisLoop={allResourcesHealthyThisLoop} delay: {delay}")


### PR DESCRIPTION
Debug messages in the `ocp_verify` were actually the wrong way around:

Example:
```
[NOTREADY] ibm-odf-validation-webhook/managed-storage-validation-webhooks = 3 replicas/3 ready/3 updated/3 available
[READY]    ibm-sls/ibm-sls-controller-manager = 2 replicas/1 ready/1 updated/1 available
```

This does not affect the functionality of the verification, but is confusing.