### PR TITLE
[patch] Fix suite template

### DIFF
--- a/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
+++ b/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
@@ -36,12 +36,12 @@ spec:
       cpopen: "{{ mas_icr_cpopen }}"
 {% if  mas_add_catalog != '' or mas_add_channel != '' %}
     dataDictionary:
-    {% if mas_add_catalog != '' %}
+{% if mas_add_catalog != '' %}
       catalog: {{ mas_add_catalog }}
-    {% endif %}
-    {% if mas_add_channel != '' %}
+{% endif %}
+{% if mas_add_channel != '' %}
       channel: {{ mas_add_channel }}
-    {% endif %}
+{% endif %}
 {% endif %}
 {% if mas_channel != '8.8.x' and mas_channel != '8.9.x' and mas_customize_scaling != '' %}
     workloadScaling:


### PR DESCRIPTION
Spotted this problem introduced by one of the changes in `15.0.0-pre.master` testing:

```
TASK [ibm.mas_devops.suite_install : Create suite.ibm.com/v1 CR] ***************
Wednesday 12 July 2023  14:04:35 +0000 (0:00:00.029)       0:00:36.503 ******** 
An exception occurred during task execution. To see the full traceback, use -vvv. The error was:                          ^
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1689170675.3339348-267-195451354536423/AnsiballZ_k8s.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/root/.ansible/tmp/ansible-tmp-1689170675.3339348-267-195451354536423/AnsiballZ_k8s.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/root/.ansible/tmp/ansible-tmp-1689170675.3339348-267-195451354536423/AnsiballZ_k8s.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.kubernetes.core.plugins.modules.k8s', init_globals=dict(_module_fqn='ansible_collections.kubernetes.core.plugins.modules.k8s', _modlib_path=modlib_path),\n  File \"/usr/lib64/python3.9/runpy.py\", line 225, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib64/python3.9/runpy.py\", line 97, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib64/python3.9/runpy.py\", line 87, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_kubernetes.core.k8s_payload_emaq48yl/ansible_kubernetes.core.k8s_payload.zip/ansible_collections/kubernetes/core/plugins/modules/k8s.py\", line 397, in <module>\n  File \"/tmp/ansible_kubernetes.core.k8s_payload_emaq48yl/ansible_kubernetes.core.k8s_payload.zip/ansible_collections/kubernetes/core/plugins/modules/k8s.py\", line 393, in main\n  File \"/tmp/ansible_kubernetes.core.k8s_payload_emaq48yl/ansible_kubernetes.core.k8s_payload.zip/ansible_collections/kubernetes/core/plugins/modules/k8s.py\", line 376, in execute_module\n  File \"/tmp/ansible_kubernetes.core.k8s_payload_emaq48yl/ansible_kubernetes.core.k8s_payload.zip/ansible_collections/kubernetes/core/plugins/module_utils/common.py\", line 491, in set_resource_definitions\n  File \"/opt/app-root/lib64/python3.9/site-packages/yaml/__init__.py\", line 93, in load_all\n    yield loader.get_data()\n  File \"/opt/app-root/lib64/python3.9/site-packages/yaml/constructor.py\", line 45, in get_data\n    return self.construct_document(self.get_node())\n  File \"/opt/app-root/lib64/python3.9/site-packages/yaml/composer.py\", line 27, in get_node\n    return self.compose_document()\n  File \"/opt/app-root/lib64/python3.9/site-packages/yaml/composer.py\", line 55, in compose_document\n    node = self.compose_node(None, None)\n  File \"/opt/app-root/lib64/python3.9/site-packages/yaml/composer.py\", line 84, in compose_node\n    node = self.compose_mapping_node(anchor)\n  File \"/opt/app-root/lib64/python3.9/site-packages/yaml/composer.py\", line 133, in compose_mapping_node\n    item_value = self.compose_node(node, item_key)\n  File \"/opt/app-root/lib64/python3.9/site-packages/yaml/composer.py\", line 84, in compose_node\n    node = self.compose_mapping_node(anchor)\n  File \"/opt/app-root/lib64/python3.9/site-packages/yaml/composer.py\", line 133, in compose_mapping_node\n    item_value = self.compose_node(node, item_key)\n  File \"/opt/app-root/lib64/python3.9/site-packages/yaml/composer.py\", line 84, in compose_node\n    node = self.compose_mapping_node(anchor)\n  File \"/opt/app-root/lib64/python3.9/site-packages/yaml/composer.py\", line 133, in compose_mapping_node\n    item_value = self.compose_node(node, item_key)\n  File \"/opt/app-root/lib64/python3.9/site-packages/yaml/composer.py\", line 84, in compose_node\n    node = self.compose_mapping_node(anchor)\n  File \"/opt/app-root/lib64/python3.9/site-packages/yaml/composer.py\", line 127, in compose_mapping_node\n    while not self.check_event(MappingEndEvent):\n  File \"/opt/app-root/lib64/python3.9/site-packages/yaml/parser.py\", line 98, in check_event\n    self.current_event = self.state()\n  File \"/opt/app-root/lib64/python3.9/site-packages/yaml/parser.py\", line 428, in parse_block_mapping_key\n    if self.check_token(KeyToken):\n  File \"/opt/app-root/lib64/python3.9/site-packages/yaml/scanner.py\", line 116, in check_token\n    self.fetch_more_tokens()\n  File \"/opt/app-root/lib64/python3.9/site-packages/yaml/scanner.py\", line 223, in fetch_more_tokens\n    return self.fetch_value()\n  File \"/opt/app-root/lib64/python3.9/site-packages/yaml/scanner.py\", line 577, in fetch_value\n    raise ScannerError(None, None,\nyaml.scanner.ScannerError: mapping values are not allowed here\n  in \"<unicode string>\", line 20, column 22:\n                  channel: 1.1.x-stable\n                         ^\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

The issue is a simple formatting problem in the template.