### PR TITLE
[patch] Fix visualinspection kind

### DIFF
--- a/ibm/mas_devops/common_vars/application_info.yml
+++ b/ibm/mas_devops/common_vars/application_info.yml
@@ -45,7 +45,7 @@ app_info:
   visualinspection:
     id: visualinspection
     api_version: apps.mas.ibm.com/v1
-    kind: VisualInspection
+    kind: VisualInspectionApp
     ws_kind: VisualInspectionWorkspace
 
   optimizer:


### PR DESCRIPTION
Visual Inspection's `kind` should be `VisualInspectionApp`, not `VisualInspection`

```
TASK [ibm.mas_devops.suite_upgrade : visualinspection : Check that the CR exists] ***
fatal: [localhost]: FAILED! => changed=false 
  assertion: app_info.resources | length == 1
  evaluated_to: false
  msg: Upgrade failed, ibm-mas-visualinspection operator has been deployed, but fvtupgrade/VisualInspection.apps.mas.ibm.com/v1 has not been created in namespace mas-fvtupgrade-visualinspection

NO MORE HOSTS LEFT *************************************************************

PLAY RECAP *********************************************************************
localhost                  : ok=123  changed=0    unreachable=0    failed=1    skipped=25   rescued=0    ignored=0   

```

```
oc -n mas-fvtupgrade-visualinspection get visualinspection
error: the server doesn't have a resource type "visualinspection"

oc -n mas-fvtupgrade-visualinspection get visualinspectionappworkspace,visualinspectionapps
NAME                                                              VERSION   STATUS   AGE
visualinspectionappworkspace.apps.mas.ibm.com/fvtupgrade-masdev   8.8.1     Ready    3d22h

NAME                                              VERSION   STATUS   AGE
visualinspectionapp.apps.mas.ibm.com/fvtupgrade   8.8.1     Ready    3d22h
```