### PR TITLE
[patch] Add let's encrypt root cert to ocs config yaml

### DIFF
--- a/ibm/mas_devops/roles/cos/templates/ibm/objectstoragecfg.yml.j2
+++ b/ibm/mas_devops/roles/cos/templates/ibm/objectstoragecfg.yml.j2
@@ -35,50 +35,7 @@ spec:
     credentials:
       secretName: ibmcos-credentials-system
   certificates:
-    - alias: cospart1
-      crt: |
-        -----BEGIN CERTIFICATE-----
-        MIIHHTCCBgWgAwIBAgIQAkVuifU8dJwVm3dNjOUC3jANBgkqhkiG9w0BAQsFADBP
-        MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMSkwJwYDVQQDEyBE
-        aWdpQ2VydCBUTFMgUlNBIFNIQTI1NiAyMDIwIENBMTAeFw0yMDExMjMwMDAwMDBa
-        Fw0yMTEyMTMyMzU5NTlaMIGeMQswCQYDVQQGEwJVUzERMA8GA1UECBMITmV3IFlv
-        cmsxDzANBgNVBAcTBkFybW9uazE0MDIGA1UEChMrSW50ZXJuYXRpb25hbCBCdXNp
-        bmVzcyBNYWNoaW5lcyBDb3Jwb3JhdGlvbjE1MDMGA1UEAwwsKi5zMy51cy5jbG91
-        ZC1vYmplY3Qtc3RvcmFnZS5hcHBkb21haW4uY2xvdWQwggEiMA0GCSqGSIb3DQEB
-        AQUAA4IBDwAwggEKAoIBAQDD6J5CGPD9G57g+ODWlrhON7A1FgL8gFo0/WM8tfpR
-        YZ8m/E7mgj5M2BDi8itshGxPssgcZVfGJVlIw+J02ka1QlaLwGjC8CCQkxomU54x
-        yLFTpGUHivld/lutwesmbzXCodxc4cbWm/BxW8gYkFO5K2/kGyAe/f3dbwClQkn9
-        QN0SViFLA8QFLvuCzJFLHgOIoQNH0KhSZNxJ5axuuObHEVQPZJzqFCWIQhNZaYwR
-        tGHJ4Q5cHiR3iKHGzbaPcEPGNTfnkHp0aEjVgGxVivFD0wxIwylRnMpsp0NoRPj1
-        trBfAI/aVbbWq/e8/a0nK7EXA6gy8Kb5fvLM2h89iyhLAgMBAAGjggOjMIIDnzAf
-        BgNVHSMEGDAWgBS3a6LqqKqEjHnqtNoPmLLFlXa59DAdBgNVHQ4EFgQU7cqRk1nE
-        8fl180bcXXp3ldejjRgwgb0GA1UdEQSBtTCBsoIsKi5zMy51cy5jbG91ZC1vYmpl
-        Y3Qtc3RvcmFnZS5hcHBkb21haW4uY2xvdWSCKyouczMtYXBpLnVzLWdlby5vYmpl
-        Y3RzdG9yYWdlLnNvZnRsYXllci5uZXSCKnMzLnVzLmNsb3VkLW9iamVjdC1zdG9y
-        YWdlLmFwcGRvbWFpbi5jbG91ZIIpczMtYXBpLnVzLWdlby5vYmplY3RzdG9yYWdl
-        LnNvZnRsYXllci5uZXQwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUF
-        BwMBBggrBgEFBQcDAjCBiwYDVR0fBIGDMIGAMD6gPKA6hjhodHRwOi8vY3JsMy5k
-        aWdpY2VydC5jb20vRGlnaUNlcnRUTFNSU0FTSEEyNTYyMDIwQ0ExLmNybDA+oDyg
-        OoY4aHR0cDovL2NybDQuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0VExTUlNBU0hBMjU2
-        MjAyMENBMS5jcmwwTAYDVR0gBEUwQzA3BglghkgBhv1sAQEwKjAoBggrBgEFBQcC
-        ARYcaHR0cHM6Ly93d3cuZGlnaWNlcnQuY29tL0NQUzAIBgZngQwBAgIwfQYIKwYB
-        BQUHAQEEcTBvMCQGCCsGAQUFBzABhhhodHRwOi8vb2NzcC5kaWdpY2VydC5jb20w
-        RwYIKwYBBQUHMAKGO2h0dHA6Ly9jYWNlcnRzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2Vy
-        dFRMU1JTQVNIQTI1NjIwMjBDQTEuY3J0MAwGA1UdEwEB/wQCMAAwggEDBgorBgEE
-        AdZ5AgQCBIH0BIHxAO8AdQD2XJQv0XcwIhRUGAgwlFaO400TGTO/3wwvIAvMTvFk
-        4wAAAXX2a/wiAAAEAwBGMEQCIHWJPv+b4fFxWMwQeuH6Mbkox+iZ5cdQU9suI1JS
-        VZwNAiBUdb1HX99usWWmC6CauE684w4ys+tcQQJl3rFS5hTWPwB2AFzcQ5L+5qtF
-        RLFemtRW5hA3+9X6R9yhc5SyXub2xw7KAAABdfZr/G8AAAQDAEcwRQIgFyUzf28x
-        2n5QRr6/Z6Chbfca8OXxNwr6Y2v25iz5YtECIQCjPfDRHnxbZSGFxdcY8RgK68/u
-        swXWG0jxjzIj3dIMDDANBgkqhkiG9w0BAQsFAAOCAQEAQ/f4H7Eh+ZckgDICufKx
-        KHMvnmTq70PuDBazFrnNhY2aE29HJUB3jQDtTgIydp3BptaDUxqsPM0hAk84DUsv
-        CMRbwAwdmIrTEkfkvjxRWBQOsYBPTZS6t+FJ2MJUomluCJLLApGVqujlcJ6aS/vm
-        mbPGsaUKIXdhnKyWEFBlF1hvNqXrt8dPRemYnQxPaIDuAm5iNvKMZDA5GYskvHb6
-        umZWtGm5xejvLQGBYflIKYwVqfRjzLXrH9fBW4AT8PkmCeo63V5NJlfC9t6FcfSn
-        D9rS1O0EU4/Ns4J0wUOCS5xv7QwKiM+KyKS29UH23OQWEI2ggBs1ruC1wHge/kb7
-        xQ==
-        -----END CERTIFICATE-----
-    - alias: cospart2
+    - alias: ibmcos-intermediate-cert
       crt: |
         -----BEGIN CERTIFICATE-----
         MIIE6jCCA9KgAwIBAgIQCjUI1VwpKwF9+K1lwA/35DANBgkqhkiG9w0BAQsFADBh
