### PR TITLE
[patch] Fix FYRE API provision/deprovision logic

### DIFF
--- a/ibm/mas_devops/roles/ocp_deprovision/tasks/providers/fyre.yml
+++ b/ibm/mas_devops/roles/ocp_deprovision/tasks/providers/fyre.yml
@@ -17,9 +17,29 @@
       - "Username ..................... {{ fyre_username }}"
       - "Password ..................... *****************"
 
-# 2. Deprovision
+# 2. Determine whether cluster exists
+# -----------------------------------------------------------------------------
+- name: "quickburn : Check if cluster already exists"
+  uri:
+    url: "https://ocpapi.svl.ibm.com/v1/check_hostname/{{ cluster_name }}"
+    user: "{{ fyre_username }}"
+    password: "{{ fyre_apikey }}"
+    method: GET
+    force_basic_auth: yes
+    validate_certs: false
+  register: _cluster_exist
+  failed_when: _cluster_exist.status == 403
+
+- name: "fyre : Debug cluster lookup"
+  debug:
+    var: _cluster_exist
+
+# 3. Deprovision if cluster exists
 # -----------------------------------------------------------------------------
 - name: "quickburn : Deprovision quick burn cluster"
+  when:
+    - _cluster_exist.json is defined
+    - _cluster_exist.json.owning_user is defined # when there's cluster owner, it means the cluster exists thus we can deprovision it
   uri:
     url: "https://ocpapi.svl.ibm.com/v1/ocp/{{cluster_name}}"
     user: "{{ fyre_username }}"

--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/fyre.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/fyre.yml
@@ -1,5 +1,4 @@
 ---
-
 # 1. Failure conditions
 # -----------------------------------------------------------------------------
 - name: "fyre : Fail if required properties are not provided"
@@ -15,7 +14,6 @@
   when: fyre_quota_type == "quick_burn"
   assert:
     that: fyre_cluster_size is defined and fyre_cluster_size != ""
-
 
 # 2. Debug Info
 # -----------------------------------------------------------------------------
@@ -37,51 +35,56 @@
       - "Worker CPU ................... {{ fyre_worker_cpu | default('<undefined>', true) }}"
       - "Worker memory ................ {{ fyre_worker_memory | default('<undefined>', true) }}"
 
-
 # 3. Determine whether there is already an environment running
 # -----------------------------------------------------------------------------
 - name: "fyre : Check if cluster already exists"
   uri:
-    url: "https://ocpapi.svl.ibm.com/v1/ocp/{{cluster_name}}"
-    user: "{{fyre_username}}"
-    password: "{{fyre_password}}"
+    url: "https://ocpapi.svl.ibm.com/v1/check_hostname/{{ cluster_name }}"
+    user: "{{ fyre_username }}"
+    password: "{{ fyre_password }}"
     method: GET
     force_basic_auth: yes
     validate_certs: false
   register: _cluster_exist
   failed_when: _cluster_exist.status == 403
 
+- name: "fyre : Debug cluster lookup"
+  debug:
+    var: _cluster_exist
 
 # 4. Deploy the OCP+ cluster
 # -----------------------------------------------------------------------------
-- name: "fyre : Create new OCP+ cluster"
-  when: _cluster_exist.json.cluster_count is not defined
-  vars:
-    fyre_template_name: "templates/fyre/{{ fyre_quota_type }}.json.j2"
-  uri:
-    url: https://ocpapi.svl.ibm.com/v1/ocp/
-    user: "{{ fyre_username }}"
-    password: "{{ fyre_password }}"
-    method: POST
-    body: "{{ lookup('template', fyre_template_name) }}"
-    force_basic_auth: yes
-    body_format: json
-    validate_certs: false
+- block:
+    - name: "fyre : Create new OCP+ cluster"
+      vars:
+        fyre_template_name: "templates/fyre/{{ fyre_quota_type }}.json.j2"
+      uri:
+        url: https://ocpapi.svl.ibm.com/v1/ocp/
+        user: "{{ fyre_username }}"
+        password: "{{ fyre_password }}"
+        method: POST
+        body: "{{ lookup('template', fyre_template_name) }}"
+        force_basic_auth: yes
+        body_format: json
+        validate_certs: false
 
+    # 5. Track the progress of the deployment
+    # -----------------------------------------------------------------------------
+    - name: "fyre : Follow deployment status (2 minute intervals)"
+      uri:
+        url: "https://ocpapi.svl.ibm.com/v1/ocp/{{ cluster_name }}/status"
+        user: "{{ fyre_username }}"
+        password: "{{ fyre_password }}"
+        method: GET
+        force_basic_auth: yes
+        validate_certs: false
+      register: _result
+      until:
+        - _result.json.deployed_status is defined
+        - _result.json.deployed_status == 'deployed'
+      retries: 60 # 60 * 2 minutes = 2 hours
+      delay: 120 # Every 2 minutes
 
