### PR TITLE
[patch]  use old-galaxy.ansible.com url until we migrate

### DIFF
--- a/.github/workflows/ansible-publish.yml
+++ b/.github/workflows/ansible-publish.yml
@@ -41,7 +41,7 @@ jobs:
       # Publish
       - name: Publish Collection
         run: |
-          ansible-galaxy collection publish ${{ github.workspace }}/ibm/mas_devops/ibm-mas_devops-${{ env.VERSION }}.tar.gz --token=${{ secrets.ANSIBLE_GALAXY_TOKEN }}
+          ansible-galaxy collection publish --server "https://old-galaxy.ansible.com/" ${{ github.workspace }}/ibm/mas_devops/ibm-mas_devops-${{ env.VERSION }}.tar.gz --token=${{ secrets.ANSIBLE_GALAXY_TOKEN }}
 
       - name: Trigger ibm-mas/cli rebuild on Ansible Collection release
         run: |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Ansible DevOps Collection for IBM Maximo Application Suite
-![Ansible Galaxy Release](https://img.shields.io/badge/dynamic/json?style=flat&label=galaxy&prefix=v&url=https://galaxy.ansible.com/api/v2/collections/ibm/mas_devops/&query=latest_version.version)
+![Ansible Galaxy Release](https://img.shields.io/badge/dynamic/json?style=flat&label=galaxy&prefix=v&url=https://old-galaxy.ansible.com/api/v2/collections/ibm/mas_devops/&query=latest_version.version)
 
 
 ## Installation


### PR DESCRIPTION
The [new Ansible Galaxy service](https://forum.ansible.com/t/new-ansible-galaxy/1155) went live on September 30th,
To continue using old service, we need to use `https://old-galaxy.ansible.com/` url.