### PR TITLE
[patch] Add Amlen entry to MAS ICSP

### DIFF
--- a/ibm/mas_devops/roles/ocp_contentsourcepolicy/templates/imagecontentsourcepolicy.yml.j2
+++ b/ibm/mas_devops/roles/ocp_contentsourcepolicy/templates/imagecontentsourcepolicy.yml.j2
@@ -44,6 +44,10 @@ spec:
     - source: quay.io/mongodb
       mirrors:
         - {{ registry_private_url }}/mongodb
+    # Eclipse Amlen - Message Broker for IoT/Mobile/Web. Mainly uses MQTT v3.x and v5.
+    - source: quay.io/amlen
+      mirrors:
+        - {{ registry_private_url }}/amlen
     # Non-product IBM Maximo Application Suite images (e.g. db2 backup operator & mirror of dockerhub mongodb image)
     - source: quay.io/ibmmas
       mirrors:


### PR DESCRIPTION
Newer release of Maximo IoT replaced the internal MessageSight MQTT message broker with [Eclipse Amlen](https://github.com/eclipse/amlen), however the ICSP has not been updated to configure mirroring for Amlen in quay.io, which means IoT can not be installed in a disconnected environment using our ICSP without the user adding further policies.