### PR TITLE
[patch] Fix SLS pre-condition in one_click_core

### DIFF
--- a/ibm/mas_devops/playbooks/oneclick_core.yml
+++ b/ibm/mas_devops/playbooks/oneclick_core.yml
@@ -28,8 +28,8 @@
           - lookup('env', 'MAS_INSTANCE_ID') != ""
           - lookup('env', 'MAS_CONFIG_DIR') != ""
           # SLS
-          - lookup('env', 'SLS_LICENSE_ID') != ""
-          - lookup('env', 'SLS_LICENSE_FILE') != ""
+          - (lookup('env', 'SLS_LICENSE_ID') != "" and lookup('env', 'SLS_LICENSE_FILE') != "") or
+            (lookup('env', 'SLS_ENTITLEMENT_FILE') != "")
           # UDS
           - lookup('env', 'UDS_CONTACT_EMAIL') != ""
           - lookup('env', 'UDS_CONTACT_FIRSTNAME') != ""


### PR DESCRIPTION
## Description

In `oneclick_core.yaml` we assert whether we have both `SLS_LICENSE_ID` and `SLS_LICENSE_FILE` but this is only required for SLS up to 3.6.0. From SLS 3.7.0 we will only need `SLS_ENTITLEMENT_FILE`. Hence, I made the assertion check for either (`SLS_LICENSE_ID` and `SLS_LICENSE_FILE`) or (`SLS_ENTITLEMENT_FILE`). The rest of the conditions are handled by the SLS role itself. 

## Related Issues

- https://github.com/ibm-mas/ansible-devops/issues/962