### PR TITLE
[minor] Add ADD podTemplates support

### DIFF
--- a/ibm/mas_devops/common_tasks/pod_templates/get_pod_templates.yml
+++ b/ibm/mas_devops/common_tasks/pod_templates/get_pod_templates.yml
@@ -1,0 +1,29 @@
+- name: Get and set podTemplates configuration
+  block:
+    - name: Check whether configuration exists
+      ansible.builtin.stat:
+        path: "{{ mas_pod_templates_dir }}/{{ item }}"
+      register: pod_templates_file_lookup
+
+    - name: Set podTemplates configuration
+      when: pod_templates_file_lookup.stat.exists
+      block:
+        - name: Load podTemplates configuration and set fact
+          ansible.builtin.include_vars:
+            file: "{{ mas_pod_templates_dir }}/{{ item }}"
+            name: pod_template_file
+
+        - name: Assert that 'podTemplates' key exists
+          ansible.builtin.assert:
+            that: "'podTemplates' in pod_template_file"
+            fail_msg: "Could not find 'podTemplates' key in {{ item }}"
+            success_msg: "Found 'podTemplates' key in {{ item }}"
+        
+        - name: Set podTemplates fact
+          ansible.builtin.set_fact:
+            "{{ item | splitext | first | replace('-', '_') }}_pod_templates": "{{ pod_template_file['podTemplates'] }}"
+
+    - name: Failed to find configuration
+      ansible.builtin.debug:
+        msg: "Could not find '{{ mas_pod_templates_dir }}/{{ item }}' - Skipping"
+      when: not pod_templates_file_lookup.stat.exists

--- a/ibm/mas_devops/common_tasks/pod_templates/get_pod_templates.yml
+++ b/ibm/mas_devops/common_tasks/pod_templates/get_pod_templates.yml
@@ -18,7 +18,7 @@
             that: "'podTemplates' in pod_template_file"
             fail_msg: "Could not find 'podTemplates' key in {{ item }}"
             success_msg: "Found 'podTemplates' key in {{ item }}"
-        
+
         - name: Set podTemplates fact
           ansible.builtin.set_fact:
             "{{ item | splitext | first | replace('-', '_') }}_pod_templates": "{{ pod_template_file['podTemplates'] }}"

--- a/ibm/mas_devops/common_tasks/pod_templates/main.yml
+++ b/ibm/mas_devops/common_tasks/pod_templates/main.yml
@@ -1,0 +1,28 @@
+---
+- name: Run podTemplates configuration
+  when:
+    - mas_pod_templates_dir is defined
+    - mas_pod_templates_dir != ''
+  block:
+    - name: Get and set podTemplates configuration
+      ansible.builtin.include_tasks: "get_pod_templates.yml"
+      loop: "{{ config_files }}"
+
+    - name: Combine podTemplates
+      vars:
+        merged_pod_templates_list: []
+      when:
+        - combine_into is defined
+        - combine_into is defined != ''
+      block:
+        - name: Get and combine podTemplates
+          ansible.builtin.set_fact:
+              merged_pod_templates_list: "{{ merged_pod_templates_list | default([]) + item_list }}"
+          vars:
+            item_name: "{{ item | splitext | first | replace('-', '_') }}_pod_templates"
+            item_list: "{{ lookup('ansible.builtin.vars', item_name, default='') | default([], true) }}"
+          with_items: "{{ config_files }}"
+
+        - name: Set combine_into fact
+          ansible.builtin.set_fact:
+            "{{ combine_into | splitext | first | replace('-', '_') }}_pod_templates": "{{ merged_pod_templates_list }}"

--- a/ibm/mas_devops/common_tasks/pod_templates/main.yml
+++ b/ibm/mas_devops/common_tasks/pod_templates/main.yml
@@ -1,4 +1,17 @@
 ---
+# This task finds podTemplates config files in MAS_POD_TEMPLATES_DIR and sets their corresponding facts
+# Params:
+#   config_files: (Required) List of config files that contain podTemplates
+#   combine_into: (Optional) Name of config file to combine all podTemplates
+# Usage:
+# - name: "Load podTemplates configuration"
+#   include_tasks: "{{ role_path }}/../../common_tasks/pod_templates/main.yml"
+#   vars:
+#     config_files:
+#       - "ibm-mas-suite.yml"
+#       - "ibm-mas-coreidp.yml"
+#     combine_into: "ibm-mas-suite.yml"
+
 - name: Run podTemplates configuration
   when:
     - mas_pod_templates_dir is defined

