### PR TITLE
[patch] mongodb doc updates for v5 and v6

### DIFF
--- a/ibm/mas_devops/roles/mongodb/README.md
+++ b/ibm/mas_devops/roles/mongodb/README.md
@@ -6,8 +6,10 @@ This role currently supports provisioning of mongodb in three different provider
  - aws (documentdb)
  - ibm
 
+!!! important
+    According to the [MongoDB Software Lifecycle Schedules](https://www.mongodb.com/support-policy/lifecycles) MongoDB 4.4 will reach end of life in February of 2024. Given this fact it is encouraged that either MongoDB 5 or 6 be used for MAS Deployments. The MAS Devops Ansible Collection can be used to install or upgrade MongoDB when the selected service provider is `community`. If the MonogDB instance used by MAS is hosted by a third party please consult the applicable documentation with respect to MongoDB 5 or 6 options. If the MongoDB instance is hosted on premises please review the appropriate MongoDB documentation related to upgrading. As a best practice it is advised perform MongoDB backups on a regular basis. This is especially important before any upgrade of MongoDB.
 
-If selected provider is `community` [MongoDb CE operator](https://github.com/mongodb/mongodb-kubernetes-operator) will be installed into the specified namespace, a 3 node cluster cluster will be created.  The cluster will bind six PVCs, these provide persistence for the data and system logs across the three nodes.  Currently there is no support built-in for customizing the cluster beyond this configuration.
+If the selected provider is `community` then the [MongoDB Community Kubernetes Operator](https://github.com/mongodb/mongodb-kubernetes-operator) will be configured and deployed into the specified namespace. By default a three member MongoDB replica set will be created.  The cluster will bind six PVCs, these provide persistence for the data and system logs across the three nodes.  Currently there is no support built-in for customizing the cluster beyond this configuration.
 
 !!! tip
     The role will generate a yaml file containing the definition of a Secret and MongoCfg resource that can be used to configure the deployed instance as the MAS system MongoDb.
@@ -71,7 +73,10 @@ The namespace where the operator and MongoDb cluster will be deployed.
 - Default Value: `mongoce`
 
 ### mongodb_version
-Defines the specific mongo version to be used.
+Defines the specific mongo version to be used. Best practice would be to use the version associated with the current Maximo Application Suite catalog. However, this value can currently be overridden to 4.4.21, 5.0.21 or 6.0.10.
+
+!!! important
+    It is advised to never attempt a downgrade a MongoDB instance managed by the MAS Devops Ansible Collection. Also best practices should include creating scheduled backups of any MongoDB instance. 
 
 - Optional
 - Environment Variable: `MONGODB_VERSION`


### PR DESCRIPTION
### More details related to MongoDB 5 and 6

Adding a bit more context around the support of MongoDB 5 and 6. Specifically call out the following:

- MongoDB 4.4 will reach end of life soon
- Always take backups before any upgrade
- Specifically which versions of MongoDB 5 and 6 the automation can configure
- If MongoDB hosted by third party or on prem consult applicable documentation