### PR TITLE
[patch] Revert cis_crn validation

### DIFF
--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/main.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/main.yml
@@ -1,13 +1,4 @@
 ---
-- name: "cis : lookup cis instances with provided 'cis_crn' value"
-  shell: ibmcloud cis instances | grep {{ cis_crn }} | awk '{print $2}'
-  register: cis_instances_output
-
-- name: "cis : assert provided 'cis_crn' is valid"
-  assert:
-    that: cis_instances_output.stdout_lines | length > 0
-    fail_msg: "There is no CIS instance with the provided 'cis_crn' in the logged IBM Cloud account. Make sure the target CIS instance is deployed in the IBM Cloud account currently in use."
-
 - name: "cis : running standard cis suite dns"
   include_tasks: tasks/providers/cis/cis_suitedns_basic.yml
   when:


### PR DESCRIPTION
Based on feedback, i'm reverting the fix that was initially intended to check if provided CIS CRN in fact corresponds to a valid CIS instance in the logged IBM Cloud account here: https://github.com/ibm-mas/ansible-devops/pull/870

It seems like the used cis command can return unexpected output depending on the name of the cis instance being looked up and on top of that it uses `ibmcloud cis` plugin which is not installed as part of the cli (and wont be installed most of the times by customers) so it just creates more downsides than benefits.