### PR TITLE
[patch] Ensure cluster_ingress_tls_crt_remove_it is defined

### DIFF
--- a/ibm/mas_devops/common_tasks/get_signed_ingress_cert.yml
+++ b/ibm/mas_devops/common_tasks/get_signed_ingress_cert.yml
@@ -98,10 +98,14 @@
     cluster_ingress_tls_crt: "{{ cluster_ingress_tls_crt | regex_findall('(?s)(-----BEGIN .+?-----.+?-----END .+?-----)', multiline=True, ignorecase=True) }}"
   no_log: true
 
-# Filter DST Root CA X3 issuer certificate if present
+# Filter out of date DST Root CA X3 issuer certificate if present
+# This is a known problem in IBMCloud ROKS clusters, where an expired
+# root certificate is included in the chain, the inclusion of this
+# certificate in our truststore prevents MAS being able to connect
+# to IBM User Data Services because it's an invalid certificate.
 - name: "Check if DST Root CA X3 issuer certificate is present"
   vars:
-    dst_root_x3: "Dfvp7OOGAN6dEOM4+qR9sdjoSYKEBpsr6GtPAQw4dy753ec5" # if DST Root CA X3 issuer certificate is present, we'll filter from the MAS config
+    dst_root_x3: "Dfvp7OOGAN6dEOM4+qR9sdjoSYKEBpsr6GtPAQw4dy753ec5"
   no_log: true
   set_fact:
     cluster_ingress_tls_crt_remove_it: "{{ cluster_ingress_tls_crt_remove_it|default([]) + [item] }}"
@@ -115,6 +119,7 @@
   set_fact:
     cluster_ingress_tls_crt: "{{ cluster_ingress_tls_crt | difference(cluster_ingress_tls_crt_remove_it) | list }}"
   when:
+    - cluster_ingress_tls_crt_remove_it is defined
     - cluster_ingress_tls_crt is defined
     - cluster_ingress_tls_crt | length > 0
 


### PR DESCRIPTION
We are not checking whether `cluster_ingress_tls_crt_remove_it` is defined before using the variable.

- Fix for #1130