### PR TITLE
[patch] fix default amq streams kafka version to 3.5.0

### DIFF
--- a/ibm/mas_devops/roles/kafka/README.md
+++ b/ibm/mas_devops/roles/kafka/README.md
@@ -37,7 +37,7 @@ The version of Kafka to deploy by the operator. Before changing the kafka_versio
 by the [amq-streams operator version](https://access.redhat.com/documentation/en-us/red_hat_amq_streams) or [strimzi operator version](https://strimzi.io/downloads/).
 
 - Environment Variable: `KAFKA_VERSION`
-- Default Value: `3.5.1` for AMQ Streams and `3.5.1` for Strimzi.
+- Default Value: `3.5.0` for AMQ Streams and `3.5.1` for Strimzi.
 
 ### kafka_namespace
 The namespace where the operator and Kafka cluster will be deployed.

--- a/ibm/mas_devops/roles/kafka/defaults/main.yaml
+++ b/ibm/mas_devops/roles/kafka/defaults/main.yaml
@@ -12,7 +12,7 @@ kafka_defaults:
     operator_name: "strimzi-kafka-operator"
     alias_name: "Strimzi"
   redhat:
-    version: "3.5.1"
+    version: "3.5.0"
     namespace: "amq-streams"
     operator_name: "amq-streams"
     alias_name: "Red Hat AMQ Streams"


### PR DESCRIPTION
Update default kafka in amq-streams to 3.5.0.
Redhat amq-streams v2.5  supports kafka 3.4.0 or 3.5.0 only. it doesn't support 3.5.1

https://archive.apache.org/dist/kafka/3.5.0/RELEASE_NOTES.html