--- a/ibm/mas_devops/roles/dro/tasks/install-dro/main.yml
+++ b/ibm/mas_devops/roles/dro/tasks/install-dro/main.yml
@@ -65,29 +65,10 @@
 
 # 4.1 Load PodTemplates configuration
 # -----------------------------------------------------------------------------
-- name: Load podTemplates configuration
+- name: "Load podTemplates configuration"
+  include_tasks: "{{ role_path }}/../../common_tasks/pod_templates/main.yml"
   vars:
-    config_file_name: "ibm-mas-bascfg.yml"
-  when:
-    - mas_pod_templates_dir is defined
-    - mas_pod_templates_dir != ''
-  block:
-    - name: Check whether configuration exists
-      ansible.builtin.stat:
-        path: "{{ mas_pod_templates_dir }}/{{ config_file_name }}"
-      register: pod_templates_file_lookup
-
-    - name: Load podTemplates configuration
-      ansible.builtin.include_vars:
-        file: "{{ mas_pod_templates_dir }}/{{ config_file_name }}"
-        name: ibm_mas_bascfg_pod_templates
-      when: pod_templates_file_lookup.stat.exists
-
-    - name: Failed to find configuration
-      ansible.builtin.debug:
-        msg: "Could not find '{{ mas_pod_templates_dir }}/{{ config_file_name }}' - Skipping"
-      when: not pod_templates_file_lookup.stat.exists
-
+    config_files: ["ibm-mas-bascfg.yml"]
 
 # 5. Install DRO
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/dro/templates/bascfg.yml.j2
+++ b/ibm/mas_devops/roles/dro/templates/bascfg.yml.j2
@@ -79,6 +79,6 @@ spec:
         mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d
         emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
         -----END CERTIFICATE-----
-{% if ibm_mas_bascfg_pod_templates.podTemplates is defined %}
-  podTemplates: {{ ibm_mas_bascfg_pod_templates.podTemplates }}
+{% if ibm_mas_bascfg_pod_templates is defined %}
+  podTemplates: {{ ibm_mas_bascfg_pod_templates }}
 {% endif %}

--- a/ibm/mas_devops/roles/sls/tasks/gencfg/main.yml
+++ b/ibm/mas_devops/roles/sls/tasks/gencfg/main.yml
@@ -39,28 +39,10 @@
 
 # 4. Load PodTemplates configuration
 # -----------------------------------------------------------------------------
-- name: Load podTemplates configuration
+- name: "Load podTemplates configuration"
+  include_tasks: "{{ role_path }}/../../common_tasks/pod_templates/main.yml"
   vars:
-    config_file_name: "ibm-mas-slscfg.yml"
-  when:
-    - mas_pod_templates_dir is defined
-    - mas_pod_templates_dir != ''
-  block:
-    - name: Check whether configuration exists
-      ansible.builtin.stat:
-        path: "{{ mas_pod_templates_dir }}/{{ config_file_name }}"
-      register: pod_templates_file_lookup
-
-    - name: Load podTemplates configuration
-      ansible.builtin.include_vars:
-        file: "{{ mas_pod_templates_dir }}/{{ config_file_name }}"
-        name: ibm_mas_slscfg_pod_templates
-      when: pod_templates_file_lookup.stat.exists
-
-    - name: Failed to find configuration
-      ansible.builtin.debug:
-        msg: "Could not find '{{ mas_pod_templates_dir }}/{{ config_file_name }}' - Skipping"
-      when: not pod_templates_file_lookup.stat.exists
+    config_files: ["ibm-mas-slscfg.yml"]
 
 # 5. Generate SLSCfg for MAS
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/sls/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/sls/tasks/install/main.yml
@@ -156,28 +156,10 @@
 
 # 5. Load PodTemplates configuration
 # -----------------------------------------------------------------------------
-- name: Load podTemplates configuration
+- name: "Load podTemplates configuration"
+  include_tasks: "{{ role_path }}/../../common_tasks/pod_templates/main.yml"
   vars:
