### PR TITLE
[patch] Fix MVI kind in a second file

### DIFF
--- a/ibm/mas_devops/roles/suite_upgrade/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_upgrade/tasks/main.yml
@@ -146,7 +146,7 @@
   vars:
     check_app:
       id: visualinspection
-      kind: VisualInspection
+      kind: VisualInspectionApp
       api_version: apps.mas.ibm.com/v1
 
 # 4.9. Optimizer


### PR DESCRIPTION
Follow up to https://github.com/ibm-mas/ansible-devops/pull/1078, found another place in the code where the `kind` value is incorrect.