### PR TITLE
[patch] Fix DRO role in docs + add missing docs

### DIFF
--- a/build/bin/copy-role-docs.sh
+++ b/build/bin/copy-role-docs.sh
@@ -33,6 +33,7 @@ copyDoc cp4d_upgrade
 copyDoc db2
 copyDoc db2_backup
 copyDoc db2_restore
+copyDoc dro
 copyDoc entitlement_key_rotation
 copyDoc gencfg_jdbc
 copyDoc gencfg_mongo

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
       - "cert_manager": roles/cert_manager.md
       - "cluster_monitoring": roles/cluster_monitoring.md
       - "cis": roles/cis.md
+      - "common-services": roles/common_services.md
       - "configure_manage_eventstreams": roles/configure_manage_eventstreams.md
       - "cos": roles/cos.md
       - "cos_bucket": roles/cos_bucket.md
@@ -54,6 +55,7 @@ nav:
       - "db2_backup": roles/db2_backup.md
       - "db2_restore": roles/db2_restore.md
       - "dro": roles/dro.md
+      - "ibm_catalogs": roles/ibm_catalogs.md
       - "kafka": roles/kafka.md
       - "nvidia_gpu": roles/nvidia_gpu.md
       - "mongodb": roles/mongodb.md
@@ -74,6 +76,7 @@ nav:
       - "suite_app_install": roles/suite_app_install.md
       - "suite_app_upgrade": roles/suite_app_upgrade.md
       - "suite_app_rollback": roles/suite_app_rollback.md
+      - "suite_certs": roles/suite_certs.md
       - "suite_config": roles/suite_config.md
       - "suite_db2_setup_for_manage": roles/suite_db2_setup_for_manage.md
       - "suite_dns": roles/suite_dns.md


### PR DESCRIPTION
The DRO PR https://github.com/ibm-mas/ansible-devops/pull/1049 was missing the copyDoc entry to copy over the role docs. This PR also adds some missing roles form the navigation (suite_certs, ibm_catalogs and common-services)