### PR TITLE
[patch] Add MCSP provider to ocp_provision role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ ibm/mas_devops/service-key_*.json
 ibm-mas_devops-*.tar.gz
 ibm/mas_devops/runAnsibl*.sh
 build/bin/downloads/*.tgz
+.pyenv

--- a/ibm/mas_devops/roles/ocp_provision/README.md
+++ b/ibm/mas_devops/roles/ocp_provision/README.md
@@ -1,7 +1,7 @@
 ocp_provision
 ===============================================================================
 
-Provision OCP cluster on DevIT Fyre or IBM Cloud ROKS.
+Provision OCP cluster on DevIT Fyre, IBM Cloud ROKS, ROSA or MCSP.
 
 Role Variables
 -------------------------------------------------------------------------------
@@ -346,6 +346,142 @@ GCP project id in which the cluster will be deployed.
 - **Required** when `cluster_type = ipi` and `ipi_platform = gcp`
 - Environment Variable: `GOOGLE_PROJECTID`
 - Default Value: None
+
+
+Role Variables - MCSP
+-------------------------------------------------------------------------------
+The following variables are only used when `cluster_type = mcsp`.
+NOTE: This is only intended for internal use within IBM.
+
+### mcsp_control_plane_api
+
+OCP API URL of the Control Plane for the targeted MCSP environment. See https://pages.github.ibm.com/ibm-saas-platform/MultiCloud-SaaS-Framework/MCSP_Overview/mcsp_clusters/
+
+- **Required** when `cluster_type = mcsp`
+- Environment Variable: `MCSP_CONTROL_PLANE_API`
+- Default Value: None
+
+### mcsp_control_plane_token
+Temporary; will be replaced with the credentials for a functional ID. See https://ibm-watson-iot.slack.com/archives/C04E0SN54KW/p1697543955467329. In the meantime, if you want to use this role, log in to the MCSP Control Plane OCP using your IBM ID and request a token via the "Copy Login Command" feature.
+
+### mcsp_region
+MCSP region within which to create the cluster. Supported values will vary depending on the MCSP environment that is being targeted. See https://pages.github.ibm.com/ibm-saas-platform/MultiCloud-SaaS-Framework/MCSP_Overview/mcsp_clusters/
+
+- **Required** when `cluster_type = mcsp`
+- Environment Variable: `MCSP_REGION`
+- Default Value: None
+
+### mcsp_platform
+
+Hyperscaler platform to target. Currently supports `aws` only.
+
+- **Required** when `cluster_type = mcsp`
+- Environment Variable: `MCSP_PLATFORM`
+- Default Value: `aws`
+
+### mcsp_platform_account_secret_name
+
+Name of the secret in the MCSP Control Plane OCP containing details necessary to authenticate with MAS's account in the targeted hyperscaler platform. This should already have been configured as part of the MAS onboarding process.
+
+- **Required** when `cluster_type = mcsp`
+- Environment Variable: `MCSP_PLATFORM_ACCOUNT_SECRET_NAME`
+- Default Value: `aws-account`
+
+### mcsp_control_plane_namespace
+The namespace assigned to MAS in the MCSP Control Plane OCP.
+
+- **Required** when `cluster_type = mcsp`
+- Environment Variable: `MCSP_CONTROL_PLANE_NAMESPACE`
+- Default Value: `mas`
+
+### mcsp_worker_count
+
+Number of worker nodes for the cluster
+
+- **Required** when `cluster_type = mcsp`
+- Environment Variable: `MCSP_WORKER_COUNT`
+- Default Value: `3`
+
+### mcsp_worker_flavor
+
+The hardware to use for each worker. See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html
+
+- **Required** when `cluster_type = mcsp`
+- Environment Variable: `MCSP_WORKER_FLAVOR`
+- Default Value: `r5a.xlarge`
+
+### mcsp_argocd_api
+
+API URL of the ArgoCD worker for the targeted MCSP environment/region. See https://pages.github.ibm.com/ibm-saas-platform/CICD-Playbook/continuous-delivery/Overview
+
+- **Required** when `cluster_type = mcsp`
+- Environment Variable: `MCSP_ARGOCD_API`
+- Default Value: None
+
+### mcsp_argocd_secret_name
+
+Name of the secret in the MCSP Control Plane OCP containing details necessary to authenticate with the targeted ArgoCD worker. This should already have been configured as part of the MAS onboarding process.
+
+- **Required** when `cluster_type = mcsp`
+- Environment Variable: `MCSP_ARGOCD_SECRET_NAME`
+- Default Value: `argo`
+
+### mcsp_argocd_project_name
+
+Name of the ArgoCD project which will contain the Applications that will be deployed to this cluster by ArgoCD.
+
+- **Required** when `cluster_type = mcsp`
+- Environment Variable: `MCSP_ARGOCD_PROJECT_NAME`
+- Default Value: `mas`
+
+### mcsp_idpverify_enabled
+
+Whether or not to enable the MCSP idpverify addon for this cluster. See https://pages.github.ibm.com/ibm-saas-platform/CP-Playbook/Addons/Addon%20List/idpverify/
+
+- **Required** when `cluster_type = mcsp`
+- Environment Variable: `MCSP_IDPVERIFY_ENABLED`
+- Default Value: true
+
+### mcsp_idpverify_secret_verify_name
+
+Name of the secret in the MCSP Control Plane OCP containing details used by the idpverify addon. This should already have been configured by the MCSP team as part of the MAS onboarding process.
+
+- **Required** when `cluster_type = mcsp`
+- Environment Variable: `MCSP_IDPVERIFY_SECRET_VERIFY_NAME`
+- Default Value: `verify`
+
+### mcsp_security_enabled
+
+Whether or not to enable the MCSP security addon for this cluster. See https://pages.github.ibm.com/ibm-saas-platform/CP-Playbook/Addons/Addon%20List/security/
+
+- **Required** when `cluster_type = mcsp`
+- Environment Variable: ``MCSP_SECURITY_ENABLED``
+- Default Value: true
+
+### mcsp_logforwarder_enabled
+
+Whether or not to enable the MCSP security addon for this cluster. See https://pages.github.ibm.com/ibm-saas-platform/CP-Playbook/Addons/Addon%20List/logforwarder/
+
+- **Required** when `cluster_type = mcsp`
+- Environment Variable: ``MCSP_LOGFORWARDER_ENABLED``
+- Default Value: true
+
+
+### mcsp_logforwarder_secret_dlc_name
+
+Name of a secret in the MCSP Control Plane OCP containing details necessary used by the logforwarder addon. This should already have been configured by the MCSP team as part of the MAS onboarding process.
+
+- **Required** when `cluster_type = mcsp`
+- Environment Variable: `MCSP_LOGFORWARDER_SECRET_DLC_NAME`
+- Default Value: `dlc-cert`
+
+### mcsp_logforwarder_secret_sf_name
+
+Name of a secret in the MCSP Control Plane OCP containing details necessary used by the logforwarder addon. This should already have been configured by the MCSP team as part of the MAS onboarding process.
+
+- **Required** when `cluster_type = mcsp`
+- Environment Variable: `MCSP_LOGFORWARDER_SECRET_SF_NAME`
+- Default Value: `syslog-forwarder`
 
 Example Playbook
 -------------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/ocp_provision/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/defaults/main.yml
@@ -13,6 +13,7 @@ supported_cluster_types:
   - roks
   - rosa
   - ipi
+  - mcsp
 
 
 # GPU support (limited)
@@ -93,3 +94,40 @@ ipi_config_dir: "{{ ipi_dir }}/config/{{ cluster_name }}"
 
 ocp_installer_dir: "{{ ipi_dir }}/installer/{{ ocp_version }}"
 ocp_installer_exe: "{{ ipi_dir }}/installer/{{ ocp_version }}/openshift-install"
+
+
+# MCSP
+# -----------------------------------------------------------------------------
+
+mcsp_control_plane_api: "{{ lookup('env', 'MCSP_CONTROL_PLANE_API')  }}"
+mcsp_control_plane_token: "{{ lookup('env', 'MCSP_CONTROL_PLANE_TOKEN')  }}"
+mcsp_region: "{{ lookup('env', 'MCSP_REGION') }}" 
+
+mcsp_platform: "{{ lookup('env', 'MCSP_PLATFORM')  | default('aws', true)  }}"
+mcsp_platform_account_secret_name: "{{ lookup('env', 'MCSP_PLATFORM_ACCOUNT_SECRET_NAME') | default('aws-account', true) }}"
+mcsp_control_plane_namespace: "{{ lookup('env', 'MCSP_CONTROL_PLANE_NAMESPACE') | default('mas', true) }}"
+
+## Workerpool config
+mcsp_worker_count: "{{ lookup('env', 'MCSP_WORKER_COUNT') | default(3, true) }}"
+mcsp_worker_flavor: "{{ lookup('env', 'MCSP_WORKER_FLAVOR') | default('r5a.xlarge', true) }}"
+
+## Addon config
+
+### argocd
+mcsp_argocd_api: "{{ lookup('env', 'MCSP_ARGOCD_API') }}"
+mcsp_argocd_secret_name: "{{ lookup('env', 'MCSP_ARGOCD_SECRET_NAME') | default('argo', true) }}"
+mcsp_argocd_project_name: "{{ lookup('env', 'MCSP_ARGOCD_PROJECT_NAME') | default('mas', true) }}"
+
+### idpverify
+mcsp_idpverify_enabled: "{{ lookup('env', 'MCSP_IDPVERIFY_ENABLED') | default(true, true) }}"
+mcsp_idpverify_secret_verify_name: "{{ lookup('env', 'MCSP_IDPVERIFY_SECRET_VERIFY_NAME') | default('verify', true) }}"
+
+
+### Security
+mcsp_security_enabled: "{{ lookup('env', 'MCSP_SECURITY_ENABLED') | default(true, true) }}"
+
+### Logforwarder
+mcsp_logforwarder_enabled: "{{ lookup('env', 'MCSP_LOGFORWARDER_ENABLED') | default(true, true) }}"
+
+mcsp_logforwarder_secret_dlc_name: "{{ lookup('env', 'MCSP_LOGFORWARDER_SECRET_DLC_NAME') | default('dlc-cert', true) }}"
+mcsp_logforwarder_secret_sf_name: "{{ lookup('env', 'MCSP_LOGFORWARDER_SECRET_SF_NAME') | default('syslog-forwarder', true) }}"

--- a/ibm/mas_devops/roles/ocp_provision/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/defaults/main.yml
@@ -101,7 +101,7 @@ ocp_installer_exe: "{{ ipi_dir }}/installer/{{ ocp_version }}/openshift-install"
 
 mcsp_control_plane_api: "{{ lookup('env', 'MCSP_CONTROL_PLANE_API')  }}"
 mcsp_control_plane_token: "{{ lookup('env', 'MCSP_CONTROL_PLANE_TOKEN')  }}"
-mcsp_region: "{{ lookup('env', 'MCSP_REGION') }}" 
+mcsp_region: "{{ lookup('env', 'MCSP_REGION') }}"
 
 mcsp_platform: "{{ lookup('env', 'MCSP_PLATFORM')  | default('aws', true)  }}"
 mcsp_platform_account_secret_name: "{{ lookup('env', 'MCSP_PLATFORM_ACCOUNT_SECRET_NAME') | default('aws-account', true) }}"

--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/mcsp.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/mcsp.yml
@@ -1,0 +1,201 @@
+- name: "mcsp : Fail if required vars are not provided"
+  assert:
+    that:
+      - cluster_name is defined and cluster_name != ""
+      - ocp_version is defined and ocp_version != ""
+      - mcsp_control_plane_api is defined and mcsp_control_plane_api != ""
+      - mcsp_control_plane_token is defined and mcsp_control_plane_token != ""
+      - mcsp_region is defined and mcsp_region != ""
+      - mcsp_platform is defined and mcsp_platform is in ["aws"]
+      - mcsp_platform_account_secret_name is defined and mcsp_platform_account_secret_name != ""
+      - mcsp_control_plane_namespace is defined and mcsp_control_plane_namespace != ""
+      - mcsp_worker_count is defined and mcsp_worker_count != ""
+      - mcsp_worker_flavor is defined and mcsp_worker_flavor != ""
+      - mcsp_argocd_api is defined and mcsp_argocd_api != ""
+      - mcsp_argocd_secret_name is defined and mcsp_argocd_secret_name != ""
+      - mcsp_argocd_project_name is defined and mcsp_argocd_project_name != ""
+      - mcsp_idpverify_enabled is defined and mcsp_idpverify_enabled is in [true, false]
+      - mcsp_idpverify_secret_verify_name is defined and mcsp_idpverify_secret_verify_name != ""
+      - mcsp_security_enabled is defined and mcsp_security_enabled is in [true, false]
+      - mcsp_logforwarder_enabled is defined and mcsp_logforwarder_enabled is in [true, false]
+      - mcsp_logforwarder_secret_dlc_name is defined and mcsp_logforwarder_secret_dlc_name != ""
+      - mcsp_logforwarder_secret_sf_name is defined and mcsp_logforwarder_secret_sf_name != ""
+
+
+- name: "mcsp : Set derived facts"
+  set_fact:
+    mcsp_cluster_name: "{{ mcsp_control_plane_namespace }}-{{ cluster_name }}"
+    mcsp_cluster_vpc_name: "{{ mcsp_control_plane_namespace }}-{{ cluster_name }}-vpc"
+
+- name: "mcsp : Debug information"
+  debug:
+    msg:
+      - "Cluster name ........................... {{ cluster_name }}"
+      - "OCP version ............................ {{ ocp_version }}"
+      - "Qualified cluster name ................. {{ mcsp_cluster_name }}"
+      - "VPC name ............................... {{ mcsp_cluster_vpc_name }}"
+      - ""
+      - "Platform ............................... {{ mcsp_platform }}"
+      - "Region ................................. {{ mcsp_region }}"
+      - "Control Plane API ...................... {{ mcsp_control_plane_api }}"
+      - "Control Plane namespace ................ {{ mcsp_control_plane_namespace }}"
+      - "Platform account secret name ........... {{ mcsp_platform_account_secret_name }}"
+      - ""
+      - "Worker Count ........................... {{ mcsp_worker_count }}"
+      - "Worker Flavor .......................... {{ mcsp_worker_flavor }}"
+      - ""
+      - "ArgoCD API ............................. {{ mcsp_argocd_api }}"
+      - "ArgoCD secret name...................... {{ mcsp_argocd_secret_name }}"
+      - "ArgoCD project name..................... {{ mcsp_argocd_project_name }}"
+      - ""
+      - "idpverify addon enabled? ............... {{ mcsp_idpverify_enabled }}"
+      - "verify secret name ..................... {{ mcsp_idpverify_secret_verify_name }}"
+      - ""
+      - "security addon enabled? ................ {{ mcsp_security_enabled }}"
+      - ""
+      - "logforwarder addon enabled? ............ {{ mcsp_logforwarder_enabled }}"
+      - "dlc-cert secret name ................... {{ mcsp_logforwarder_secret_dlc_name }}"
+      - "syslog-forwarder secret name ........... {{ mcsp_logforwarder_secret_sf_name }}"
+
+
+- name: "mcsp : Login to MCSP Control Plane"
+  shell: >
+    oc login --token={{ mcsp_control_plane_token }} --server={{ mcsp_control_plane_api }}
+
+
+
+- name: "mcsp : Lookup {{ mcsp_platform_account_secret_name }} secret"
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    namespace: "{{ mcsp_control_plane_namespace }}"
+    name: "{{ mcsp_platform_account_secret_name }}"
+  register: _mcsp_platform_account_secret_name
+- name: "mcsp : Fail if {{ mcsp_platform_account_secret_name }} secret does not exist"
+  fail:
+    msg: "The required {{ mcsp_platform_account_secret_name }} secret does not exist. We must create this secret manually once per MCSP environment. See https://pages.github.ibm.com/maximoappsuite/saas/mcsp/"
+  when: _mcsp_platform_account_secret_name.resources | length == 0
+
+- name: "mcsp : Lookup {{ mcsp_argocd_secret_name }} secret"
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    namespace: "{{ mcsp_control_plane_namespace }}"
+    name: "{{ mcsp_argocd_secret_name }}"
+  register: _mcsp_argocd_secret_name
+- name: "mcsp : Fail if {{ mcsp_argocd_secret_name }} secret does not exist"
+  fail:
+    msg: "The required {{ mcsp_argocd_secret_name }} secret does not exist. We must create this secret manually once per MCSP environment. See https://pages.github.ibm.com/maximoappsuite/saas/mcsp/"
+  when: _mcsp_argocd_secret_name.resources | length == 0
+
+- name: "mcsp : Lookup {{ mcsp_idpverify_secret_verify_name }} secret"
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    namespace: "{{ mcsp_control_plane_namespace }}"
+    name: "{{ mcsp_idpverify_secret_verify_name }}"
+  register: _mcsp_idpverify_secret_verify_name
+- name: "mcsp : Fail if {{ mcsp_idpverify_secret_verify_name }} secret does not exist"
+  fail:
+    msg: "The required {{ mcsp_idpverify_secret_verify_name }} secret does not exist. This should have been setup by the MCSP team during onboarding. See https://pages.github.ibm.com/maximoappsuite/saas/mcsp/"
+  when: _mcsp_idpverify_secret_verify_name.resources | length == 0
+
+- name: "mcsp : Lookup {{ mcsp_logforwarder_secret_dlc_name }} secret"
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    namespace: "{{ mcsp_control_plane_namespace }}"
+    name: "{{ mcsp_logforwarder_secret_dlc_name }}"
+  register: _mcsp_logforwarder_secret_dlc_name
+- name: "mcsp : Fail if {{ mcsp_logforwarder_secret_dlc_name }} secret does not exist"
+  fail:
+    msg: "The required {{ mcsp_logforwarder_secret_dlc_name }} secret does not exist. This should have been setup by the MCSP team during onboarding. See https://pages.github.ibm.com/maximoappsuite/saas/mcsp/"
+  when: _mcsp_logforwarder_secret_dlc_name.resources | length == 0
+
+- name: "mcsp : Lookup {{ mcsp_logforwarder_secret_sf_name }} secret"
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    namespace: "{{ mcsp_control_plane_namespace }}"
+    name: "{{ mcsp_logforwarder_secret_sf_name }}"
+  register: _mcsp_logforwarder_secret_sf_name
+- name: "mcsp : Fail if {{ mcsp_logforwarder_secret_sf_name }} secret does not exist"
+  fail:
+    msg: "The required {{ mcsp_logforwarder_secret_sf_name }} secret does not exist. This should have been setup by the MCSP team during onboarding. See https://pages.github.ibm.com/maximoappsuite/saas/mcsp/"
+  when: _mcsp_logforwarder_secret_sf_name.resources | length == 0
+
+
+
+# NOTE: field_selectors like below not supported
+#     field_selectors:
+#       - spec.sos.issos = true
+#       - location = {{ mcsp_region }}
+# Instead, we have to get all VPCs and loop through them to look for a matching SoS VPC
+
+- name: "mcsp : Lookup VPCs in order verify that SoS VPC is present and correct for {{ mcsp_region }}"
+  kubernetes.core.k8s_info:
+    api_version: automation.ibm.com/v1alpha1
+    kind: CloudRockVpc
+    namespace: "{{ mcsp_control_plane_namespace }}"
+  register: _vpcs
+
+- name: "mcsp : Look for VPC with spec.sos.issos=true and spec.location={{ mcsp_region }}"
+  set_fact:
+    sos_vpc_name: "{{
+        _vpcs.resources
+        | selectattr('spec.sos.issos', 'defined')
+        | selectattr('spec.sos.issos', 'equalto', true)
+        | selectattr('spec.location', 'defined')
+        | selectattr('spec.location', 'equalto', mcsp_region)
+        | map(attribute='metadata.name')
+        | first
+        | default('')
+      }}"
+
+- name: "mcsp : Fail if SoS VPC is absent"
+  assert:
+    that:
+    - sos_vpc_name is defined
+    - sos_vpc_name != ""
+
+- name: "mcsp : Verify that {{ sos_vpc_name }} is ready"
+  kubernetes.core.k8s_info:
+    api_version: automation.ibm.com/v1alpha1
+    kind: CloudRockVpc
+    namespace: "{{ mcsp_control_plane_namespace }}"
+    wait: yes
+    wait_condition:
+      type: Ready
+      status: 'True' 
+    wait_timeout: 5
+
+
+- name: "mcsp : Ensure CloudRockCluster CR is present"
+  kubernetes.core.k8s:
+    state: present
+    template: 'templates/mcsp/cloudrockcluster.yaml.j2'
+
+    # In case this is an update, wait for the controller to acknowledge the update
+    wait: yes
+    wait_sleep: 5
+    wait_timeout: 60
+    wait_condition:
+      type: Ready
+      status: 'False'
+      reason: 'ForceReconcile'
+
+# Now wait for the status to transition to (or back to, in case of an update) Ready=True
+- name: "mcsp : Wait for CloudRockCluster CR to be ready"
+  kubernetes.core.k8s_info:
+    api_version: automation.ibm.com/v1alpha1
+    kind: CloudRockCluster
+    namespace: "{{ mcsp_control_plane_namespace }}"
+    name: "{{ mcsp_cluster_name }}"
+    wait: yes
+    wait_sleep: 60
+    wait_timeout: 3600 # can take up to 60 minutes
+    wait_condition:
+      type: Ready
+      status: 'True'
+  ignore_errors: true
+

--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/mcsp.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/mcsp.yml
@@ -63,7 +63,6 @@
     oc login --token={{ mcsp_control_plane_token }} --server={{ mcsp_control_plane_api }}
 
 
-
 - name: "mcsp : Lookup {{ mcsp_platform_account_secret_name }} secret"
   kubernetes.core.k8s_info:
     api_version: v1
@@ -125,7 +124,6 @@
   when: _mcsp_logforwarder_secret_sf_name.resources | length == 0
 
 
-
 # NOTE: field_selectors like below not supported
 #     field_selectors:
 #       - spec.sos.issos = true
@@ -155,8 +153,8 @@
 - name: "mcsp : Fail if SoS VPC is absent"
   assert:
     that:
-    - sos_vpc_name is defined
-    - sos_vpc_name != ""
+      - sos_vpc_name is defined
+      - sos_vpc_name != ""
 
 - name: "mcsp : Verify that {{ sos_vpc_name }} is ready"
   kubernetes.core.k8s_info:
@@ -166,7 +164,7 @@
     wait: yes
     wait_condition:
       type: Ready
-      status: 'True' 
+      status: 'True'
     wait_timeout: 5
 
 
@@ -198,4 +196,3 @@
       type: Ready
       status: 'True'
   ignore_errors: true
-

--- a/ibm/mas_devops/roles/ocp_provision/templates/mcsp/cloudrockcluster.yaml.j2
+++ b/ibm/mas_devops/roles/ocp_provision/templates/mcsp/cloudrockcluster.yaml.j2
@@ -1,0 +1,75 @@
+apiVersion: automation.ibm.com/v1alpha1
+kind: CloudRockCluster
+metadata:
+  name: "{{ mcsp_cluster_name }}"
+  namespace: "{{ mcsp_control_plane_namespace }}"
+spec:
+  infrastructure: "{{ mcsp_platform }}"
+  kube_version: "{{ ocp_version }}"
+  location: "{{ mcsp_region }}"
+  multiaz: true
+  vpc:
+    name: "{{ mcsp_cluster_vpc_name }}"
+  workerpools:
+    - count: {{ mcsp_worker_count }}
+      flavor: "{{ mcsp_worker_flavor }}"
+      id: default         
+  account:
+    secretname: "{{ mcsp_platform_account_secret_name }}"
+  addon:
+    argocd:
+      config:
+        argoprojects:
+          - argoprojectname: "{{ mcsp_argocd_project_name }}"
+            destinationnamespace: '*'
+        argourl: "{{ mcsp_argocd_api }}"
+        cluster:
+          argoprojectname: "{{ mcsp_argocd_project_name }}"
+          global: false
+      enabled: true
+      secrets:
+        argo: "{{ mcsp_argocd_secret_name }}"
+
+    # idpverify, security and logforward addon config is required (even if it's not enabled)
+    idpverify:
+      enabled: {{ mcsp_idpverify_enabled }}
+      config:
+        mcspaccess: true
+        issuer: https://sre-ibm-prod.verify.ibm.com/oidc/endpoint/default
+        clusterrolebindings:
+          - groups:
+              - Automation_Platform_Build_Global_PlatformSRE_AutoPlatform
+              - Automation_Platform_Build_Global_PlatformDeveloper_AutoPlatform
+            roleref: cluster-admin
+          - groups:
+              - Automation_Platform_Build_Global_Security_AutoPlatform
+            roleref: viewer
+      secrets:
+        verify: "{{ mcsp_idpverify_secret_verify_name }}"
+    security:
+      enabled: {{ mcsp_security_enabled }}
+      config: 
+        crowdstrike:
+          version: v1.0.4
+          memlimit: 2Gi
+          tolerations: 
+            - key: samplekey
+              operator: Exists
+              effect: NoSchedule
+    logforwarder:
+      enabled: {{ mcsp_logforwarder_enabled }}
+      config:
+        usecloudwatch: "true"
+        useinfralogs: "true"
+        useauditlogs: "true"
+        useapplogs: "true"
+        cloudwatchregion: "{{ mcsp_region }}"
+        cloudwatchgroupprefix: "mascluster"
+      secrets: 
+        dlc-cert: "{{ mcsp_logforwarder_secret_dlc_name }}"
+        syslog-forwarder: "{{ mcsp_logforwarder_secret_sf_name }}"
+  actions: 
+    reconcile: true
+    donotreconcile: false
+    allowdeletion: false
+    hibernate: false


### PR DESCRIPTION
https://jsw.ibm.com/browse/MASCORE-484

Logs in to MCSP Control Plane OCP, verifies required cluster resources are present (Secrets, SOS VPC), creates a `CloudRockerCluster` CR and blocks until is reconciled successfully.

NOTE: this is an initial delivery for development use. Will be expanded in future to e.g.:
 - support authentication with MCSP control plane via a functional ID (at present a manually-generated token must be supplied).
 - allow control of additional cluster configuration parameters.