### PR TITLE
[minor] improve sls and install_operator role

### DIFF
--- a/ibm/mas_devops/roles/entitlement_key_rotation/tasks/rotate-ibm-entitlement.yml
+++ b/ibm/mas_devops/roles/entitlement_key_rotation/tasks/rotate-ibm-entitlement.yml
@@ -9,7 +9,7 @@
         name: 'ibm-entitlement'
         namespace: '{{ item }}'
       data:
-        .dockerconfigjson: "{{ lookup('template', 'templates/ibm-entitlement-with-artifactory.json.j2') | to_json | b64encode }}"
+        .dockerconfigjson: "{{ lookup('template', 'templates/ibm-entitlement-with-artifactory.json.j2') | to_nice_json | b64encode }}"
 
 - set_fact:
     namespace_summary_output: "{{ namespace_summary_output | default([]) + [item] }}"

--- a/ibm/mas_devops/roles/entitlement_key_rotation/tasks/rotate-wiotp-docker-local.yml
+++ b/ibm/mas_devops/roles/entitlement_key_rotation/tasks/rotate-wiotp-docker-local.yml
@@ -9,7 +9,7 @@
         name: 'wiotp-docker-local'
         namespace: 'openshift-marketplace'
       data:
-        .dockerconfigjson: "{{ lookup('template', 'templates/ibm-entitlement-with-artifactory.json.j2') | to_json | b64encode }}"
+        .dockerconfigjson: "{{ lookup('template', 'templates/ibm-entitlement-with-artifactory.json.j2') | to_nice_json | b64encode }}"
 
 - name: "Cluster {{ cluster_item }} - Set Namespaces where entitlement key was rotated"
   set_fact:

--- a/ibm/mas_devops/roles/install_operator/tasks/main.yml
+++ b/ibm/mas_devops/roles/install_operator/tasks/main.yml
@@ -1,5 +1,19 @@
 ---
-# 1. Create namespace we will deploy to
+# 1. Check artifactory_username/icr_username combination
+# -----------------------------------------------------------------------------
+- name: "Fail if icr_username is provided but not icr_password"
+  ansible.builtin.assert:
+    that: icr_password is defined and icr_password != ""
+    fail_msg: "icr_password property has not been set"
+  when: icr_username is defined and icr_username != ""
+
+- name: "Fail if artifactory_username is provided but not artifactory_token"
+  ansible.builtin.assert:
+    that: artifactory_token is defined and artifactory_token != ""
+    fail_msg: "artifactory_token property has not been set"
+  when: artifactory_username is defined and artifactory_username != ""
+
+# 2. Create namespace we will deploy to
 # -----------------------------------------------------------------------------
 - name: "Create namespace"
   kubernetes.core.k8s:
@@ -15,16 +29,16 @@
     name: "{{ namespace }}"
     definition: "{{ lookup('template', 'templates/custom_labels.json.j2') }}"
 
-# 2. Create an image pull secret for the pre-release catalog
+# 3. Create an image pull secret for the pre-release catalog
 # -----------------------------------------------------------------------------
 - name: "Debug Entitlement Secret Creation"
   debug:
     msg:
       - "Target Namespace ....................... {{ namespace }}"
       - "Artifactory Username ................... {{ artifactory_username | default('<undefined>', true) }}"
-      - "Artifactory Password ................... {{ '************' if (artifactory_token is defined) else '<undefined>' }}"
+      - "Artifactory Password ................... {{ (artifactory_token is defined and artifactory_token != '') | ternary('************', '<undefined>') }}"
       - "ICR Username ........................... {{ icr_username | default('<undefined>', true) }}"
-      - "ICR Password ........................... {{ '************' if (icr_password is defined) else '<undefined>' }}"
+      - "ICR Password ........................... {{ (icr_password is defined and icr_password != '') | ternary('************', '<undefined>') }}"
 
 - name: "Create ibm-entitlement secret"
   kubernetes.core.k8s:
