### PR TITLE
ocp_config the ocp_operatorhub_disable_redhat_sources default value typo

### DIFF
--- a/ibm/mas_devops/roles/ocp_config/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_config/defaults/main.yml
@@ -13,4 +13,5 @@ ocp_ingress_server_timeout: "{{ lookup('env', 'OCP_INGRESS_SERVER_TIMEOUT') | de
 
 # Ingress Controller Settings
 # -----------------------------------------------------------------------------
-ocp_operatorhub_disable_redhat_sources: "{{ lookup('env', 'OCP_OPERATORHUB_DISABLE_REDHAT_SOURCES') | default('30s', true) }}"
+ocp_operatorhub_disable_redhat_sources: "{{ lookup('env', 'OCP_OPERATORHUB_DISABLE_REDHAT_SOURCES') | default('False', true) | bool }}"
+


### PR DESCRIPTION
The default value should be either True or False