### PR TITLE
[patch] Inspection workspace kind fix

### DIFF
--- a/ibm/mas_devops/common_vars/application_info.yml
+++ b/ibm/mas_devops/common_vars/application_info.yml
@@ -46,7 +46,8 @@ app_info:
     id: visualinspection
     api_version: apps.mas.ibm.com/v1
     kind: VisualInspectionApp
-    ws_kind: VisualInspectionWorkspace
+    # Note this is non-standard "xAppWorkspace" instead of "xWorkspace"
+    ws_kind: VisualInspectionAppWorkspace
 
   optimizer:
     id: optimizer


### PR DESCRIPTION
Inspection's workspace kind is not the expected `VisualInspectionWorkspace`, but rather `VisualInspectionAppWorkspace`.