-    config_file_name: "ibm-sls-licenseservice.yml"
-  when:
-    - mas_pod_templates_dir is defined
-    - mas_pod_templates_dir != ''
-  block:
-    - name: Check whether configuration exists
-      ansible.builtin.stat:
-        path: "{{ mas_pod_templates_dir }}/{{ config_file_name }}"
-      register: pod_templates_file_lookup
-
-    - name: Load podTemplates configuration
-      ansible.builtin.include_vars:
-        file: "{{ mas_pod_templates_dir }}/{{ config_file_name }}"
-        name: ibm_sls_licenseservice_pod_templates
-      when: pod_templates_file_lookup.stat.exists
-
-    - name: Failed to find configuration
-      ansible.builtin.debug:
-        msg: "Could not find '{{ mas_pod_templates_dir }}/{{ config_file_name }}' - Skipping"
-      when: not pod_templates_file_lookup.stat.exists
+    config_files: ["ibm-sls-licenseservice.yml"]
 
 # 6. Set up the domain name for SLS
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/sls/templates/licenseservice.yml.j2
+++ b/ibm/mas_devops/roles/sls/templates/licenseservice.yml.j2
@@ -11,8 +11,8 @@ metadata:
 {% endif %}
 spec:
   domain: {{ sls_domain }}
-{% if after_sls_380 and ibm_sls_licenseservice_pod_templates.podTemplates is defined %}
-  podTemplates: {{ ibm_sls_licenseservice_pod_templates.podTemplates }}
+{% if after_sls_380 and ibm_sls_licenseservice_pod_templates is defined %}
+  podTemplates: {{ ibm_sls_licenseservice_pod_templates }}
 {% endif %}
   settings:
     auth:

--- a/ibm/mas_devops/roles/sls/templates/slscfg.yml.j2
+++ b/ibm/mas_devops/roles/sls/templates/slscfg.yml.j2
@@ -37,6 +37,6 @@ spec:
     - alias: ca
       crt: |
         {{ sls_tls_crt | indent(8) }}
-{% if ibm_mas_slscfg_pod_templates.podTemplates is defined %}
-  podTemplates: {{ ibm_mas_slscfg_pod_templates.podTemplates }}
+{% if ibm_mas_slscfg_pod_templates is defined %}
+  podTemplates: {{ ibm_mas_slscfg_pod_templates }}
 {% endif %}

--- a/ibm/mas_devops/roles/smtp/tasks/main.yml
+++ b/ibm/mas_devops/roles/smtp/tasks/main.yml
@@ -20,28 +20,10 @@
 
 # 2. Load PodTemplates configuration
 # -----------------------------------------------------------------------------
-- name: Load podTemplates configuration
+- name: "Load podTemplates configuration"
+  include_tasks: "{{ role_path }}/../../common_tasks/pod_templates/main.yml"
   vars:
-    config_file_name: "ibm-mas-smtpcfg.yml"
-  when:
-    - mas_pod_templates_dir is defined
-    - mas_pod_templates_dir != ''
-  block:
-    - name: Check whether configuration exists
-      ansible.builtin.stat:
-        path: "{{ mas_pod_templates_dir }}/{{ config_file_name }}"
-      register: pod_templates_file_lookup
-
-    - name: Load podTemplates configuration
-      ansible.builtin.include_vars:
-        file: "{{ mas_pod_templates_dir }}/{{ config_file_name }}"
-        name: ibm_mas_smtpcfg_pod_templates
-      when: pod_templates_file_lookup.stat.exists
-
-    - name: Failed to find configuration
-      ansible.builtin.debug:
-        msg: "Could not find '{{ mas_pod_templates_dir }}/{{ config_file_name }}' - Skipping"
-      when: not pod_templates_file_lookup.stat.exists
+    config_files: ["ibm-mas-smtpcfg.yml"]
 
 # 3. Execute provider specific tasks
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/smtp/templates/sendgrid/smtpcfg.yml.j2
+++ b/ibm/mas_devops/roles/smtp/templates/sendgrid/smtpcfg.yml.j2
@@ -126,6 +126,6 @@ spec:
         dEr/VxqHD3VILs9RaRegAhJhldXRQLIQTO7ErBBDpqWeCtWVYpoNz4iCxTIM5Cuf
         ReYNnyicsbkqWletNw+vHX/bvZ8=
         -----END CERTIFICATE-----
