### PR TITLE
[patch] Fix support for kafka/ocs in mas update  

### DIFF
--- a/ibm/mas_devops/roles/kafka/tasks/main.yaml
+++ b/ibm/mas_devops/roles/kafka/tasks/main.yaml
@@ -6,4 +6,4 @@
       - "Kafka Action .................... {{ kafka_action }}"
 
 - name: Provision or Deprovision Kafka Instance
-  include_tasks: ../roles/tasks/provider/{{ kafka_provider }}/{{ kafka_action }}.yml
+  include_tasks: ../roles/kafka/tasks/provider/{{ kafka_provider }}/{{ kafka_action }}.yml

--- a/ibm/mas_devops/roles/kafka/tasks/main.yaml
+++ b/ibm/mas_devops/roles/kafka/tasks/main.yaml
@@ -6,4 +6,4 @@
       - "Kafka Action .................... {{ kafka_action }}"
 
 - name: Provision or Deprovision Kafka Instance
-  include_tasks: tasks/provider/{{ kafka_provider }}/{{ kafka_action }}.yml
+  include_tasks: ../roles/tasks/provider/{{ kafka_provider }}/{{ kafka_action }}.yml

--- a/ibm/mas_devops/roles/ocs/tasks/upgrade/main.yml
+++ b/ibm/mas_devops/roles/ocs/tasks/upgrade/main.yml
@@ -155,7 +155,7 @@
     - storage_cluster_info.resources | length > 0
   set_fact:
     storageCluster_name: "{{ storage_cluster_info.resources[0].metadata.name }}"
-    storageCluster_version: "{{ storage_cluster_info.resources[0].status.version | regex_search('^([0-9]+)\\.([0-9]+)') }}"
+    storageCluster_version: "{{ storage_cluster_info.resources[0].spec.version | regex_search('^([0-9]+)\\.([0-9]+)') }}"
 
 - name: "Update the storage cluster version if needed"
   when:

--- a/ibm/mas_devops/roles/ocs/tasks/upgrade/main.yml
+++ b/ibm/mas_devops/roles/ocs/tasks/upgrade/main.yml
@@ -153,9 +153,13 @@
   when:
     - storage_cluster_info.resources is defined
     - storage_cluster_info.resources | length > 0
+    - storage_cluster_info.resources[0].metadata is defined
+    - storage_cluster_info.resources[0].metadata.name is defined
+    - storage_cluster_info.resources[0].status is defined
+    - storage_cluster_info.resources[0].status.version is defined
   set_fact:
     storageCluster_name: "{{ storage_cluster_info.resources[0].metadata.name }}"
-    storageCluster_version: "{{ storage_cluster_info.resources[0].spec.version | regex_search('^([0-9]+)\\.([0-9]+)') }}"
+    storageCluster_version: "{{ storage_cluster_info.resources[0].status.version | regex_search('^([0-9]+)\\.([0-9]+)') }}"
 
 - name: "Update the storage cluster version if needed"
   when:


### PR DESCRIPTION
while testing mas update cli I found these 2 code changes to be necessary.  
There's an update for kafka provider path and an update to ocs.