### PR TITLE
[patch] Improve Mongodb catalog error handling

### DIFF
--- a/ibm/mas_devops/playbooks/mirror_add_monitor.yml
+++ b/ibm/mas_devops/playbooks/mirror_add_monitor.yml
@@ -50,3 +50,4 @@
       vars:
         manifest_name: ibm-mas-monitor
         manifest_version: "{{ lookup('env', 'MAS_MONITOR_VERSION') | default (mas_monitor_version[mas_channel], True) }}"
+

--- a/ibm/mas_devops/playbooks/mirror_add_monitor.yml
+++ b/ibm/mas_devops/playbooks/mirror_add_monitor.yml
@@ -50,4 +50,3 @@
       vars:
         manifest_name: ibm-mas-monitor
         manifest_version: "{{ lookup('env', 'MAS_MONITOR_VERSION') | default (mas_monitor_version[mas_channel], True) }}"
-

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/install.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/install.yml
@@ -1,13 +1,13 @@
 ---
 
-# The MongoDB version is based on the chosen ibm-operator-catalog.  However the 
-# ibm-operator-catalog does not explicitly include information about the mongo version.  
+# The MongoDB version is based on the chosen ibm-operator-catalog.  However the
+# ibm-operator-catalog does not explicitly include information about the mongo version.
 #
-# The configuration files in common_vars/casebundles do specify the MongoDB 
-# version for each of the MAS published ibm-operator-catalog catalogs.  
+# The configuration files in common_vars/casebundles do specify the MongoDB
+# version for each of the MAS published ibm-operator-catalog catalogs.
 #
-# To determine which common_vars/casebundles configuration file to use, this role 
-# extracts the catalog_tag from the ibm-operator-catalog's displayName.  
+# To determine which common_vars/casebundles configuration file to use, this role
+# extracts the catalog_tag from the ibm-operator-catalog's displayName.
 #
 # For example:
 #   displayName: IBM Maximo Operators (v8-230926-amd64)
@@ -15,12 +15,12 @@
 # catalog_tag is v8-230926-amd64
 # MongoDB version will be determined by loading common_vars/casebundles/v8-230926-amd64.yml
 #
-# And FINALLY... 
+# And FINALLY...
 #   If the MongoDB version cannot be determined from the above logic,
-#   the MongoDB version will be determined by the last configuration file in 
+#   the MongoDB version will be determined by the last configuration file in
 #   common_vars/casebundles/
 #
-#   And if still it cannot be determined because perhaps its not specified in the 
+#   And if still it cannot be determined because perhaps its not specified in the
 #   configuration file, a default value will be used.
 
 # List the common_vars/casebundle configuration files
@@ -34,7 +34,7 @@
 # Determine the last configuration file in the list just in case we need it later
 - set_fact:
     last_catalog_tag: "{{ find_result['files'] | map(attribute='path') | map('regex_replace', '^.*/(.*).yml$', '\\1') | last }}"
-  when find_result is defined
+  when: find_result is defined
 
 # Display the Last Catalog Version
 - name: "Display the Last Catalog Version"
@@ -62,12 +62,12 @@ block:
     stat:
       path: "{{ role_path }}/../../common_vars/casebundles/{{ catalog_tag }}.yml"
     register: file_exists_result
-    when catalog_tag is defined
+    when: catalog_tag is defined
 
   # use last_catalog_tag if the casebundles file does not exist
   - set_fact:
       catalog_tag: last_catalog_tag
-    when: 
+    when:
       - not file_exists_result.stat.exists
       - last_catalog_tag is defined
 
@@ -75,14 +75,14 @@ rescue:
   # use the last_catalog_tag when the catalog_tag cannot be determined from the displayName
   - set_fact:
       catalog_tag: last_catalog_tag
-    when last_catalog_tag is defined
+    when: last_catalog_tag is defined
 
 # check again if the file exists to be certain we have a valid catalog_tag
 - name: Check again if file exists in casebundles
   stat:
     path: "{{ role_path }}/../../common_vars/casebundles/{{ catalog_tag }}.yml"
   register: stat_result
