### PR TITLE
[patch] Fix Inspection upgrade failure

### DIFF
--- a/ibm/mas_devops/roles/suite_app_upgrade/tasks/check_app_compatibility.yml
+++ b/ibm/mas_devops/roles/suite_app_upgrade/tasks/check_app_compatibility.yml
@@ -95,6 +95,9 @@
 
 # 4. Check that the Application CR meets the required state
 # -----------------------------------------------------------------------------
+# We've noticed that Inspection application will sometimes fail the Ready assertion
+# so this step will wait for up to 10 minutes for the application to get into the
+# desired state before giving up and failing the upgrade.
 - name: "{{ mas_app_id }} : Get Application CR for for {{ mas_app_fqn }}"
   when: app_sub_info.resources[0].spec.channel != mas_app_upgrade_target_channel
   kubernetes.core.k8s_info:
@@ -102,6 +105,12 @@
     name: "{{ mas_instance_id }}"
     namespace: "{{ mas_app_namespace }}"
     kind: "{{ app_info[mas_app_id].kind }}"
+    wait: yes
+    wait_sleep: 20
+    wait_timeout: 600 # 10 minutes until we give up waiting for the application to get into the expected state
+    wait_condition:
+      type: Ready
+      reason: "Ready"
   register: app_cr_lookup
 
 - name: "{{ mas_app_id }} : Debug Application CR"


### PR DESCRIPTION
```
TASK [ibm.mas_devops.suite_app_upgrade : visualinspection : Check that the Application CR is in a healthy state] ***
fatal: [localhost]: FAILED! => changed=false 
  assertion: app_cr_lookup.resources | json_query('[*].status.conditions[?type==`Ready`][].reason') | select ('match','Ready') | list | length == 1
  evaluated_to: false
  msg: Upgrade failed because fvtupgrade/VisualInspectionApp.apps.mas.ibm.com/v1 is not healthy

NO MORE HOSTS LEFT *************************************************************

PLAY RECAP *********************************************************************
localhost                  : ok=23   changed=0    unreachable=0    failed=1    skipped=2    rescued=0    ignored=0   
```

However, when checking the cluster shortly after we can see that the application is healthy.  The addition of a wait here should allow the application a suitable window of time to get into ready state to allow the upgrade to proceed, rather than only performing a one-time check.