### PR TITLE
[patch] Increase IoT install retries because of EdgeConfig

### DIFF
--- a/ibm/mas_devops/roles/suite_app_install/vars/iot.yml
+++ b/ibm/mas_devops/roles/suite_app_install/vars/iot.yml
@@ -4,4 +4,4 @@ mas_app_fqn: iots.iot.ibm.com
 mas_app_api_version: iot.ibm.com/v1
 mas_app_kind: IoT
 mas_app_install_delay: 120
-mas_app_install_retries: 30
+mas_app_install_retries: 60

--- a/ibm/mas_devops/roles/suite_app_install/vars/iot.yml
+++ b/ibm/mas_devops/roles/suite_app_install/vars/iot.yml
@@ -4,4 +4,4 @@ mas_app_fqn: iots.iot.ibm.com
 mas_app_api_version: iot.ibm.com/v1
 mas_app_kind: IoT
 mas_app_install_delay: 120
-mas_app_install_retries: 60
+mas_app_install_retries: 45


### PR DESCRIPTION
`EdgeConfig` component takes a long time to be ready. It has been experienced twice in a Fyre cluster. Refer to slack thread: https://ibm-watson-iot.slack.com/archives/C031Q7W21FZ/p1693519332957449?thread_ts=1692690544.888749&cid=C031Q7W21FZ