### PR TITLE
[patch] add 8.9.x channel to all apps  in 231004 case vars

### DIFF
--- a/ibm/mas_devops/common_vars/casebundles/v8-231004-amd64.yml
+++ b/ibm/mas_devops/common_vars/casebundles/v8-231004-amd64.yml
@@ -40,9 +40,11 @@ mas_core_version:
 mas_assist_version:
   8.10.x: 8.7.2   # No Update
   8.11.x: 8.8.0   # No Update
+  8.9.x: 8.6.5    # No Update
 mas_hputilities_version:
   8.10.x: 8.6.2   # No Update
   8.11.x: ""      # Not Supported
+  8.9.x: 8.5.3    # No Update
 mas_iot_version:
   8.10.x: 8.7.4   # No Update
   8.11.x: 8.8.0   # No Update
@@ -54,6 +56,7 @@ mas_manage_version:
 mas_monitor_version:
   8.10.x: 8.10.5  # No Update
   8.11.x: 8.11.0  # No Update
+  8.9.x: 8.9.6    # No Update
 mas_optimizer_version:
   8.10.x: 8.4.1   # No Update
   8.11.x: 8.5.0   # No Update
@@ -61,9 +64,11 @@ mas_optimizer_version:
 mas_predict_version:
   8.10.x: 8.8.2   # No Update
   8.11.x: 8.9.0   # No Update
+  8.9.x: 8.7.2    # No Update
 mas_visualinspection_version:
   8.10.x: 8.8.1   # No Update
   8.11.x: 8.9.0   # No Update
+  8.9.x: 8.7.1    # No Update
 
 # Extra Images for UDS
 # ------------------------------------------------------------------------------

--- a/ibm/mas_devops/common_vars/casebundles/v8-231004-amd64.yml
+++ b/ibm/mas_devops/common_vars/casebundles/v8-231004-amd64.yml
@@ -36,6 +36,7 @@ couchdb_version: 1.0.13                      # Operator version 2.2.1
 mas_core_version:
   8.10.x: 8.10.5  # No Update
   8.11.x: 8.11.1  # Updated
+  8.9.x: 8.9.10   # Updated
 mas_assist_version:
   8.10.x: 8.7.2   # No Update
   8.11.x: 8.8.0   # No Update
@@ -45,15 +46,18 @@ mas_hputilities_version:
 mas_iot_version:
   8.10.x: 8.7.4   # No Update
   8.11.x: 8.8.0   # No Update
+  8.9.x: 8.6.9    # No Update
 mas_manage_version:
   8.10.x: 8.6.5   # No Update
   8.11.x: 8.7.0   # No Update
+  8.9.x: 8.5.9    # Updated
 mas_monitor_version:
   8.10.x: 8.10.5  # No Update
   8.11.x: 8.11.0  # No Update
 mas_optimizer_version:
   8.10.x: 8.4.1   # No Update
   8.11.x: 8.5.0   # No Update
+  8.9.x: 8.3.3    # No Update
 mas_predict_version:
   8.10.x: 8.8.2   # No Update
   8.11.x: 8.9.0   # No Update


### PR DESCRIPTION
Existing customers on MAS 8.9.x airgap couldn't get their digest maps updated for Core and Manage. This is because the 8.9.x channel was removed from the `v8-231004-amd64` casebundle vars.

[update-digest-maps.yml](https://github.com/ibm-mas/ansible-devops/blob/master/ibm/mas_devops/roles/ibm_catalogs/tasks/install/update-digest-maps.yml) looks for this channel in the casebundle vars, so adding it back.