### PR TITLE
[patch] Reduce default prometheus cluster_monitoring storage consumption

### DIFF
--- a/ibm/mas_devops/roles/cluster_monitoring/README.md
+++ b/ibm/mas_devops/roles/cluster_monitoring/README.md
@@ -48,7 +48,7 @@ Adjust the size of the volume used to store metrics, only used when both `promet
 
 - Optional
 - Environment Variable: `PROMETHEUS_STORAGE_SIZE`
-- Default Value: `300Gi`
+- Default Value: `20Gi`
 
 ### prometheus_alertmgr_storage_class
 Declare the storage class for AlertManager's persistent volume.
@@ -83,7 +83,7 @@ Adjust the size of the volume used to store User Workload metrics.
 
 - Optional
 - Environment Variable: `PROMETHEUS_USERWORKLOAD_STORAGE_SIZE`
-- Default Value: `300Gi`
+- Default Value: `20Gi`
 
 
 Role Variables - Grafana

--- a/ibm/mas_devops/roles/cluster_monitoring/defaults/main.yml
+++ b/ibm/mas_devops/roles/cluster_monitoring/defaults/main.yml
@@ -6,14 +6,14 @@ cluster_monitoring_action: "{{ lookup('env', 'CLUSTER_MONITORING_ACTION') | defa
 # Settings to update openshift monitoring to define a specific storage class for Prometheus logs
 prometheus_retention_period: "{{ lookup('env', 'PROMETHEUS_RETENTION_PERIOD') | default('15d', true) }}"
 prometheus_storage_class: "{{ lookup('env', 'PROMETHEUS_STORAGE_CLASS') }}"
-prometheus_storage_size: "{{ lookup('env', 'PROMETHEUS_STORAGE_SIZE') | default('300Gi', true) }}"
+prometheus_storage_size: "{{ lookup('env', 'PROMETHEUS_STORAGE_SIZE') | default('20Gi', true) }}"
 prometheus_alertmgr_storage_class: "{{ lookup('env', 'PROMETHEUS_ALERTMGR_STORAGE_CLASS') }}"
 prometheus_alertmgr_storage_size: "{{ lookup('env', 'PROMETHEUS_ALERTMGR_STORAGE_SIZE') | default('20Gi', true) }}"
 
 # Settings to update openshift user workload monitoring to define a specific storage class and size for Prometheus logs
 prometheus_userworkload_retention_period: "{{ lookup('env', 'PROMETHEUS_USERWORKLOAD_RETENTION_PERIOD') | default('15d', true) }}"
 prometheus_userworkload_storage_class: "{{ lookup('env', 'PROMETHEUS_USERWORKLOAD_STORAGE_CLASS') | default(lookup('env', 'PROMETHEUS_STORAGE_CLASS'), true) }}"
-prometheus_userworkload_storage_size: "{{ lookup('env', 'PROMETHEUS_USERWORKLOAD_STORAGE_SIZE') | default('300Gi', true) }}"
+prometheus_userworkload_storage_size: "{{ lookup('env', 'PROMETHEUS_USERWORKLOAD_STORAGE_SIZE') | default('20Gi', true) }}"
 
 
 # --- Grafana settings ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
the Prometheus PVC's consume almost 1.2 TB of storage on the cluster. this is a lot of unused storage that affects the cluster performance. 

reducing the default storage limits to 20Gi, 20 X 4 = 80Gi should be sufficient, this has a successful fvt run .

Slack discussions:
https://ibm-watson-iot.slack.com/archives/CNDB5GZ3P/p1694118152787259

![image](https://github.com/ibm-mas/ansible-devops/assets/110647904/01fce81e-8fc5-4220-b33f-95ecee738b9a)
