### PR TITLE
[patch] Fix missing mirroring for Amlen operator image

### DIFF
--- a/ibm/mas_devops/common_vars/casebundles/v8-230725-amd64.yml
+++ b/ibm/mas_devops/common_vars/casebundles/v8-230725-amd64.yml
@@ -76,3 +76,7 @@ db2u_extras_version: 1.0.1
 # Extra Images for IBM Watson Discovery
 # ------------------------------------------------------------------------------
 wd_extras_version: 1.0.0
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.0.1

--- a/ibm/mas_devops/common_vars/casebundles/v8-230829-amd64.yml
+++ b/ibm/mas_devops/common_vars/casebundles/v8-230829-amd64.yml
@@ -76,3 +76,7 @@ db2u_extras_version: 1.0.2
 # Extra Images for IBM Watson Discovery
 # ------------------------------------------------------------------------------
 wd_extras_version: 1.0.1
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.0.1

--- a/ibm/mas_devops/common_vars/casebundles/v8-230926-amd64.yml
+++ b/ibm/mas_devops/common_vars/casebundles/v8-230926-amd64.yml
@@ -76,3 +76,7 @@ db2u_extras_version: 1.0.2
 # Extra Images for IBM Watson Discovery
 # ------------------------------------------------------------------------------
 wd_extras_version: 1.0.1
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.0.1

--- a/ibm/mas_devops/common_vars/casebundles/v8-231004-amd64.yml
+++ b/ibm/mas_devops/common_vars/casebundles/v8-231004-amd64.yml
@@ -86,3 +86,7 @@ db2u_extras_version: 1.0.2
 # Extra Images for IBM Watson Discovery
 # ------------------------------------------------------------------------------
 wd_extras_version: 1.0.1
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.0.1

--- a/ibm/mas_devops/common_vars/casebundles/v8-231031-amd64.yml
+++ b/ibm/mas_devops/common_vars/casebundles/v8-231031-amd64.yml
@@ -86,3 +86,7 @@ db2u_extras_version: 1.0.2
 # Extra Images for IBM Watson Discovery
 # ------------------------------------------------------------------------------
 wd_extras_version: 1.0.1
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.0.1

--- a/ibm/mas_devops/playbooks/mirror_add_iot.yml
+++ b/ibm/mas_devops/playbooks/mirror_add_iot.yml
@@ -35,3 +35,20 @@
       vars:
         manifest_name: ibm-mas-iot
         manifest_version: "{{ lookup('env', 'MAS_IOT_VERSION') | default (mas_iot_version[mas_channel], True) }}"
+
+
+    # 2. Eclipse Amlen
+    # -------------------------------------------------------------------------
+    - name: ibm.mas_devops.mirror_extras_prepare
+      when:
+        - amlen_extras_version is defined
+        - mirror_mode != "from-filesystem"
+      vars:
+        extras_name: amlen
+        extras_version: "{{ amlen_extras_version }}"
+
+    - name: ibm.mas_devops.mirror_images
+      when: amlen_extras_version is defined
+      vars:
+        manifest_name: extras_amlen
+        manifest_version: "{{ amlen_extras_version }}"

--- a/ibm/mas_devops/roles/mirror_extras_prepare/vars/amlen_1.0.1.yml
+++ b/ibm/mas_devops/roles/mirror_extras_prepare/vars/amlen_1.0.1.yml
@@ -1,0 +1,11 @@
+---
+extra_images:
+  - name: amlen/operator-bundle
+    registry: quay.io
+    digest: sha256:f098ccdab9413bd1ee773731b2306870d48bab25ec658123942a191b35ba8d58
+    tag: 1.0.1
+
+  - name: amlen/operator
+    registry: quay.io
+    digest: sha256:f89c5cf95a630aa986f3a212c0b1c6bd100ec00ff22649f282a6c8781a06f36d
+    tag: 1.0.1


### PR DESCRIPTION
After improving our airgap testing environments to block quay.io we disovered that we have a gap in the image mirroring for IoT; the Amlen operator image and bundle image are not being mirrored along with the rest of the IoT content.  This update remedies that by introducing a new amlen extras configuration.

This configuration has been applied to all catalogs since the July 25th catalog update.  Catalog versions before July are already unsupported due to end of life for OCP 4.10 in September.