### PR TITLE
[patch] More dbm_config cleanup

### DIFF
--- a/ibm/mas_devops/roles/db2/defaults/main.yml
+++ b/ibm/mas_devops/roles/db2/defaults/main.yml
@@ -80,7 +80,7 @@ db2_default_config:
     DB2_WORKLOAD: '{{ db2_workload }}'
 
 db2_database_db_config: "{{ lookup('env', 'DB2_DATABASE_DB_CONFIG') | ibm.mas_devops.db2_overwrite_config | default(db2_default_config.dbConfig, true) }}"
-db2_instance_dbm_config: "{{ lookup('env', 'DB2_INSTANCE_DBM_CONFIG') | ibm.mas_devops.db2_overwrite_config | default(db2_default_config.dbmConfig, true) }}"
+db2_instance_dbm_config: "{{ lookup('env', 'DB2_INSTANCE_DBM_CONFIG') | ibm.mas_devops.db2_overwrite_config | default("", true) }}"
 db2_instance_registry: "{{ lookup('env', 'DB2_INSTANCE_REGISTRY') | ibm.mas_devops.db2_overwrite_config |  default(db2_default_config.registry, true) }}"
 
 # Support DB2 MPP configurations


### PR DESCRIPTION
The default for `db2_instance_dbm_config` was left pointing at `db2_default_config.dbmConfig`, which has been removed as part of the previous fix.