### PR TITLE
[minor] Support cluster monitoring config without grafana

### DIFF
--- a/ibm/mas_devops/roles/cluster_monitoring/defaults/main.yml
+++ b/ibm/mas_devops/roles/cluster_monitoring/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+# Whether to perform an install or an uninstall
+cluster_monitoring_action: "{{ lookup('env', 'CLUSTER_MONITORING_ACTION') | default('install', true) }}"
+
 # --- Prometheous settings --------------------------------------------------------------------------------------------
 # Settings to update openshift monitoring to define a specific storage class for Prometheus logs
 prometheus_retention_period: "{{ lookup('env', 'PROMETHEUS_RETENTION_PERIOD') | default('15d', true) }}"
@@ -12,15 +15,19 @@ prometheus_userworkload_retention_period: "{{ lookup('env', 'PROMETHEUS_USERWORK
 prometheus_userworkload_storage_class: "{{ lookup('env', 'PROMETHEUS_USERWORKLOAD_STORAGE_CLASS') | default(lookup('env', 'PROMETHEUS_STORAGE_CLASS'), true) }}"
 prometheus_userworkload_storage_size: "{{ lookup('env', 'PROMETHEUS_USERWORKLOAD_STORAGE_SIZE') | default('300Gi', true) }}"
 
-# Settings to set grafana to define a specific storage class and size
-grafana_instance_storage_class: "{{ lookup('env', 'GRAFANA_INSTANCE_STORAGE_CLASS') }}"
-grafana_instance_storage_size: "{{ lookup('env', 'GRAFANA_INSTANCE_STORAGE_SIZE') | default('10Gi', true) }}"
+
+# --- Grafana settings ------------------------------------------------------------------------------------------------
+# Grafana is an optional part of the monitoring stack, by default it is disabled.
+cluster_monitoring_include_grafana: "{{ lookup('env', 'CLUSTER_MONITORING_INCLUDE_GRAFANA') | default('False', true) | bool }}"
 
 # Settings to set grafana location
 grafana_namespace: "{{ lookup('env', 'GRAFANA_NAMESPACE') | default('grafana', true) }}"
 
-# Whether to perform an install or an uninstall
-cluster_monitoring_action: "{{ lookup('env', 'CLUSTER_MONITORING_ACTION') | default('install', true) }}"
+# Settings to set grafana to define a specific storage class and size
+grafana_instance_storage_class: "{{ lookup('env', 'GRAFANA_INSTANCE_STORAGE_CLASS') }}"
+grafana_instance_storage_size: "{{ lookup('env', 'GRAFANA_INSTANCE_STORAGE_SIZE') | default('10Gi', true) }}"
 
+
+# --- Open Telemetry settings -----------------------------------------------------------------------------------------
 # OpenTelemetry is an optional part of the monitoring stack, by default it is disabled.
 cluster_monitoring_include_opentelemetry: "{{ lookup('env', 'CLUSTER_MONITORING_INCLUDE_OPENTELEMETRY') | default('False', true) | bool }}"

--- a/ibm/mas_devops/roles/cluster_monitoring/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/cluster_monitoring/tasks/install/main.yml
@@ -20,6 +20,7 @@
 # 3. Install and configure Grafana
 # -----------------------------------------------------------------------------
 - name: "install : Install Grafana"
+  when: cluster_monitoring_include_grafana
   include_tasks: tasks/install/grafana.yml
 
 

--- a/ibm/mas_devops/roles/cluster_monitoring/tasks/uninstall/main.yml
+++ b/ibm/mas_devops/roles/cluster_monitoring/tasks/uninstall/main.yml
@@ -10,6 +10,7 @@
 # 2. Uninstall Grafana
 # -----------------------------------------------------------------------------
 - name: "uninstall : Uninstall Grafana"
+  when: cluster_monitoring_include_grafana
   include_tasks: tasks/uninstall/grafana.yml
 
 

--- a/ibm/mas_devops/roles/mirror_ocp/README.md
+++ b/ibm/mas_devops/roles/mirror_ocp/README.md
@@ -9,17 +9,23 @@ Four actions are supported:
 - `from-filesystem` Mirror content from the local filesystem to your target registry
 - `install-catalogs` Install CatalogSources for the mirrored content.
 
-Three **CatalogSources** are created by the `install-catalogs` action in the `openshift-marketplace` namespace, containing the following content:
+Two **CatalogSources** are created by the `install-catalogs` action in the `openshift-marketplace` namespace, containing the following content:
 
 ### certified-operator-index
 - crunchy-postgres-operator (required by ibm.mas_devops.uds role)
 
-### community-operator-index
-- grafana-operator (required by ibm.mas_devops.cluster_monitoring role)
-
 ### redhat-operator-index
 - amq-streams (required by ibm.mas_devops.kafka role)
 - openshift-pipelines-operator-rh (required by the MAS CLI)
+
+!!! note
+    We are limited to the content we can support mirroring for today due to bug with Red Hat's support for OCI images, this prevents the mirroring of the following packages (which are all optional dependencies):
+
+    - **kubeturbo-certified**
+    - **grafana-operator**
+    - **opentelemetry-operator**
+
+    For more information refer to [solution 6997884](https://access.redhat.com/solutions/6997884) and [CFE 780](https://issues.redhat.com/browse/CFE-780).
 
 
 Requirements

--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -30,14 +30,14 @@ mirror:
         #   OCI index found, but accept header does not support OCI indexes
 
     # community-operators
-    - catalog: registry.redhat.io/redhat/community-operator-index:v{{ ocp_release }}
-      packages:
-        - name: grafana-operator  #  Required by ibm.mas_devops.cluster_monitoring role
-        # - name: opentelemetry-operator  # Required by ibm.mas_devops.cluster_monitoring role
-        #   OCI images are not supported by oc image mirror
-        #   https://access.redhat.com/solutions/6997884
-        #   https://issues.redhat.com/browse/CFE-780
-        #   OCI index found, but accept header does not support OCI indexes
+    # - catalog: registry.redhat.io/redhat/community-operator-index:v{{ ocp_release }}
+    #   packages:
+    #     - name: grafana-operator  #  Required by ibm.mas_devops.cluster_monitoring role
+    #     - name: opentelemetry-operator  # Required by ibm.mas_devops.cluster_monitoring role
+    #   OCI images are not supported by oc image mirror
+    #   https://access.redhat.com/solutions/6997884
+    #   https://issues.redhat.com/browse/CFE-780
+    #   OCI index found, but accept header does not support OCI indexes
 
     # redhat-operators
     - catalog: registry.redhat.io/redhat/redhat-operator-index:v{{ ocp_release }}


### PR DESCRIPTION
We continue to face issues where customers are unable to mirror OCI images due to lack of support on the base OCP product.  Until this is addressed all we can really do is work around the issue by making Grafana an optional part of the cluster monitoring stack that we set up :(

Ref:
- https://access.redhat.com/solutions/6997884
- https://issues.redhat.com/browse/CFE-780