### PR TITLE
[patch] Fix Turbonomic secret field names

### DIFF
--- a/ibm/mas_devops/roles/kubeturbo/templates/turbonomic-secret.yml.j2
+++ b/ibm/mas_devops/roles/kubeturbo/templates/turbonomic-secret.yml.j2
@@ -11,6 +11,6 @@ metadata:
 {% endfor %}
 {% endif %}
 stringData:
-  opsManagerPassword: "{{ turbonomic_password }}"
-  opsManagerUserName: "{{ turbonomic_username }}"
+  password: "{{ turbonomic_password }}"
+  username: "{{ turbonomic_username }}"
   


### PR DESCRIPTION
Update turbonomic update key name - to username and password

Ref: https://github.com/turbonomic/kubeturbo/wiki/OpenShift-Operator-Hub-Details#credentials-via-k8s-secret

CC: @pseemung 