### PR TITLE
[patch] add 8.11.x to compatibility matrix

### DIFF
--- a/ibm/mas_devops/common_vars/compatibility_matrix.yml
+++ b/ibm/mas_devops/common_vars/compatibility_matrix.yml
@@ -1,5 +1,13 @@
 ---
 compatibility_matrix:
+  8.11.x:
+    assist: [8.7.x, 8.8.x]
+    iot: [8.7.x, 8.8.x]
+    manage: [8.6.x, 8.7.x]
+    monitor: [8.10.x, 8.11.x]
+    optimizer: [8.4.x, 8.5.x]
+    predict: [8.8.x, 8.9.x]
+    visualinspection: [8.8.x, 8.9.x]
   8.10.x:
     assist: [8.6.x, 8.7.x]
     hputilities: [8.5.x, 8.6.x]
@@ -56,6 +64,7 @@ upgrade_requirement:
 
 # There is probably a better way to do this by manipulating the channel string, but this is fast and cheap!
 upgrade_path:
+  8.10.x: 8.11.x
   8.9.x: 8.10.x
   8.8.x: 8.9.x
   8.7.x: 8.8.x


### PR DESCRIPTION
Adding 8.11.x to compatibility matrix.

Fix for https://github.com/ibm-mas/ansible-devops/issues/1028