-{% if ibm_mas_smtpcfg_pod_templates.podTemplates is defined %}
-  podTemplates: {{ ibm_mas_smtpcfg_pod_templates.podTemplates }}
+{% if ibm_mas_smtpcfg_pod_templates is defined %}
+  podTemplates: {{ ibm_mas_smtpcfg_pod_templates }}
 {% endif %}

--- a/ibm/mas_devops/roles/suite_install/README.md
+++ b/ibm/mas_devops/roles/suite_install/README.md
@@ -19,7 +19,7 @@ Required when using this role for development versions of MAS
 Defines which channel of MAS to subscribe to
 
 ### mas_domain
-Opitional fact, if not provided the role will use the default cluster subdomain
+Optional fact, if not provided the role will use the default cluster subdomain
 
 ### mas_instance_id
 Defines the instance id to be used for MAS installation
@@ -82,7 +82,7 @@ Boolean variable that defines whether default Certificate Authorities are includ
 - Default: True
 
 ### mas_pod_templates_dir
-Provide the directory where supported pod templates configuration files are defined.  This role will look for a configuration file named `ibm-mas-suite.yml` in the named directory.  The content of the configuration file should be the yaml block that you wish to be inserted into the Suite spec under a top level `podTemplates` element, e.g. `podTemplates: {object}`.
+Provide the directory where supported pod templates configuration files are defined. This role will look for a configuration files named `ibm-mas-suite.yml`, `ibm-mas-coreidp.yml` and `ibm-data-dictionary-assetdatadictionary.yml` in the named directory.  The content of the configuration file should be the yaml block that you wish to be inserted into the Suite spec under a top level `podTemplates` element, e.g. `podTemplates: {object}`. For ibm-data-dictionary the podTemplates will be inserted into the Suite spec under `settings->dataDictionary->podTemplates`. The ibm-mas-suite operator will then pass this on to the AssetDataDictionary CR when available.
 
 For examples refer to the [BestEfforts reference configuration in the MAS CLI](https://github.com/ibm-mas/cli/blob/master/image/cli/mascli/templates/pod-templates/best-effort/ibm-mas-suite.yml), for full documentation of the supported options refer to the [Customizing Pod Templates](https://www.ibm.com/docs/en/mas-cd/continuous-delivery?topic=configuring-customizing-workloads) in the product documentation.
 
@@ -91,7 +91,7 @@ For examples refer to the [BestEfforts reference configuration in the MAS CLI](h
 - Default: None
 
 ### enable_IPv6
-Boolean variable that inciates whether it is to install in an IPv6-enabled environment.  If it is true, the suite CR will have the PreferDualStack for ipFamilyPolicy and ["IPv6", "IPv4"] for ipFamilies.  These ipFamily properties will be populated to all the services. This is currently available only in internal fyre clusters at the RTP site for testing purpose.
+Boolean variable that indicates whether it is to install in an IPv6-enabled environment.  If it is true, the suite CR will have the PreferDualStack for ipFamilyPolicy and ["IPv6", "IPv4"] for ipFamilies.  These ipFamily properties will be populated to all the services. This is currently available only in internal fyre clusters at the RTP site for testing purpose.
 
 - Optional
 - Environment Variable: `ENABLE_IPv6`,

--- a/ibm/mas_devops/roles/suite_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_install/tasks/main.yml
@@ -115,6 +115,14 @@
   vars:
     config_files:
       - "ibm-mas-suite.yml"
+      - "ibm-mas-coreidp.yml"
+    combine_into:
+      - "ibm-mas-suite.yml"
+
+- name: "Load podTemplates configuration"
+  include_tasks: "{{ role_path }}/../../common_tasks/pod_templates/main.yml"
+  vars:
+    config_files:
       - "ibm-data-dictionary-assetdatadictionary.yml"
 
 # 3. Set up the domain name for MAS

--- a/ibm/mas_devops/roles/suite_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_install/tasks/main.yml
@@ -12,7 +12,7 @@
     fail_msg:
       - "mas_instance_id does not meet requirements"
       - "Must be 3-12 characters long"
-      - "Must only use lowercase letters, numbers, and hypen (-) symbol"
+      - "Must only use lowercase letters, numbers, and hyphen (-) symbol"
       - "Must start with a lowercase letter"
       - "Must end with a lowercase letter or a number"
 
@@ -253,7 +253,7 @@
 # 10. Handle IBM Common Services Install plan approvals when upgrade strategy is set to Manual
 # -----------------------------------------------------------------------------
 # ibm-common-services operators deployed by MAS will inherit the inherit MAS upgrade strategy
-# when its set to Manual, we need to interate those to ensure we do approve the first install plan
+# when its set to Manual, we need to iterate those to ensure we do approve the first install plan
 # otherwise MAS installation wont succeed.
 - include_tasks: tasks/ibm-common-services.yml
   when: mas_upgrade_strategy == 'Manual'

--- a/ibm/mas_devops/roles/suite_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_install/tasks/main.yml
@@ -110,28 +110,12 @@
 
 # 2. Load PodTemplates configuration
 # -----------------------------------------------------------------------------
-- name: Load podTemplates configuration
+- name: "Load podTemplates configuration"
+  include_tasks: "{{ role_path }}/../../common_tasks/pod_templates/main.yml"
   vars:
-    config_file_name: "ibm-mas-suite.yml"
-  when:
-    - mas_pod_templates_dir is defined
-    - mas_pod_templates_dir != ''
-  block:
-    - name: Check whether configuration exists
-      ansible.builtin.stat:
-        path: "{{ mas_pod_templates_dir }}/{{ config_file_name }}"
-      register: pod_templates_file_lookup
-
-    - name: Load podTemplates configuration
-      ansible.builtin.include_vars:
-        file: "{{ mas_pod_templates_dir }}/{{ config_file_name }}"
-        name: ibm_mas_suite_pod_templates
-      when: pod_templates_file_lookup.stat.exists
-
-    - name: Failed to find configuration
-      ansible.builtin.debug:
-        msg: "Could not find '{{ mas_pod_templates_dir }}/{{ config_file_name }}' - Skipping"
-      when: not pod_templates_file_lookup.stat.exists
+    config_files:
+      - "ibm-mas-suite.yml"
+      - "ibm-data-dictionary-assetdatadictionary.yml"
 
 # 3. Set up the domain name for MAS
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/suite_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_install/tasks/main.yml
@@ -116,8 +116,7 @@
     config_files:
       - "ibm-mas-suite.yml"
       - "ibm-mas-coreidp.yml"
-    combine_into:
-      - "ibm-mas-suite.yml"
+    combine_into: "ibm-mas-suite.yml"
 
 - name: "Load podTemplates configuration"
   include_tasks: "{{ role_path }}/../../common_tasks/pod_templates/main.yml"

--- a/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
+++ b/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
@@ -27,8 +27,8 @@ spec:
   domain: "{{ mas_domain }}"
   license:
     accept: true
-{% if ibm_mas_suite_pod_templates.podTemplates is defined %}
-  podTemplates: {{ ibm_mas_suite_pod_templates.podTemplates }}
+{% if ibm_mas_suite_pod_templates is defined %}
+  podTemplates: {{ ibm_mas_suite_pod_templates }}
 {% endif %}
   settings:
 {% if mas_channel != '8.7.x' and mas_channel != '8.8.x' %}
@@ -44,6 +44,9 @@ spec:
 {% endif %}
 {% if mas_add_channel != '' %}
       channel: {{ mas_add_channel }}
+{% endif %}
+{% if ibm_data_dictionary_assetdatadictionary_pod_templates is defined %}
+      podTemplates: {{ ibm_data_dictionary_assetdatadictionary_pod_templates }}
 {% endif %}
 {% endif %}
 {% if mas_img_pull_policy != '' %}

--- a/ibm/mas_devops/roles/uds/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/uds/tasks/install/main.yml
@@ -27,28 +27,10 @@
 
 # 3. Load PodTemplates configuration
 # -----------------------------------------------------------------------------
-- name: Load podTemplates configuration
+- name: "Load podTemplates configuration"
+  include_tasks: "{{ role_path }}/../../common_tasks/pod_templates/main.yml"
   vars:
-    config_file_name: "ibm-mas-bascfg.yml"
-  when:
-    - mas_pod_templates_dir is defined
-    - mas_pod_templates_dir != ''
-  block:
-    - name: Check whether configuration exists
-      ansible.builtin.stat:
-        path: "{{ mas_pod_templates_dir }}/{{ config_file_name }}"
-      register: pod_templates_file_lookup
-
-    - name: Load podTemplates configuration
-      ansible.builtin.include_vars:
-        file: "{{ mas_pod_templates_dir }}/{{ config_file_name }}"
-        name: ibm_mas_bascfg_pod_templates
-      when: pod_templates_file_lookup.stat.exists
-
-    - name: Failed to find configuration
-      ansible.builtin.debug:
-        msg: "Could not find '{{ mas_pod_templates_dir }}/{{ config_file_name }}' - Skipping"
-      when: not pod_templates_file_lookup.stat.exists
+    config_files: ["ibm-mas-bascfg.yml"]
 
 
 # 4. Install Crunchy Postgres Operator (Properly)

--- a/ibm/mas_devops/roles/uds/tasks/install_suds/main.yml
+++ b/ibm/mas_devops/roles/uds/tasks/install_suds/main.yml
@@ -7,28 +7,10 @@
 
 # 2. Load PodTemplates configuration
 # -----------------------------------------------------------------------------
-- name: Load podTemplates configuration
+- name: "Load podTemplates configuration"
+  include_tasks: "{{ role_path }}/../../common_tasks/pod_templates/main.yml"
   vars:
-    config_file_name: "ibm-mas-bascfg.yml"
-  when:
-    - mas_pod_templates_dir is defined
-    - mas_pod_templates_dir != ''
-  block:
-    - name: Check whether configuration exists
-      ansible.builtin.stat:
-        path: "{{ mas_pod_templates_dir }}/{{ config_file_name }}"
-      register: pod_templates_file_lookup
-
-    - name: Load podTemplates configuration
-      ansible.builtin.include_vars:
-        file: "{{ mas_pod_templates_dir }}/{{ config_file_name }}"
-        name: ibm_mas_bascfg_pod_templates
-      when: pod_templates_file_lookup.stat.exists
-
-    - name: Failed to find configuration
-      ansible.builtin.debug:
-        msg: "Could not find '{{ mas_pod_templates_dir }}/{{ config_file_name }}' - Skipping"
-      when: not pod_templates_file_lookup.stat.exists
+    config_files: ["ibm-mas-bascfg.yml"]
 
 # 3. Generate BASCfg for MAS
 # All we need to do is create the relevant config, the BASCfg entity manager will

--- a/ibm/mas_devops/roles/uds/templates/bascfg-suds.yml.j2
+++ b/ibm/mas_devops/roles/uds/templates/bascfg-suds.yml.j2
@@ -10,6 +10,6 @@ metadata:
 spec:
   displayName: SUDS {{ mas_instance_id }}
   suds: true
-{% if ibm_mas_bascfg_pod_templates.podTemplates is defined %}
-  podTemplates: {{ ibm_mas_bascfg_pod_templates.podTemplates }}
+{% if ibm_mas_bascfg_pod_templates is defined %}
+  podTemplates: {{ ibm_mas_bascfg_pod_templates }}
 {% endif %}

--- a/ibm/mas_devops/roles/uds/templates/bascfg.yml.j2
+++ b/ibm/mas_devops/roles/uds/templates/bascfg.yml.j2
@@ -82,6 +82,6 @@ spec:
         mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d
         emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
         -----END CERTIFICATE-----
-{% if ibm_mas_bascfg_pod_templates.podTemplates is defined %}
-  podTemplates: {{ ibm_mas_bascfg_pod_templates.podTemplates }}
+{% if ibm_mas_bascfg_pod_templates is defined %}
+  podTemplates: {{ ibm_mas_bascfg_pod_templates }}
 {% endif %}


### PR DESCRIPTION
## Description

- Refactored podTemplates code into a common one under common_tasks
- We can now merge multiple podTemplates into one (used for Suite CR e.g. suite and coreidp) by passing in `vars -> combine_into`
- Auto generates the fact e.g., `ibm-mas-suite.yml` -> `ibm_mas_suite_pod_templates`
- Added support for `ibm-data-dictionary-assetdatadictionary.yml` podTemplates
- Updated suite_install README

## Testing

- Tested in fyre cluster