### PR TITLE
[patch] Check StorageCluster Version using Status for ocs upgrade

### DIFF
--- a/ibm/mas_devops/roles/ocs/tasks/upgrade/main.yml
+++ b/ibm/mas_devops/roles/ocs/tasks/upgrade/main.yml
@@ -155,7 +155,7 @@
     - storage_cluster_info.resources | length > 0
   set_fact:
     storageCluster_name: "{{ storage_cluster_info.resources[0].metadata.name }}"
-    storageCluster_version: "{{ storage_cluster_info.resources[0].spec.version | regex_search('^([0-9]+)\\.([0-9]+)') }}"
+    storageCluster_version: "{{ storage_cluster_info.resources[0].status.version | regex_search('^([0-9]+)\\.([0-9]+)') }}"
 
 - name: "Update the storage cluster version if needed"
   when:


### PR DESCRIPTION
Sometimes the StorageCluster spec version is not available so use status version to determine if the StorageCluster needs an upgrade. 