### PR TITLE
[patch] MongoDB version fix

### DIFF
--- a/ibm/mas_devops/roles/mongodb/README.md
+++ b/ibm/mas_devops/roles/mongodb/README.md
@@ -64,12 +64,6 @@ Community MongoDB Role Variables
 Role Variables
 -------------------------------------------------------------------------------
 
-### catalog_tag
-Set the MAS Catalog Version to indicate the version of MongoDb Community Edition to install.  Catalog versions can be found in common_vars/casebundles, for example v8-230725-amd64.  The role can be rerun with an upgraded catalog version.  Upgrading upwards is supported.  The MongoDb Community Edition Operator will be upgraded as well as the underlying MongoDb replicaset without lose of service.
-
-- Environment Variable: `MAS_CATALOG_VERSION`
-- Default: `v8-230725-amd64`
-
 ### mongodb_namespace
 The namespace where the operator and MongoDb cluster will be deployed.
 

--- a/ibm/mas_devops/roles/mongodb/defaults/main.yml
+++ b/ibm/mas_devops/roles/mongodb/defaults/main.yml
@@ -37,6 +37,9 @@ controlled_upgrade: false
 # Indicates if cluster_monitoring role has been run
 supports_integreatly_org: false
 
+# Version of Mongo installed when the IBM Catalog does is not installed or the corresponding CaseBundle does not exist
+mongo_extras_version_default: 4.4.21
+
 # aws documentdb vars
 # -----------------------------------------------------------------------------
 aws_access_key_id: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') }}"

--- a/ibm/mas_devops/roles/mongodb/defaults/main.yml
+++ b/ibm/mas_devops/roles/mongodb/defaults/main.yml
@@ -10,8 +10,6 @@ mongodb_action: "{{ lookup('env', 'MONGODB_ACTION') | default('install', true) }
 # mongodb community vars
 # -----------------------------------------------------------------------------
 
-catalog_tag: "{{ lookup('env', 'MAS_CATALOG_VERSION') | default ('v8-230725-amd64', True) }}"
-
 # Where to install the operator and create the mongo instance
 mongodb_namespace: "{{ lookup('env', 'MONGODB_NAMESPACE') | default('mongoce', True) }}"
 

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/install.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/install.yml
@@ -5,7 +5,7 @@
 - name: "Lookup ibm-operator-catalog"
   kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
-    name: ibm-operator-catalog2
+    name: ibm-operator-catalog
     namespace: openshift-marketplace
     kind: CatalogSource
   register: catalog_lookup

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/install.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/install.yml
@@ -1,16 +1,42 @@
 ---
 
-# 1. Check for undefined properties that do not have a default
+# 1. Get the IBM Catalog if available
 # -----------------------------------------------------------------------------
-- name: "Fail if catalog_tag is not provided"
-  assert:
-    that: catalog_tag is defined and catalog_tag != ""
+- name: "Lookup ibm-operator-catalog"
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    name: ibm-operator-catalog2
+    namespace: openshift-marketplace
+    kind: CatalogSource
+  register: catalog_lookup
+
+- set_fact:
+    catalog_tag: "{{ catalog_lookup.resources[0].spec.displayName.split('(')[1].split(')')[0].split(' ')[0] }}"
+  when:
+    - catalog_lookup.resources[0].spec.displayName is defined
+
+- name: "Catalog Version"
+  debug:
+    msg:
+      - "Catalog Version ............................ {{ catalog_tag }}"
+  when: catalog_tag is defined
 
 # 2. Load default settings
 # -----------------------------------------------------------------------------
 - name: Load CASE bundle versions
   include_vars:
     file: "{{ role_path }}/../../common_vars/casebundles/{{ catalog_tag }}.yml"
+  when: catalog_tag is defined and catalog_tag != ""
+
+- name: Set mongo version to default value when no catalog
+  set_fact:
+    mongo_extras_version: "{{ mongo_extras_version_default }}"
+  when: mongo_extras_version is not defined
+
+- name: "Mongo Version"
+  debug:
+    msg:
+      - "Mongo Version ............................ {{ mongo_extras_version }}"
 
 - name: Load mongo defaults
   include_vars:


### PR DESCRIPTION
Remove MongoDB community dependency on the ibm catalog version.  Instead dynamically lookup the installed catalog version or fallback to the default MongoDB version.