-# 5. Track the progress of the deployment
-# -----------------------------------------------------------------------------
-- name: "fyre : Follow deployment status (2 minute intervals)"
-  uri:
-    url: "https://ocpapi.svl.ibm.com/v1/ocp/{{ cluster_name }}/status"
-    user: "{{ fyre_username }}"
-    password: "{{ fyre_password }}"
-    method: GET
-    force_basic_auth: yes
-    validate_certs: false
-  register: _result
-  until:
-    - _result.json is defined
-    - _result.json.deployed_status == 'deployed'
-  retries: 60 # 60 * 2 minutes = 2 hours
-  delay: 120 # Every 2 minutes
+  when:
+    - _cluster_exist.json is defined
+    - _cluster_exist.json.owning_user is not defined # when there's no cluster owner, it means there's no cluster thus we create it

--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/fyre.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/fyre.yml
@@ -54,37 +54,36 @@
 
 # 4. Deploy the OCP+ cluster
 # -----------------------------------------------------------------------------
-- block:
-    - name: "fyre : Create new OCP+ cluster"
-      vars:
-        fyre_template_name: "templates/fyre/{{ fyre_quota_type }}.json.j2"
-      uri:
-        url: https://ocpapi.svl.ibm.com/v1/ocp/
-        user: "{{ fyre_username }}"
-        password: "{{ fyre_password }}"
-        method: POST
-        body: "{{ lookup('template', fyre_template_name) }}"
-        force_basic_auth: yes
-        body_format: json
-        validate_certs: false
 
-    # 5. Track the progress of the deployment
-    # -----------------------------------------------------------------------------
-    - name: "fyre : Follow deployment status (2 minute intervals)"
-      uri:
-        url: "https://ocpapi.svl.ibm.com/v1/ocp/{{ cluster_name }}/status"
-        user: "{{ fyre_username }}"
-        password: "{{ fyre_password }}"
-        method: GET
-        force_basic_auth: yes
-        validate_certs: false
-      register: _result
-      until:
-        - _result.json.deployed_status is defined
-        - _result.json.deployed_status == 'deployed'
-      retries: 60 # 60 * 2 minutes = 2 hours
-      delay: 120 # Every 2 minutes
-
+- name: "fyre : Create new OCP+ cluster"
   when:
     - _cluster_exist.json is defined
     - _cluster_exist.json.owning_user is not defined # when there's no cluster owner, it means there's no cluster thus we create it
+  vars:
+    fyre_template_name: "templates/fyre/{{ fyre_quota_type }}.json.j2"
+  uri:
+    url: https://ocpapi.svl.ibm.com/v1/ocp/
+    user: "{{ fyre_username }}"
+    password: "{{ fyre_password }}"
+    method: POST
+    body: "{{ lookup('template', fyre_template_name) }}"
+    force_basic_auth: yes
+    body_format: json
+    validate_certs: false
+
+# 5. Track the progress of the deployment
+# -----------------------------------------------------------------------------
+- name: "fyre : Follow deployment status (2 minute intervals)"
+  uri:
+    url: "https://ocpapi.svl.ibm.com/v1/ocp/{{ cluster_name }}/status"
+    user: "{{ fyre_username }}"
+    password: "{{ fyre_password }}"
+    method: GET
+    force_basic_auth: yes
+    validate_certs: false
+  register: _result
+  until:
+    - _result.json.deployed_status is defined
+    - _result.json.deployed_status == 'deployed'
+  retries: 60 # 60 * 2 minutes = 2 hours
+  delay: 120 # Every 2 minutes

--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/fyre.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/fyre.yml
@@ -83,6 +83,7 @@
     validate_certs: false
   register: _result
   until:
+    - _result.json is defined
     - _result.json.deployed_status is defined
     - _result.json.deployed_status == 'deployed'
   retries: 60 # 60 * 2 minutes = 2 hours

--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/fyre.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/fyre.yml
@@ -70,6 +70,11 @@
     force_basic_auth: yes
     body_format: json
     validate_certs: false
+  register: _cluster_create
+
+- name: "fyre : Debug cluster provision"
+  debug:
+    var: _cluster_create
 
 # 5. Track the progress of the deployment
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Fixing issue reported by @jeancrg 
https://ibm-watson-iot.slack.com/archives/C0195MVCEUD/p1687807344114479

This changes the fyre api and the `when` condition used to check if cluster exists prior provisioning or deprovisioning the quickburn cluster.