-  when catalog_tag is defined
+  when: catalog_tag is defined
 
 - name: "Catalog Version"
   debug:

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/install.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/install.yml
@@ -10,7 +10,8 @@
 # extracts the catalog_tag from the ibm-operator-catalog's displayName.  
 #
 # For example:
-#     displayName: IBM Maximo Operators (v8-230926-amd64)
+#   displayName: IBM Maximo Operators (v8-230926-amd64)
+#
 # catalog_tag is v8-230926-amd64
 # MongoDB version will be determined by loading common_vars/casebundles/v8-230926-amd64.yml
 #

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/install.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/install.yml
@@ -1,7 +1,48 @@
 ---
 
-# 1. Get the IBM Catalog if available
-# -----------------------------------------------------------------------------
+# The MongoDB version is based on the chosen ibm-operator-catalog.  However the 
+# ibm-operator-catalog does not explicitly include information about the mongo version.  
+#
+# The configuration files in common_vars/casebundles do specify the MongoDB 
+# version for each of the MAS published ibm-operator-catalog catalogs.  
+#
+# To determine which common_vars/casebundles configuration file to use, this role 
+# extracts the catalog_tag from the ibm-operator-catalog's displayName.  
+#
+# For example:
+#     displayName: IBM Maximo Operators (v8-230926-amd64)
+# catalog_tag is v8-230926-amd64
+# MongoDB version will be determined by loading common_vars/casebundles/v8-230926-amd64.yml
+#
+# And FINALLY... 
+#   If the MongoDB version cannot be determined from the above logic,
+#   the MongoDB version will be determined by the last configuration file in 
+#   common_vars/casebundles/
+#
+#   And if still it cannot be determined because perhaps its not specified in the 
+#   configuration file, a default value will be used.
+
+# List the common_vars/casebundle configuration files
+- name: "List yml files in common_vars/casebundles folder"
+  find:
+    paths: "{{ role_path }}/../../common_vars/casebundles"
+    patterns: '*.yml'
+    file_type: "file"
+  register: find_result
+
+# Determine the last configuration file in the list just in case we need it later
+- set_fact:
+    last_catalog_tag: "{{ find_result['files'] | map(attribute='path') | map('regex_replace', '^.*/(.*).yml$', '\\1') | last }}"
+  when find_result is defined
+
+# Display the Last Catalog Version
+- name: "Display the Last Catalog Version"
+  debug:
+    msg:
+      - "Last Catalog Version ............................ {{ last_catalog_tag }}"
+  when: last_catalog_tag is defined
+
+# Get the IBM Catalog if available
 - name: "Lookup ibm-operator-catalog"
   kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
@@ -10,24 +51,43 @@
     kind: CatalogSource
   register: catalog_lookup
 
-- set_fact:
-    catalog_tag: "{{ catalog_lookup.resources[0].spec.displayName.split('(')[1].split(')')[0].split(' ')[0] }}"
-  when:
-    - catalog_lookup.resources[0].spec.displayName is defined
+block:
+  # extract the catalog tag from displayName
+  - set_fact:
+      catalog_tag: "{{ catalog_lookup.resources[0].spec.displayName.split('(')[1].split(')')[0].split(' ')[0] }}"
+    when: catalog_lookup is defined
+
+  - name: Check if file exists in casebundles
+    stat:
+      path: "{{ role_path }}/../../common_vars/casebundles/{{ catalog_tag }}.yml"
+    register: file_exists_result
+    when catalog_tag is defined
+
+  # use last_catalog_tag if the casebundles file does not exist
+  - set_fact:
+      catalog_tag: last_catalog_tag
+    when: 
+      - not file_exists_result.stat.exists
+      - last_catalog_tag is defined
+
+rescue:
+  # use the last_catalog_tag when the catalog_tag cannot be determined from the displayName
+  - set_fact:
+      catalog_tag: last_catalog_tag
+    when last_catalog_tag is defined
+
+# check again if the file exists to be certain we have a valid catalog_tag
+- name: Check again if file exists in casebundles
+  stat:
+    path: "{{ role_path }}/../../common_vars/casebundles/{{ catalog_tag }}.yml"
+  register: stat_result
+  when catalog_tag is defined
 
 - name: "Catalog Version"
   debug:
     msg:
       - "Catalog Version ............................ {{ catalog_tag }}"
   when: catalog_tag is defined
