### PR TITLE
[patch] Fix path to determine-storage-classes

### DIFF
--- a/ibm/mas_devops/roles/dro/tasks/install-dro/main.yml
+++ b/ibm/mas_devops/roles/dro/tasks/install-dro/main.yml
@@ -8,7 +8,7 @@
 
 # 2. Load default storage class (if not provided by the user)
 # -----------------------------------------------------------------------------
-- include_tasks: tasks/install/determine-storage-classes.yml
+- include_tasks: tasks/install-dro/determine-storage-classes.yml
 
 # 3. Display DRO deployment details
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
The change from `install` to `install-dro` left behind a reference to `install`.