### PR TITLE
[patch] Allow FYRE provision without storage configuration

### DIFF
--- a/ibm/mas_devops/playbooks/ocp_fyre_provision.yml
+++ b/ibm/mas_devops/playbooks/ocp_fyre_provision.yml
@@ -8,6 +8,8 @@
     # requires for FIPS clusters
     ocp_update_ciphers_for_semeru: True
 
+    fyre_config_storage: "{{ lookup('env', 'FYRE_CONFIG_STORAGE') | default('true', True) | bool }}"
+
   pre_tasks:
     # For the full set of supported environment variables refer to the playbook documentation
     - name: Check for required environment variables
@@ -21,14 +23,15 @@
 
   roles:
     # 1. Provision the FYRE cluster
-    - ibm.mas_devops.ocp_provision
+    - name: ibm.mas_devops.ocp_provision
 
     # 2. Login and verify the cluster is ready
-    - ibm.mas_devops.ocp_login
-    - ibm.mas_devops.ocp_verify
+    - name: ibm.mas_devops.ocp_login
+    - name: ibm.mas_devops.ocp_verify
 
     # 3. Update the APIServer to custom for FIPS compatibility
-    - ibm.mas_devops.ocp_config
+    - name: ibm.mas_devops.ocp_config
 
     # 4. Install OpenShift Container Storage
-    - ibm.mas_devops.ocs
+    - name: ibm.mas_devops.ocs
+      when: fyre_config_storage


### PR DESCRIPTION
This is primarily used in airgap testing, we don't want to install the cluster storage before we switch to the mirror catalog source.