-
-# 2. Load default settings
-# -----------------------------------------------------------------------------
-- name: Check if file exists in casebundles
-  stat:
-    path: "{{ role_path }}/../../common_vars/casebundles/{{ catalog_tag }}.yml"
-  register: stat_result
-  when: catalog_tag is defined and catalog_tag != ""
 
 - name: Load CASE bundle versions
   include_vars:

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/install.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/install.yml
@@ -68,7 +68,7 @@
 
     # use last_catalog_tag if the casebundles file does not exist
     - set_fact:
-        catalog_tag: last_catalog_tag
+        catalog_tag: "{{ last_catalog_tag }}"
       when:
         - not file_exists_result.stat.exists
         - last_catalog_tag is defined and last_catalog_tag != ""
@@ -76,7 +76,7 @@
   rescue:
     # use the last_catalog_tag when the catalog_tag cannot be determined from the displayName
     - set_fact:
-        catalog_tag: last_catalog_tag
+        catalog_tag: "{{ last_catalog_tag }}"
       when: last_catalog_tag is defined and last_catalog_tag != ""
 
 - name: "Catalog Version"

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/install.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/install.yml
@@ -58,7 +58,13 @@
     # extract the catalog tag from displayName
     - set_fact:
         catalog_tag: "{{ catalog_lookup.resources[0].spec.displayName.split('(')[1].split(')')[0].split(' ')[0] }}"
-      when: catalog_lookup is defined
+      when: 
+        - catalog_lookup is defined
+        - catalog_lookup.resources is defined
+        - catalog_lookup.resources | length > 0
+        - catalog_lookup.resources[0].spec is defined
+        - catalog_lookup.resources[0].spec.displayName is defined
+        - "(" in catalog_lookup.resources[0].spec.displayName
 
     - name: Check if file exists in casebundles
       stat:

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/install.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/install.yml
@@ -41,7 +41,7 @@
   debug:
     msg:
       - "Last Catalog Version ............................ {{ last_catalog_tag }}"
-  when: last_catalog_tag is defined
+  when: last_catalog_tag is defined and last_catalog_tag != ""
 
 # 1. Get the IBM Catalog if available
 # -----------------------------------------------------------------------------
@@ -64,26 +64,26 @@
       stat:
         path: "{{ role_path }}/../../common_vars/casebundles/{{ catalog_tag }}.yml"
       register: file_exists_result
-      when: catalog_tag is defined
+      when: catalog_tag is defined and catalog_tag != ""
 
     # use last_catalog_tag if the casebundles file does not exist
     - set_fact:
         catalog_tag: last_catalog_tag
       when:
         - not file_exists_result.stat.exists
-        - last_catalog_tag is defined
+        - last_catalog_tag is defined and last_catalog_tag != ""
 
   rescue:
     # use the last_catalog_tag when the catalog_tag cannot be determined from the displayName
     - set_fact:
         catalog_tag: last_catalog_tag
-      when: last_catalog_tag is defined
+      when: last_catalog_tag is defined and last_catalog_tag != ""
 
 - name: "Catalog Version"
   debug:
     msg:
       - "Catalog Version ............................ {{ catalog_tag }}"
-  when: catalog_tag is defined
+  when: catalog_tag is defined and catalog_tag != ""
 
 # 2. Load default settings
 # -----------------------------------------------------------------------------
@@ -91,7 +91,7 @@
   stat:
     path: "{{ role_path }}/../../common_vars/casebundles/{{ catalog_tag }}.yml"
   register: stat_result
-  when: catalog_tag is defined
+  when: catalog_tag is defined and catalog_tag != ""
 
 - name: Load CASE bundle versions
   include_vars:

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/install.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/install.yml
@@ -43,7 +43,8 @@
       - "Last Catalog Version ............................ {{ last_catalog_tag }}"
   when: last_catalog_tag is defined
 
-# Get the IBM Catalog if available
+# 1. Get the IBM Catalog if available
+# -----------------------------------------------------------------------------
 - name: "Lookup ibm-operator-catalog"
   kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
@@ -52,42 +53,44 @@
     kind: CatalogSource
   register: catalog_lookup
 
