### PR TITLE
[patch] update nov catalog digest and amlen 1.0.2 extras

### DIFF
--- a/ibm/mas_devops/common_vars/casebundles/v8-231128-amd64.yml
+++ b/ibm/mas_devops/common_vars/casebundles/v8-231128-amd64.yml
@@ -1,11 +1,11 @@
 ---
-# Case bundle configuration for IBM Maximo Operator Catalog v230926
+# Case bundle configuration for IBM Maximo Operator Catalog v231128
 # -----------------------------------------------------------------------------
 # In the future this won't be necessary as we'll be able to mirror from the
 # catalog itself, but not everything in the catalog supports this yet (including MAS)
 # so we need to use the CASE bundle mirror process still.
 
-catalog_digest: sha256:c9188a9e546afc4c918ed7a9b55fce58504063f98926cfb11a8c2fd591dd44e4
+catalog_digest: sha256:e9f2439166ee18b540b8fc4484e3df5235bfaf7293dadd181b5755c3c79c602a
 
 # Dependencies
 # -----------------------------------------------------------------------------
@@ -91,3 +91,7 @@ db2u_extras_version: 1.0.2
 # Extra Images for IBM Watson Discovery
 # ------------------------------------------------------------------------------
 wd_extras_version: 1.0.1
+
+# Extra Images for Amlen
+# ------------------------------------------------------------------------------
+amlen_extras_version: 1.0.2

--- a/ibm/mas_devops/roles/mirror_extras_prepare/vars/amlen_1.0.2.yml
+++ b/ibm/mas_devops/roles/mirror_extras_prepare/vars/amlen_1.0.2.yml
@@ -1,0 +1,11 @@
+---
+extra_images:
+  - name: amlen/operator-bundle
+    registry: quay.io
+    digest: sha256:5b850a46f4c00458efae2dafdad292fcd20312279324110aef65aec92bb9807e
+    tag: 1.0.2
+
+  - name: amlen/operator
+    registry: quay.io
+    digest: sha256:1c65cc6211019f35364552f4ed331cbec45425e4f21e737eda7dfc88d453057e
+    tag: 1.0.2


### PR DESCRIPTION
https://github.ibm.com/maximoappsuite/ibm-maximo-operator-catalog/pull/327

Update Nov catalog digest and it now contains Amlen 1.0.2