@@ -109,7 +66,7 @@ spec:
         as6xuwAwapu3r9rxxZf+ingkquqTgLozZXq8oXfpf2kUCwA/d5KxTVtzhwoT0JzI
         8ks5T1KESaZMkE4f97Q=
         -----END CERTIFICATE-----
-    - alias: cospart3
+    - alias: ibmcos-root-cert
       crt: |
         -----BEGIN CERTIFICATE-----
         MIIDrzCCApegAwIBAgIQCDvgVpBCRrGhdWrJWZHHSjANBgkqhkiG9w0BAQUFADBh

--- a/ibm/mas_devops/roles/cos/templates/ocs/objectstoragecfg.yml.j2
+++ b/ibm/mas_devops/roles/cos/templates/ocs/objectstoragecfg.yml.j2
@@ -41,7 +41,7 @@ spec:
     - alias: cospart2
       crt: |
         {{ ocscos_certs[1] | indent(8) }}
-    - alias: isrg-root-x1
+    - alias: isrg-root-x1 # default root certificate used by Let's Encrypt
       crt: |
         -----BEGIN CERTIFICATE-----
         MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw
@@ -74,4 +74,3 @@ spec:
         mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d
         emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
         -----END CERTIFICATE-----
-    

--- a/ibm/mas_devops/roles/cos/templates/ocs/objectstoragecfg.yml.j2
+++ b/ibm/mas_devops/roles/cos/templates/ocs/objectstoragecfg.yml.j2
@@ -41,3 +41,37 @@ spec:
     - alias: cospart2
       crt: |
         {{ ocscos_certs[1] | indent(8) }}
+    - alias: isrg-root-x1
+      crt: |
+        -----BEGIN CERTIFICATE-----
+        MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw
+        TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
+        cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4
+        WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu
+        ZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY
+        MTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc
+        h77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+
+        0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U
+        A5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW
+        T8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyH
+        B5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UC
+        B5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUv
+        KBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWn
+        OlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTn
+        jh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbw
+        qHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CI
+        rU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNV
+        HRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkq
+        hkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZL
+        ubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ
+        3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KK
+        NFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5
+        ORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7Ur
+        TkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdC
+        jNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVc
+        oyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq
+        4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPA
+        mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d
+        emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
+        -----END CERTIFICATE-----
+    

--- a/ibm/mas_devops/roles/uds/templates/bascfg.yml.j2
+++ b/ibm/mas_devops/roles/uds/templates/bascfg.yml.j2
@@ -49,7 +49,7 @@ spec:
       crt: |
         {{ uds_tls_crt[1] | indent(8) }}
 {% endif %}
-    - alias: isrg-root-x1
+    - alias: isrg-root-x1 # default root certificate used by Let's Encrypt
       crt: |
         -----BEGIN CERTIFICATE-----
         MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw


### PR DESCRIPTION
Fixes for https://github.com/ibm-mas/ansible-devops/issues/570:
  - this adds root cert for let's encrypt so it works for ibm cloud hosted ocs (similar to what we have for uds)
  - also removes invalid/expired leaf cert from the cos certificate chain