### PR TITLE
[patch] Remove db2 heapsize setting

### DIFF
--- a/ibm/mas_devops/roles/suite_db2_setup_for_manage/templates/setupdb.sh.j2
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_manage/templates/setupdb.sh.j2
@@ -30,7 +30,6 @@ db2 update db cfg for {{ db2_dbname }} using AUTO_DB_BACKUP ON DEFERRED
 db2 update db cfg for {{ db2_dbname }} using CATALOGCACHE_SZ 800 DEFERRED
 db2 update db cfg for {{ db2_dbname }} using CHNGPGS_THRESH 40 DEFERRED
 db2 update db cfg for {{ db2_dbname }} using DBHEAP AUTOMATIC
-db2 update db cfg for {{ db2_dbname }} using APPLHEAPSZ 16384 DEFERRED
 db2 update db cfg for {{ db2_dbname }} using LOCKLIST AUTOMATIC DEFERRED
 db2 update db cfg for {{ db2_dbname }} using LOGBUFSZ 1024 DEFERRED
 db2 update db cfg for {{ db2_dbname }} using LOCKTIMEOUT 300 DEFERRED


### PR DESCRIPTION
This update removes the explicit heapsize setting added in #942, because it will cause problems when used with resource limits less than 16Gb.