-block:
-  # extract the catalog tag from displayName
-  - set_fact:
-      catalog_tag: "{{ catalog_lookup.resources[0].spec.displayName.split('(')[1].split(')')[0].split(' ')[0] }}"
-    when: catalog_lookup is defined
+- name: "Determine catalog version from catalog displayName"
+  block:
+    # extract the catalog tag from displayName
+    - set_fact:
+        catalog_tag: "{{ catalog_lookup.resources[0].spec.displayName.split('(')[1].split(')')[0].split(' ')[0] }}"
+      when: catalog_lookup is defined
 
-  - name: Check if file exists in casebundles
-    stat:
-      path: "{{ role_path }}/../../common_vars/casebundles/{{ catalog_tag }}.yml"
-    register: file_exists_result
-    when: catalog_tag is defined
+    - name: Check if file exists in casebundles
+      stat:
+        path: "{{ role_path }}/../../common_vars/casebundles/{{ catalog_tag }}.yml"
+      register: file_exists_result
+      when: catalog_tag is defined
 
-  # use last_catalog_tag if the casebundles file does not exist
-  - set_fact:
-      catalog_tag: last_catalog_tag
-    when:
-      - not file_exists_result.stat.exists
-      - last_catalog_tag is defined
+    # use last_catalog_tag if the casebundles file does not exist
+    - set_fact:
+        catalog_tag: last_catalog_tag
+      when:
+        - not file_exists_result.stat.exists
+        - last_catalog_tag is defined
 
-rescue:
-  # use the last_catalog_tag when the catalog_tag cannot be determined from the displayName
-  - set_fact:
-      catalog_tag: last_catalog_tag
-    when: last_catalog_tag is defined
-
-# check again if the file exists to be certain we have a valid catalog_tag
-- name: Check again if file exists in casebundles
-  stat:
-    path: "{{ role_path }}/../../common_vars/casebundles/{{ catalog_tag }}.yml"
-  register: stat_result
-  when: catalog_tag is defined
+  rescue:
+    # use the last_catalog_tag when the catalog_tag cannot be determined from the displayName
+    - set_fact:
+        catalog_tag: last_catalog_tag
+      when: last_catalog_tag is defined
 
 - name: "Catalog Version"
   debug:
     msg:
       - "Catalog Version ............................ {{ catalog_tag }}"
+  when: catalog_tag is defined
+
+# 2. Load default settings
+# -----------------------------------------------------------------------------
+- name: Check again if file exists in casebundles
+  stat:
+    path: "{{ role_path }}/../../common_vars/casebundles/{{ catalog_tag }}.yml"
+  register: stat_result
   when: catalog_tag is defined
 
 - name: Load CASE bundle versions

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/install.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/install.yml
@@ -58,13 +58,13 @@
     # extract the catalog tag from displayName
     - set_fact:
         catalog_tag: "{{ catalog_lookup.resources[0].spec.displayName.split('(')[1].split(')')[0].split(' ')[0] }}"
-      when: 
+      when:
         - catalog_lookup is defined
         - catalog_lookup.resources is defined
         - catalog_lookup.resources | length > 0
         - catalog_lookup.resources[0].spec is defined
         - catalog_lookup.resources[0].spec.displayName is defined
-        - "(" in catalog_lookup.resources[0].spec.displayName
+        - '"(" in catalog_lookup.resources[0].spec.displayName'
 
     - name: Check if file exists in casebundles
       stat:
@@ -76,7 +76,17 @@
     - set_fact:
         catalog_tag: "{{ last_catalog_tag }}"
       when:
+        - file_exists_result is defined
+        - file_exists_result.stat is defined
+        - file_exists_result.stat.exists is defined
         - not file_exists_result.stat.exists
+        - last_catalog_tag is defined and last_catalog_tag != ""
+
+    # use last_catalog_tag if unable to get catalog_tag from displayName
+    - set_fact:
+        catalog_tag: "{{ last_catalog_tag }}"
+      when:
+        - catalog_tag is not defined
         - last_catalog_tag is defined and last_catalog_tag != ""
 
   rescue:


### PR DESCRIPTION
Add better error handling for the scenario where the ibm-operator-catalog does not include the build tag in the displayName. In this case default to the latest choice.