### PR TITLE
[patch] Fixes and tweaks for better Red Hat content mirroring

### DIFF
--- a/ibm/mas_devops/roles/mirror_ocp/tasks/actions/to-filesystem.yml
+++ b/ibm/mas_devops/roles/mirror_ocp/tasks/actions/to-filesystem.yml
@@ -25,4 +25,4 @@
 
 - name: "Mirror Red Hat content from source registry to filesystem"
   shell: >
-    DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --config={{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml file:///{{ mirror_working_dir }} &> {{ mirror_working_dir }}/logs/mirror-ocp{{ ocp_release }}.log
+    DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --config={{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml file:///{{ mirror_working_dir }} &> {{ mirror_working_dir }}/logs/mirror-to-filesystem-ocp{{ ocp_release }}.log

--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -25,11 +25,9 @@ mirror:
           channels:
             - name: v5
         - name: gpu-operator-certified  # Required by ibm.mas_devops.nvidia_gpu role
-        # - name: kubeturbo-certified  # Required by ibm.mas_devops.kubeturbo role
-        #   OCI images are not supported by oc image mirror
-        #   https://access.redhat.com/solutions/6997884
-        #   https://issues.redhat.com/browse/CFE-780
-        #   OCI index found, but accept header does not support OCI indexes
+        - name: kubeturbo-certified  # Required by ibm.mas_devops.kubeturbo role
+          channels:
+            - name: stable
 
     # community-operators
     - catalog: registry.redhat.io/redhat/community-operator-index:v{{ ocp_release }}
@@ -37,12 +35,12 @@ mirror:
         - name: grafana-operator  #  Required by ibm.mas_devops.cluster_monitoring role
           channels:
             - name: v4
-    #   - name: opentelemetry-operator  # Required by ibm.mas_devops.cluster_monitoring role
-
-    #   OCI images are not supported by oc image mirror
-    #   https://access.redhat.com/solutions/6997884
-    #   https://issues.redhat.com/browse/CFE-780
-    #   OCI index found, but accept header does not support OCI indexes
+        - name: opentelemetry-operator  # Required by ibm.mas_devops.cluster_monitoring role
+          channels:
+            - name: alpha
+        - name: strimzi-kafka-operator  #  Required by ibm.mas_devops.kafka role
+          channels:
+            - name: stable
 
     # redhat-operators
     - catalog: registry.redhat.io/redhat/redhat-operator-index:v{{ ocp_release }}

--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -25,6 +25,8 @@ mirror:
           channels:
             - name: v5
         - name: gpu-operator-certified  # Required by ibm.mas_devops.nvidia_gpu role
+          channels:
+            - name: v23.3
         - name: kubeturbo-certified  # Required by ibm.mas_devops.kubeturbo role
           channels:
             - name: stable

--- a/ibm/mas_devops/roles/nvidia_gpu/README.md
+++ b/ibm/mas_devops/roles/nvidia_gpu/README.md
@@ -29,7 +29,7 @@ The namespace where the NVIDIA GPU operator will be deployed. For version 1.8.x,
 The channel to subscribe to for the gpu operator installation and updates. Available channels may be found in the package manifest of gpu-operator-certified operator in openshift.
 
 - Environment Variable: `GPU_CHANNEL`
-- Default Value: `v1.11`
+- Default Value: `v23.3`
 
 ### gpu_driver_version
 The gpu driver version image that needs to be pulled from the gpu driver repository. It is recommended that the right version of GPU driver is used depending on the OS version. The default versions are shown below. See the attached links for more information and to decide which driver version to use.

--- a/ibm/mas_devops/roles/ocp_contentsourcepolicy/templates/redhat-catalogs.yml.j2
+++ b/ibm/mas_devops/roles/ocp_contentsourcepolicy/templates/redhat-catalogs.yml.j2
@@ -41,17 +41,41 @@ metadata:
 spec:
   repositoryDigestMirrors:
   - mirrors:
+    - {{ registry_private_url }}/cpopen
+    source: icr.io/cpopen
+  - mirrors:
+    - {{ registry_private_url }}/rhel8
+    source: registry.redhat.io/rhel8
+  - mirrors:
     - {{ registry_private_url }}/crunchydata
     source: registry.connect.redhat.com/crunchydata
   - mirrors:
-    - {{ registry_private_url }}/kubebuilder
-    source: gcr.io/kubebuilder
+    - {{ registry_private_url }}/nvidia
+    source: registry.connect.redhat.com/nvidia
   - mirrors:
-    - {{ registry_private_url }}/amq-streams
-    source: registry.redhat.io/amq-streams
+    - {{ registry_private_url }}/grafana-operator
+    source: quay.io/grafana-operator
+  - mirrors:
+    - {{ registry_private_url }}/open-telemetry
+    source: ghcr.io/open-telemetry
+  - mirrors:
+    - {{ registry_private_url }}/source-to-image
+    source: registry.redhat.io/source-to-image
+  - mirrors:
+    - {{ registry_private_url }}/odf4
+    source: registry.redhat.io/odf4
+  - mirrors:
+    - {{ registry_private_url }}/operator-pipeline-prod
+    source: quay.io/operator-pipeline-prod
+  - mirrors:
+    - {{ registry_private_url }}/strimzi
+    source: quay.io/strimzi
   - mirrors:
     - {{ registry_private_url }}/rhceph
     source: registry.redhat.io/rhceph
+  - mirrors:
+    - {{ registry_private_url }}/amq-streams
+    source: registry.redhat.io/amq-streams
   - mirrors:
     - {{ registry_private_url }}/nvidia
     source: nvcr.io/nvidia
@@ -59,32 +83,20 @@ spec:
     - {{ registry_private_url }}/openshift4
     source: registry.redhat.io/openshift4
   - mirrors:
-    - {{ registry_private_url }}/openshift-pipelines
-    source: registry.redhat.io/openshift-pipelines
-  - mirrors:
-    - {{ registry_private_url }}/operator-pipeline-prod
-    source: quay.io/operator-pipeline-prod
-  - mirrors:
     - {{ registry_private_url }}/openshift-community-operators
     source: quay.io/openshift-community-operators
   - mirrors:
-    - {{ registry_private_url }}/grafana-operator
-    source: quay.io/grafana-operator
+    - {{ registry_private_url }}/kubebuilder
+    source: gcr.io/kubebuilder
   - mirrors:
     - {{ registry_private_url }}/ubi8
     source: registry.redhat.io/ubi8
   - mirrors:
-    - {{ registry_private_url }}/ocp-tools-4-tech-preview
-    source: registry.redhat.io/ocp-tools-4-tech-preview
+    - {{ registry_private_url }}/openshift-pipelines
+    source: registry.redhat.io/openshift-pipelines
   - mirrors:
     - {{ registry_private_url }}/openshift-serverless-1
     source: registry.redhat.io/openshift-serverless-1
   - mirrors:
-    - {{ registry_private_url }}/odf4
-    source: registry.redhat.io/odf4
-  - mirrors:
-    - {{ registry_private_url }}/rhel8
-    source: registry.redhat.io/rhel8
-  - mirrors:
-    - {{ registry_private_url }}/nvidia
-    source: registry.connect.redhat.com/nvidia
+    - {{ registry_private_url }}/turbonomic
+    source: registry.connect.redhat.com/turbonomic


### PR DESCRIPTION
- Expands the scope of content included in the `ImageSetConfiguration`
- Adds new entries to the MAS Red Hat Catalog `ImageContentSourcePolicy`
- Corrects the default channel in Nvidia role documentation