### PR TITLE
[patch] Validate that the application itself is supported in the new release

### DIFF
--- a/ibm/mas_devops/roles/suite_upgrade/tasks/check_app_compatibility.yml
+++ b/ibm/mas_devops/roles/suite_upgrade/tasks/check_app_compatibility.yml
@@ -17,6 +17,14 @@
   debug:
     var: checkapp_sub_info
 
+- name: "{{ check_app.id }} : Check that upgrade is supported from current application"
+  when:
+    - not ( skip_compatibility_check is defined and skip_compatibility_check )
+    - checkapp_sub_info.resources is defined and checkapp_sub_info.resources | length == 1
+  assert:
+    that: check_app.id in compatibility_matrix[mas_channel]
+    fail_msg: "Unable to upgrade to {{ mas_channel }} because ibm-mas-{{ check_app.id }} is installed and is not compatible with this release ({{ mas_channel }})."
+
 - name: "{{ check_app.id }} : Check that upgrade is supported from current channel"
   when:
     - not ( skip_compatibility_check is defined and skip_compatibility_check )

--- a/ibm/mas_devops/roles/suite_upgrade/tasks/check_app_compatibility.yml
+++ b/ibm/mas_devops/roles/suite_upgrade/tasks/check_app_compatibility.yml
@@ -23,7 +23,7 @@
     - checkapp_sub_info.resources is defined and checkapp_sub_info.resources | length == 1
   assert:
     that: check_app.id in compatibility_matrix[mas_channel]
-    fail_msg: "Unable to upgrade to {{ mas_channel }} because ibm-mas-{{ check_app.id }} is installed and is not compatible with this release ({{ mas_channel }})."
+    fail_msg: "Unable to upgrade to {{ mas_channel }} because ibm-mas-{{ check_app.id }} is installed and is not compatible with this release."
 
 - name: "{{ check_app.id }} : Check that upgrade is supported from current channel"
   when:


### PR DESCRIPTION
Example: When upgrading from MAS 8.10 to 8.11 with HPU installed:

Before:
```
TASK [ibm.mas_devops.suite_upgrade : hputilities : Check that upgrade is supported from current channel] ***
fatal: [localhost]: FAILED! => 
  msg: |-
    The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'hputilities'
  
    The error appears to be in '/opt/app-root/lib64/python3.9/site-packages/ansible_collections/ibm/mas_devops/roles/suite_upgrade/tasks/check_app_compatibility.yml': line 20, column 3, but may
    be elsewhere in the file depending on the exact syntax problem.
  
    The offending line appears to be:
  
  
    - name: "{{ check_app.id }} : Check that upgrade is supported from current channel"
      ^ here
    We could be wrong, but this one looks like it might be an issue with
    missing quotes. Always quote template expression brackets when they
    start a value. For instance:
  
        with_items:
          - {{ foo }}
  
    Should be written as:
  
        with_items:
          - "{{ foo }}"
```

After:
```
TASK [ibm.mas_devops.suite_upgrade : hputilities : Check that upgrade is supported from current application] ***
fatal: [localhost]: FAILED! => changed=false 
  assertion: check_app.id in compatibility_matrix[mas_channel]
  evaluated_to: false
  msg: Unable to upgrade to 8.11.x because ibm-mas-hputilities is installed and is not compatible with this release.
```