### PR TITLE
[patch] get db2u version from db2u-release configmap instead of secret

### DIFF
--- a/ibm/mas_devops/roles/db2/README.md
+++ b/ibm/mas_devops/roles/db2/README.md
@@ -75,7 +75,7 @@ Version of the DB2 engine to be used while creating/upgrading the DB2 instances.
 
 - Optional
 - Environment Variable: `DB2_VERSION`
-- Default: The default db2 engine version will be automatically defined to the latest version supported by the installed DB2 operator if this is not set. The DB2 engine versions supported by the installed DB2 operator are stored in `db2u-license-keys` secret under `ibm-common-services` namespace.
+- Default: The default db2 engine version will be automatically defined to the latest version supported by the installed DB2 operator if this is not set. The DB2 engine versions supported by the installed DB2 operator are stored in `db2u-release` configmap under `ibm-common-services` namespace.
 
 ### db2_4k_device_support
 Whether 4K device support is turned on or not.

--- a/ibm/mas_devops/roles/db2/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/db2/tasks/install/main.yml
@@ -255,7 +255,7 @@
 
     - name: Set db2 version
       ansible.builtin.set_fact:
-        db2_version: "{{ db2_releases_content.database.db2u | last }}"
+        db2_version: "{{ db2_releases_content.databases.db2u | last }}"
 
   when: db2_version is not defined or db2_version == ""
 

--- a/ibm/mas_devops/roles/db2/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/db2/tasks/install/main.yml
@@ -230,31 +230,32 @@
     - db2_crd_info.resources | length > 0
 
 # if db2_version is not set, then we define it based on the latest version supported by the db2u-license-keys secret
+# Starting with s11.5.8.0-cn3, the 's' prefix is removed in db2u-license-keys, we are recommeded to use db2u-release configmap.
 - block:
-    - name: "Wait until the db2u-license-keys secret is available"
+    - name: "Wait until the db2u-release configmap is available"
       no_log: true
       kubernetes.core.k8s_info:
         api_version: v1
-        name: db2u-license-keys
+        name: db2u-release
         namespace: "{{ ibm_common_services_namespace }}"
-        kind: Secret
-      register: db2_license_info
+        kind: ConfigMap
+      register: db2_release_info
       retries: 20 # ~approx 10 minutes before we give up waiting for the CRD to be created
       delay: 30 # seconds
       until:
-        - db2_license_info.resources is defined
-        - db2_license_info.resources | length > 0
-        - db2_license_info.resources[0].data is defined
-        - db2_license_info.resources[0].data | length > 0
+        - db2_release_info.resources is defined
+        - db2_release_info.resources | length > 0
+        - db2_release_info.resources[0].data is defined
+        - db2_release_info.resources[0].data | length > 0
 
-    - name: Set db2u-license-keys secret content
+    - name: Set db2u-release configmap content
       no_log: true
       set_fact:
-        db2_license_content: "{{ db2_license_info.resources[0].data.json | b64decode }}"
+        db2_releases_content: "{{ db2_release_info.resources[0].data.json }}"
 
     - name: Set db2 version
       ansible.builtin.set_fact:
-        db2_version: "{{ db2_license_content.db2wh | last }}"
+        db2_version: "{{ db2_releases_content.database.db2u | last }}"
 
   when: db2_version is not defined or db2_version == ""
 

--- a/ibm/mas_devops/roles/db2/tasks/upgrade/run-db2-instances-upgrade.yml
+++ b/ibm/mas_devops/roles/db2/tasks/upgrade/run-db2-instances-upgrade.yml
@@ -22,31 +22,32 @@
 # 2. Determine if upgrade is needed and perform it
 # -----------------------------------------------------------------------------
 # if db2_version is not set, then we define it based on the latest version supported by the db2u-license-keys secret
+# Starting with s11.5.8.0-cn3, the 's' prefix is removed in db2u-license-keys, we are recommeded to use db2u-release configmap.
 - block:
-    - name: "Wait until the db2u-license-keys secret is available"
+    - name: "Wait until the db2u-release configmap is available"
       no_log: true
       kubernetes.core.k8s_info:
         api_version: v1
-        name: db2u-license-keys
+        name: db2u-release
         namespace: "{{ ibm_common_services_namespace }}"
-        kind: Secret
-      register: db2_license_info
+        kind: ConfigMap
+      register: db2_release_info
       retries: 20 # ~approx 10 minutes before we give up waiting for the CRD to be created
       delay: 30 # seconds
       until:
-        - db2_license_info.resources is defined
-        - db2_license_info.resources | length > 0
-        - db2_license_info.resources[0].data is defined
-        - db2_license_info.resources[0].data | length > 0
+        - db2_release_info.resources is defined
+        - db2_release_info.resources | length > 0
+        - db2_release_info.resources[0].data is defined
+        - db2_release_info.resources[0].data | length > 0
 
-    - name: Set db2u-license-keys secret content
+    - name: Set db2u-release configmap content
       no_log: true
       set_fact:
-        db2_license_content: "{{ db2_license_info.resources[0].data.json | b64decode }}"
+        db2_releases_content: "{{ db2_release_info.resources[0].data.json }}"
 
     - name: Set db2 version
       ansible.builtin.set_fact:
-        db2_version: "{{ db2_license_content.db2wh | last }}"
+        db2_version: "{{ db2_releases_content.database.db2u | last }}"
 
   when: db2_version is not defined or db2_version == ""
 

--- a/ibm/mas_devops/roles/db2/tasks/upgrade/run-db2-instances-upgrade.yml
+++ b/ibm/mas_devops/roles/db2/tasks/upgrade/run-db2-instances-upgrade.yml
@@ -47,7 +47,7 @@
 
     - name: Set db2 version
       ansible.builtin.set_fact:
-        db2_version: "{{ db2_releases_content.database.db2u | last }}"
+        db2_version: "{{ db2_releases_content.databases.db2u | last }}"
 
   when: db2_version is not defined or db2_version == ""
 


### PR DESCRIPTION
Starting with db2u v`s11.5.8.0-cn3`, the 's' prefix is removed in db2u-license-keys causing installation issues , we were recommended to use `db2u-release` configmap instead of `db2u-license-keys` secret.

This change is in preparation for November curated content from IBM operator catalog. and also backward compatible.

