### PR TITLE
[patch] update uds_version to 2.0.12 for airgap mirroring

### DIFF
--- a/ibm/mas_devops/common_vars/casebundles/v8-231031-amd64.yml
+++ b/ibm/mas_devops/common_vars/casebundles/v8-231031-amd64.yml
@@ -12,7 +12,7 @@ catalog_digest: sha256:709606362f60456afdb117606dafecc3133118de42d26236f9f2c8bbd
 common_svcs_version: 1.19.4                  # Operator version 3.23.4 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
 db2u_version: 5.1.4                          # Operator version 110508.0.2 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
 events_version: 4.6.1                        # Operator version 4.6.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
-uds_version: 2.0.11                          # Operator version 2.0.11
+uds_version: 2.0.12                          # Operator version 2.0.12
 sls_version: 3.8.1                           # Operator version 3.8.1
 tsm_version: 1.5.1                           # Operator version 1.5.1
 dd_version: 1.1.5                            # Operator version 1.1.5


### PR DESCRIPTION
https://github.com/ibm-mas/cli/issues/644

UDS 2.0.11 was mirrored though 2.0.12 was available in 231031 catalog. 
This change should allow mirror-images role to pick up 2.0.12 for 231031 catalog.