@@ -36,9 +50,10 @@
         name: ibm-entitlement
         namespace: "{{ namespace }}"
       data:
-        .dockerconfigjson: "{{ lookup('template', 'templates/ibm-entitlement-with-artifactory.json.j2') | to_json | b64encode }}"
+        .dockerconfigjson: "{{ lookup('template', 'templates/ibm-entitlement-with-artifactory.json.j2') | to_nice_json | b64encode }}"
+  when: (icr_username is defined and icr_username != "") or (artifactory_username is defined and artifactory_username != "")
 
-# 3. Patch the default service account for pre-release build access
+# 4. Patch the default service account for pre-release build access
 # -----------------------------------------------------------------------------
 # If we don't do this then we won't be able to pull the operator image from
 # Artifactory
@@ -56,7 +71,7 @@
       imagePullSecrets:
         - name: ibm-entitlement
 
-# 4. Create the operator group that will scope the operator
+# 5. Create the operator group that will scope the operator
 # -----------------------------------------------------------------------------
 - name: "Create operator group"
   kubernetes.core.k8s:
@@ -64,7 +79,7 @@
     wait: yes
     wait_timeout: 60 # subsequent tasks will fail if the group isn't fully created
 
-# 5. Create the subscription for the operator
+# 6. Create the subscription for the operator
 # -----------------------------------------------------------------------------
 - name: "Create subscription"
   kubernetes.core.k8s:

--- a/ibm/mas_devops/roles/install_operator/templates/ibm-entitlement-with-artifactory.json.j2
+++ b/ibm/mas_devops/roles/install_operator/templates/ibm-entitlement-with-artifactory.json.j2
@@ -1,8 +1,22 @@
-{"auths":{
+{
+  "auths": {
 {% if artifactory_username is defined and artifactory_username != "" %}
-"docker-na-public.artifactory.swg-devops.com/wiotp-docker-local":{"username":"{{ artifactory_username }}","password":"{{ artifactory_token }}","auth":"{{ (artifactory_username ~ ':' ~ artifactory_token) | b64encode }}"},
+    "docker-na-public.artifactory.swg-devops.com/wiotp-docker-local": {
+      "username": "{{ artifactory_username }}",
+      "password": "{{ artifactory_token }}",
+      "auth": "{{ (artifactory_username ~ ':' ~ artifactory_token) | b64encode }}"
+  {% if icr_username is defined and icr_username != "" %}
+    },
+  {% else %}
+    }
+  {% endif %}
 {% endif %}
 {% if icr_username is defined and icr_username != "" %}
-"cp.icr.io/cp":{"username":"{{ icr_username }}","password":"{{ icr_password }}","auth":"{{ (icr_username ~ ':' ~ icr_password) | b64encode }}"}
+    "cp.icr.io/cp": {
+      "username": "{{ icr_username }}",
+      "password": "{{ icr_password }}",
+      "auth": "{{ (icr_username ~ ':' ~ icr_password) | b64encode }}"
+    }
 {% endif %}
-}}
+  }
+}

--- a/ibm/mas_devops/roles/install_operator/templates/ibm-entitlement-with-artifactory.json.j2
+++ b/ibm/mas_devops/roles/install_operator/templates/ibm-entitlement-with-artifactory.json.j2
@@ -2,4 +2,7 @@
 {% if artifactory_username is defined and artifactory_username != "" %}
 "docker-na-public.artifactory.swg-devops.com/wiotp-docker-local":{"username":"{{ artifactory_username }}","password":"{{ artifactory_token }}","auth":"{{ (artifactory_username ~ ':' ~ artifactory_token) | b64encode }}"},
 {% endif %}
-"cp.icr.io/cp":{"username":"{{ icr_username }}","password":"{{ icr_password }}","auth":"{{ (icr_username ~ ':' ~ icr_password) | b64encode }}"}}}
+{% if icr_username is defined and icr_username != "" %}
+"cp.icr.io/cp":{"username":"{{ icr_username }}","password":"{{ icr_password }}","auth":"{{ (icr_username ~ ':' ~ icr_password) | b64encode }}"}
+{% endif %}
+}}

