### PR TITLE
[patch] Adding cluster's ingress in DNS record list for Route53 hosted zone

### DIFF
--- a/ibm/mas_devops/common_tasks/pod_templates/main.yml
+++ b/ibm/mas_devops/common_tasks/pod_templates/main.yml
@@ -30,7 +30,7 @@
       block:
         - name: Get and combine podTemplates
           ansible.builtin.set_fact:
-              merged_pod_templates_list: "{{ merged_pod_templates_list | default([]) + item_list }}"
+            merged_pod_templates_list: "{{ merged_pod_templates_list | default([]) + item_list }}"
           vars:
             item_name: "{{ item | splitext | first | replace('-', '_') }}_pod_templates"
             item_list: "{{ lookup('ansible.builtin.vars', item_name, default='') | default([], true) }}"

--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/route53/create-cnames.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/route53/create-cnames.yml
@@ -20,14 +20,24 @@
     route53_lb_dnsname_output: "{{ aws_hosted_zone_loadbalancer_output.stdout }}"
 
 - set_fact:
-    route53_lb_dnsname: "{{ route53_lb_dnsname_output | first }}"
+    route53_lb_dnsname: "{{ route53_lb_dnsname_output | first | regex_search('^.*(?=.$)') }}" # removes a dot at the end that aws cli command adds
+
+- name: "aws-route53 : Lookup Load Balancer's zone id" # this finds the load balancer host id based on the load balancer dns name
+  shell: |
+    aws elb describe-load-balancers |
+    jq --arg name {{ route53_lb_dnsname }} \
+    -r '.LoadBalancerDescriptions | .[] | select(.CanonicalHostedZoneName=="\($name)") | .CanonicalHostedZoneNameID'
+  register: aws_hosted_zone_id_loadbalancer_output
+
+- set_fact:
+    route53_lb_zone_id: "{{ aws_hosted_zone_id_loadbalancer_output.stdout }}"
 
 - name: "Assert Load Balancer DNS Name for cluster {{ cluster_ingress }} exists"
   assert:
     that: route53_lb_dnsname is defined and route53_lb_dnsname != ""
     fail_msg: "There is no Load Balancer DNS Name found for {{ cluster_ingress }}. Verify your AWS Route53 hosted zone '{{ route53_hosted_zone_name }}' and ensure there's an 'A type' entry for your cluster and a corresponding load balancer associated to it."
 
-- name: "aws-route53 : Generate CNAME json file for {{ route53_lb_dnsname }}"
+- name: "aws-route53 : Generate CNAME json file in: {{ route53_cname_json_file_path_local }}/{{ mas_instance_id }}-{{ route53_hosted_zone_name }}-cnames.json"
   ansible.builtin.template:
     src: "{{ route53_cname_json_file_path_local }}/create-cnames.json.j2"
     dest: "{{ route53_cname_json_file_path_local }}/{{ mas_instance_id }}-{{ route53_hosted_zone_name }}-cnames.json"
@@ -37,4 +47,7 @@
   shell: |
     aws route53 change-resource-record-sets --hosted-zone-id {{ route53_hosted_zone_id }} --change-batch file://{{ route53_cname_json_file_path_local }}/{{ mas_instance_id }}-{{ route53_hosted_zone_name }}-cnames.json
   register: aws_hosted_zone_loadbalancer_output
-  failed_when: aws_hosted_zone_loadbalancer_output.rc > 0 and ('it already exists' not in aws_hosted_zone_loadbalancer_output.stderr )
+  failed_when: aws_hosted_zone_loadbalancer_output.rc > 0 and ('it already exists' in aws_hosted_zone_loadbalancer_output.stderr )
+
+- debug:
+    var: aws_hosted_zone_loadbalancer_output

--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/route53/create-cnames.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/route53/create-cnames.yml
@@ -48,6 +48,3 @@
     aws route53 change-resource-record-sets --hosted-zone-id {{ route53_hosted_zone_id }} --change-batch file://{{ route53_cname_json_file_path_local }}/{{ mas_instance_id }}-{{ route53_hosted_zone_name }}-cnames.json
   register: aws_hosted_zone_loadbalancer_output
   failed_when: aws_hosted_zone_loadbalancer_output.rc > 0 and ('it already exists' in aws_hosted_zone_loadbalancer_output.stderr )
-
-- debug:
-    var: aws_hosted_zone_loadbalancer_output

--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/route53/create-cnames.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/route53/create-cnames.yml
@@ -41,7 +41,7 @@
   ansible.builtin.template:
     src: "{{ route53_cname_json_file_path_local }}/create-cnames.json.j2"
     dest: "{{ route53_cname_json_file_path_local }}/{{ mas_instance_id }}-{{ route53_hosted_zone_name }}-cnames.json"
-    mode: '664'
+    mode: "664"
 
 - name: "aws-route53 : Create CNAME records pointing to {{ route53_lb_dnsname }}"
   shell: |

--- a/ibm/mas_devops/roles/suite_dns/templates/route53/create-cnames.json.j2
+++ b/ibm/mas_devops/roles/suite_dns/templates/route53/create-cnames.json.j2
@@ -21,6 +21,18 @@
 				    "Value": "{{ route53_lb_dnsname }}"
 				}]
 			}
+		},
+		{
+			"Action": "CREATE",
+			"ResourceRecordSet": {
+			    "Name": "{{ cluster_ingress }}",
+				"Type": "A",
+				"AliasTarget": {
+					"HostedZoneId": "{{ route53_lb_zone_id }}",
+					"DNSName": "{{ route53_lb_dnsname }}",
+					"EvaluateTargetHealth": false
+				}
+			}
 		}
 	]
 }


### PR DESCRIPTION
- Fix for #[547](https://github.com/ibm-mas/cli/issues/547) and #[548](https://github.com/ibm-mas/cli/issues/548)

We are simply adding the cluster's ingress as "A" type entry on the record list for the hosted zone in order to resolve the certificate requests coming from the target cluster.