### PR TITLE
[patch] Delete redhat-marketplace secret during DRO during uninstall

### DIFF
--- a/ibm/mas_devops/roles/dro/tasks/uninstall/main.yml
+++ b/ibm/mas_devops/roles/dro/tasks/uninstall/main.yml
@@ -102,6 +102,13 @@
     wait_timeout: 600
   when: (dro_subscription.resources is defined) and (dro_subscription.resources| length == 1)
 
+- name: "uninstall : Delete the redhat-marketplace-pull-secret secret"
+  kubernetes.core.k8s:
+    state: absent
+    api_version: v1
+    kind: Secret
+    namespace: redhat-marketplace
+    name: redhat-marketplace-pull-secret
 # RMO
 
 - name: Get ibm-metrics-operator Subscription


### PR DESCRIPTION
[MASCORE-711](https://jsw.ibm.com/browse/MASCORE-711) : Delete redhat-marketplace-pull-secret as part of DRO uninstall

The [redhat-marketplace-pull-secret](https://console-openshift-console.apps.plgtest1.cp.fyre.ibm.com/k8s/ns/redhat-marketplace/secrets/redhat-marketplace-pull-secret) is not being deleted as part of dro uninstall role. So when a user adds a wrong key the first time. there is no way to change it .

delete [redhat-marketplace-pull-secret](https://console-openshift-console.apps.plgtest1.cp.fyre.ibm.com/k8s/ns/redhat-marketplace/secrets/redhat-marketplace-pull-secret) as part of uninstall.