### PR TITLE
[minor] set kafka default to 3.5.1 to support amq-streams 2.5.0

### DIFF
--- a/ibm/mas_devops/roles/kafka/README.md
+++ b/ibm/mas_devops/roles/kafka/README.md
@@ -37,7 +37,7 @@ The version of Kafka to deploy by the operator. Before changing the kafka_versio
 by the [amq-streams operator version](https://access.redhat.com/documentation/en-us/red_hat_amq_streams) or [strimzi operator version](https://strimzi.io/downloads/).
 
 - Environment Variable: `KAFKA_VERSION`
-- Default Value: `3.3.1` for AMQ Streams and `3.5.1` for Strimzi.
+- Default Value: `3.5.1` for AMQ Streams and `3.5.1` for Strimzi.
 
 ### kafka_namespace
 The namespace where the operator and Kafka cluster will be deployed.

--- a/ibm/mas_devops/roles/kafka/defaults/main.yaml
+++ b/ibm/mas_devops/roles/kafka/defaults/main.yaml
@@ -12,7 +12,7 @@ kafka_defaults:
     operator_name: "strimzi-kafka-operator"
     alias_name: "Strimzi"
   redhat:
-    version: "3.3.1"
+    version: "3.5.1"
     namespace: "amq-streams"
     operator_name: "amq-streams"
     alias_name: "Red Hat AMQ Streams"


### PR DESCRIPTION
Update default kafka in amq-streams to 3.5.1. 
Redhat amq-streams v2.5 was released recently which supports kafka 3.4.x or greater. so we ll use the laetst 3.5.x  - kafka 3.5.1.

https://archive.apache.org/dist/kafka/3.5.1/RELEASE_NOTES.html

https://access.redhat.com/documentation/en-us/red_hat_amq_streams/2.5/html/release_notes_for_amq_streams_2.5_on_openshift/enhancements-str


