### PR TITLE
[patch] Remove dbmConfig.INSTANCE_MEMORY

### DIFF
--- a/ibm/mas_devops/roles/db2/defaults/main.yml
+++ b/ibm/mas_devops/roles/db2/defaults/main.yml
@@ -73,8 +73,6 @@ db2_tolerate_effect: "{{ lookup('env', 'DB2_TOLERATE_EFFECT') }}"
 db2_default_config:
   dbConfig:
     APPLHEAPSZ: 8192 AUTOMATIC # Recommended heap memory size: https://www.ibm.com/docs/en/mas83/8.3.0?topic=dependencies-configure-database-health
-  dbmConfig:
-    INSTANCE_MEMORY: AUTOMATIC
   registry:
     DB2AUTH: 'OSAUTHDB,ALLOW_LOCAL_FALLBACK,PLUGIN_AUTO_RELOAD'
     DB2_4K_DEVICE_SUPPORT: '{{ db2_4k_device_support }}'


### PR DESCRIPTION
Detected a bad merge in the work to support db2 node labelling (#854).