### PR TITLE
[patch] Update kafka role path

### DIFF
--- a/ibm/mas_devops/roles/kafka/tasks/main.yaml
+++ b/ibm/mas_devops/roles/kafka/tasks/main.yaml
@@ -6,4 +6,4 @@
       - "Kafka Action .................... {{ kafka_action }}"
 
 - name: Provision or Deprovision Kafka Instance
-  include_tasks: ../roles/kafka/tasks/provider/{{ kafka_provider }}/{{ kafka_action }}.yml
+  include_tasks: "{{ role_path }}/tasks/provider/{{ kafka_provider }}/{{ kafka_action }}.yml"


### PR DESCRIPTION
Recently the kafka role main task was updated from 
```include_tasks: tasks/provider/{{ kafka_provider }}/{{ kafka_action }}.yml```

to
```include_tasks: ../roles/kafka/tasks/provider/{{ kafka_provider }}/{{ kafka_action }}.yml```

This update worked for running "mas update" however it broke the performance teams scripts, they apparently have their own playbooks.

Therefore I am updating the code to be
```include_tasks: "{{ role_path }}/tasks/provider/{{ kafka_provider }}/{{ kafka_action }}.yml"```