--- a/ibm/mas_devops/roles/sls/README.md
+++ b/ibm/mas_devops/roles/sls/README.md
@@ -20,27 +20,6 @@ Role Variables - Installation
 -------------------------------------------------------------------------------
 If `sls_url` is set then the role will skip the installation of an SLS instance and simply generate the SLSCfg resource for the SLS instance defined.
 
-### ibm_entitlement_key
-Provide your [IBM entitlement key](https://myibm.ibm.com/products-services/containerlibrary).
-
-- **Required** unless `sls_url` is provided
-- Environment Variable: `IBM_ENTITLEMENT_KEY`
-- Default: None
-
-### sls_entitlement_username
-Username for entitled registry. This username will be used to create the image pull secret.
-
-- Optional
-- Environment Variable: `SLS_ENTITLEMENT_USERNAME`
-- Default: `cp`
-
-### sls_entitlement_key
-An IBM entitlement key specific for SLS installation, primarily used to override `ibm_entitlement_key` in development.
-
-- Optional
-- Environment Variable: `SLS_ENTITLEMENT_KEY`
-- Default: None
-
 ### artifactory_username
 Provide your artifactory username, primarily used to update the image pull secret in development.
 
@@ -76,13 +55,6 @@ Define the namespace where sls must be installed.
 - Environment Variable: `SLS_NAMESPACE`
 - Default: `ibm-sls`
 
-### sls_icr_cp [Deprecated in SLS 3.8.0]
-The container registry source for all container images deployed by the SLS operator. The api-licensing container image has moved to `cpopen` in SLS 3.8.0. Set this variable for SLS 3.7.0 and lower. Override to use development images.
-
-- Optional
-- Environment Variable: `SLS_ICR_CP`
-- Default: `cp.icr.io/cp`
-
 ### sls_icr_cpopen
 The container registry source for all container images deployed by the SLS operator. From SLS 3.8.0 onwards this will be the only variable to set the registry. Override to use development images.
 
@@ -96,6 +68,34 @@ Defines the instance ID to be used for SLS installation.
 - Optional
 - Environment Variable: `SLS_INSTANCE_NAME`
 - Default: `sls`
+
+### sls_icr_cp [Deprecated in SLS 3.8.0]
+The container registry source for all container images deployed by the SLS operator. The api-licensing container image has moved to `icr.io/cpopen` in SLS 3.8.0. Set this variable for SLS 3.7.0 and lower. Override to use development images.
+
+- Optional
+- Environment Variable: `SLS_ICR_CP`
+- Default: `cp.icr.io/cp`
+
+### ibm_entitlement_key [Deprecated in SLS 3.8.0]
+Provide your [IBM entitlement key](https://myibm.ibm.com/products-services/containerlibrary). This is now deprecated in SLS 3.8.0. Provide this only for versions up to 3.7.0.
+
+- **Required** unless `sls_url` is provided
+- Environment Variable: `IBM_ENTITLEMENT_KEY`
+- Default: None
+
+### sls_entitlement_username [Deprecated in SLS 3.8.0]
+Username for entitled registry. This username will be used to create the image pull secret. This is now deprecated in SLS 3.8.0. Provide this only for versions up to 3.7.0.
+
+- Optional
+- Environment Variable: `SLS_ENTITLEMENT_USERNAME`
+- Default: `cp`
+
+### sls_entitlement_key [Deprecated in SLS 3.8.0]
+An IBM entitlement key specific for SLS installation, primarily used to override `ibm_entitlement_key` in development. This is now deprecated in SLS 3.8.0. Provide this only for versions up to 3.7.0.
+
+- Optional
+- Environment Variable: `SLS_ENTITLEMENT_KEY`
+- Default: None
 
 
 Role Variables - Configuration
@@ -180,6 +180,17 @@ For examples refer to the [BestEfforts reference configuration in the MAS CLI](h
 - Default: None
 
 
+Role Variables - Bootstrap [SLS 3.7.0 and higher]
+-------------------------------------------------------------------------------
+
+### entitlement_file
+Defines the License File to be used to bootstrap SLS. Don't set if you wish to setup entitlement later on.
+
+- Optional
+- Environment Variable: `SLS_ENTITLEMENT_FILE`
+- Default: None
+
+
 Role Variables - Bootstrap [Partly deprecated in SLS 3.7.0]
 -------------------------------------------------------------------------------
 ### bootstrap.license_file [Deprecated in SLS 3.7.0]
@@ -201,16 +212,6 @@ Defines the Registration Key to be used to bootstrap SLS. Don't set if you wish 
 
 - Optional
 - Environment Variable: `SLS_REGISTRATION_KEY`
-- Default: None
-
-Role Variables - Upload License file [SLS 3.7.0 and higher]
--------------------------------------------------------------------------------
-
-### entitlement_file
-Defines the License File to be used to bootstrap SLS. Don't set if you wish to setup entitlement later on. Note: use this variable with SLS version 3.7.0 and higher. Do not set `bootstrap.license_id` as this will be extracted automatically from the license file. Do not set deprecated `bootstrap.license_file` as this will cause conflict.
-
-- Optional
-- Environment Variable: `SLS_ENTITLEMENT_FILE`
 - Default: None
 
 
@@ -296,12 +297,25 @@ Example Playbook
     - ibm.mas_devops.sls
 ```
 
-### Install and upload license file [from SLS 3.7.0]
+### Install and upload license file [SLS 3.7.0]
 ```yaml
 - hosts: localhost
   any_errors_fatal: true
   vars:
     ibm_entitlement_key: xxxx
+    mas_instance_id: inst1
+    sls_mongodb_cfg_file: "/etc/mas/mongodb.yml"
+    entitlement_file: "/etc/mas/entitlement.lic"
+
+  roles:
+    - ibm.mas_devops.sls
+```
+
+### Install and upload license file [from SLS 3.8.0]
+```yaml
+- hosts: localhost
+  any_errors_fatal: true
+  vars:
     mas_instance_id: inst1
     sls_mongodb_cfg_file: "/etc/mas/mongodb.yml"
     entitlement_file: "/etc/mas/entitlement.lic"

--- a/ibm/mas_devops/roles/sls/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/sls/tasks/install/main.yml
@@ -1,10 +1,35 @@
 ---
-# 1. Check for missing properties that do not have defaults
+# 1. Check SLS version and define version aware vars
+# -----------------------------------------------------------------------------
+- name: Check SLS version
+  ansible.builtin.include_tasks: "{{ role_path }}/../../common_tasks/get_version_from_channel.yml"
+  vars:
+    op_pm_name: "ibm-sls"
+    op_channel_name: "{{ sls_channel }}"
+
+- name: Set after_sls_380
+  ansible.builtin.set_fact:
+    after_sls_380: "{{ op_version is version('3.8.0', '>=') }}"
+
+- name: Set before_sls_380
+  ansible.builtin.set_fact:
+    before_sls_380: "{{ op_version is version('3.8.0', '<') }}"
+
+- name: Set after_sls_370
+  ansible.builtin.set_fact:
+    after_sls_370: "{{ op_version is version('3.7.0', '>=') }}"
+
+- name: Set before_sls_370
+  ansible.builtin.set_fact:
+    before_sls_370: "{{ op_version is version('3.7.0', '<') }}"
+
+# 2. Check for missing properties that do not have defaults
 # -----------------------------------------------------------------------------
 - name: "Fail if sls_entitlement_key has not been provided"
   ansible.builtin.assert:
     that: sls_entitlement_key is defined and sls_entitlement_key != ""
     fail_msg: "sls_entitlement_key property has not been set"
+  when: before_sls_380
 
 - name: "Fail if no MongoDb config is provided"
   ansible.builtin.assert:
@@ -20,26 +45,6 @@
       - sls_mongodb.password is defined
     fail_msg: "Review provided MongoDb details, it is missing required elements"
   when: sls_mongodb is defined
-
-# 2. Check SLS version and define version aware vars
-# -----------------------------------------------------------------------------
-- name: Check SLS version
-  ansible.builtin.include_tasks: "{{ role_path }}/../../common_tasks/get_version_from_channel.yml"
-  vars:
-    op_pm_name: "ibm-sls"
-    op_channel_name: "{{ sls_channel }}"
-
-- name: Set after_sls_380
-  ansible.builtin.set_fact:
-    after_sls_380: "{{ op_version is version('3.8.0', '>=') }}"
-
-- name: Set after_sls_370
-  ansible.builtin.set_fact:
-    after_sls_370: "{{ op_version is version('3.7.0', '>=') }}"
-
-- name: Set before_sls_370
-  ansible.builtin.set_fact:
-    before_sls_370: "{{ op_version is version('3.7.0', '<') }}"
 
 # 3. Determine Bootstrap
 # -----------------------------------------------------------------------------
@@ -205,8 +210,8 @@
     name: ibm.mas_devops.install_operator
   vars:
     namespace: "{{ sls_namespace }}"
-    icr_username: "{{ sls_entitlement_username }}"
-    icr_password: "{{ sls_entitlement_key }}"
+    icr_username: "{{ before_sls_380 | ternary(sls_entitlement_username, '') }}"
+    icr_password: "{{ before_sls_380 | ternary(sls_entitlement_key, '') }}"
     catalog_source: "{{ sls_catalog_source }}"
     operator_group: "{{ lookup('template', 'templates/operator-group.yml.j2') }}"
     subscription: "{{ lookup('template', 'templates/subscription.yml.j2') }}"

--- a/ibm/mas_devops/roles/sls/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/sls/tasks/install/main.yml
@@ -179,17 +179,7 @@
         msg: "Could not find '{{ mas_pod_templates_dir }}/{{ config_file_name }}' - Skipping"
       when: not pod_templates_file_lookup.stat.exists
 
-# 6. Create the namespace for SLS
-# -----------------------------------------------------------------------------
-- name: "Create SLS Namespace"
-  kubernetes.core.k8s:
-    definition:
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: "{{ sls_namespace }}"
-
-# 7. Set up the domain name for SLS
+# 6. Set up the domain name for SLS
 # -----------------------------------------------------------------------------
 - name: "Get cluster subdomain"
   kubernetes.core.k8s_info:
@@ -203,7 +193,7 @@
     sls_domain: "{{ sls_namespace }}.{{ _cluster_subdomain.resources[0].spec.domain }}"
   when: not sls_domain
 
-# 8. Install Operator & create entitlement
+# 7. Install Operator & create entitlement
 # -----------------------------------------------------------------------------
 - name: "Install SLS Operator"
   ansible.builtin.include_role:
@@ -216,7 +206,7 @@
     operator_group: "{{ lookup('template', 'templates/operator-group.yml.j2') }}"
     subscription: "{{ lookup('template', 'templates/subscription.yml.j2') }}"
 
-# 9. Wait until the LicenseService CRD is available
+# 8. Wait until the LicenseService CRD is available
 # -----------------------------------------------------------------------------
 - name: "Wait until the LicenseService CRD is available"
   kubernetes.core.k8s_info:
@@ -236,7 +226,7 @@
     - sls_crd_info.resources is defined
     - sls_crd_info.resources | length > 0
 
-# 10. Create Mongo Secret
+# 9. Create Mongo Secret
 # -----------------------------------------------------------------------------
 - name: Read MongoDb config file
   ansible.builtin.set_fact:
@@ -280,7 +270,7 @@
     namespace: "{{ sls_namespace }}"
     template: templates/mongo-secret.yml.j2
 
-# 11. Bootstrap the license service
+# 10. Bootstrap the license service
 # -----------------------------------------------------------------------------
 - name: Initialize Bootstrap
   when: bootstrap_mode
@@ -329,7 +319,7 @@
     - after_sls_370
     - entitlement_file != ""
 
-# 12. Integrated Airgap support
+# 11. Integrated Airgap support
 # -----------------------------------------------------------------------------
 # Before we create the CR we will set up the Airgap Image Map
 # We need to install the digest imagemap for ibm-sls and ibm-truststore-mgr
@@ -340,7 +330,7 @@
   ansible.builtin.include_tasks: "tasks/install/install_digest_cm.yml"
   when: airgap_install
 
-# 13. Create the license service CR
+# 12. Create the license service CR
 # -----------------------------------------------------------------------------
 - name: Create the sls.ibm.com/v1.LicenseService
   kubernetes.core.k8s:
@@ -349,12 +339,12 @@
     template: templates/licenseservice.yml.j2
   register: sls_cr_result
 
-# 14. Wait for it to hit Ready
+# 13. Wait for it to hit Ready
 # -----------------------------------------------------------------------------
 - name: Verify LicenseService CR
   ansible.builtin.include_tasks: "tasks/install/sls-verify.yml"
 
-# 15. Generate SLSCfg
+# 14. Generate SLSCfg
 # -----------------------------------------------------------------------------
 # The SLSCfg resource is not generated as part of this role anymore, a dedicated
 # role exists to generate the configuration file (gencfg_sls), this role will set


### PR DESCRIPTION
## Description

SLS 3.8.0 does no longer need the ibm-entitlement pull secret because api-licensing has moved to `icr.io/cpopen`.

### `sls` role
-  Updated README
    - Deprecated `ibm_entitlement_key`, `sls_entitlement_username`, and `sls_entitlement_key` in SLS `3.8.0`
    - Moved deprecated items towards bottom so that currently active ones are at the top
    - minor cleanup
- Added new fact `before_sls_380`
- Ensured `sls_entitlement_key` is only needed for SLS 3.7.0 and below
- Removed `Create SLS Namespace` task because it gets created in the `install_operator` role anyway
- Ensured `icr_username` and `icr_password` are only passed on to `install_operator` role when SLS 3.7.0 or lower is deployed
 
### `install_operator` role
- `ibm-entitlement-with-artifactory.json.j2`
  - Re-structured so that it is more friendly to the eye
  - Added if conditions to make both, artifactory and icr, auths optional
- Using `to_nice_json` throughout wherever `ibm-entitlement-with-artifactory.json.j2` is applied
- Added new checks to make sure if `artifactory_username` is set then `artifactory_token` must be set too - likewise if `icr_username` is set then `icr_password` must be set as well

## Testing

I ran the sls role locally against a fyre cluster.
_Note: `icr_username` always defaults to `cp` and therefore always passed on_

Test paths:
- Install SLS `3.8.0`
  - with `icr_password`, `artifactory_username`, and `artifactory_token` -> _creates ibm-entitlement with artifactory auth only_
  - with `icr_password` -> _no ibm-entitlement created_
  - with `artifactory_username` -> _assertion failure - must provide `artifactory_token`_
  - with no auth vars -> _no ibm-entitlement created_
- Install SLS `3.7.0`
  - with `icr_password`, `artifactory_username`, and `artifactory_token` -> _creates ibm-entitlement with artifactory and icr auth_
  - with `icr_password` -> _creates ibm-entitlement with icr auth only_
  - with `artifactory_username` and `artifactory_token` -> _assertion failure - must provide `icr_password`_
  - with `icr_password` and `artifactory_username` -> _assertion failure - must provide `artifactory_token`_

All of these outcomes were expected and where no assertion failure occurred SLS was installed successfully. 