### PR TITLE
[patch] add support to new db2 operator versions in suite_db2_setup_for_manage

### DIFF
--- a/ibm/mas_devops/roles/suite_db2_setup_for_manage/tasks/apply-db2-config-settings.yml
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_manage/tasks/apply-db2-config-settings.yml
@@ -58,7 +58,7 @@
 
 # Run script twice for DB2 standalone
 - name: Check DB2 cfg is take effect
-  when: 
+  when:
     - prepare_cmds_status is defined
     - prepare_cmds_status.rc == 0
   shell: |

--- a/ibm/mas_devops/roles/suite_db2_setup_for_manage/tasks/apply-db2-config-settings.yml
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_manage/tasks/apply-db2-config-settings.yml
@@ -27,18 +27,34 @@
   pause:
     minutes: 1
 
-- name: Run script to make changes take effect
-  shell: oc exec -n {{db2_namespace}} {{db2_pod_name}} -- su -lc '/db2u/scripts/apply-db2cfg-settings.sh | tee /tmp/apply-db2cfg-settings.log' db2inst1
+- name: Run script (for db2 operator s11.5.8.0-cn2 and older) to make changes take effect
+  shell: oc exec -n {{db2_namespace}} {{db2_pod_name}} -- su -lc '/db2u/scripts/apply-db2cfg-settings.sh' db2inst1
+  register: old_prepare_cmds_status
+
+- name: Run script (for db2 operator s11.5.8.0-cn3 and newer) to make changes take effect
+  when: old_prepare_cmds_status.rc != 0
+  shell: oc exec -n {{db2_namespace}} {{db2_pod_name}} -- su -lc '/db2u/scripts/apply-db2cfg-settings.sh --setting all' db2inst1
   register: prepare_cmds_status
 
-- fail: msg="Failed to execute the script /db2u/scripts/apply-db2cfg-settings.sh on DB2 instance"
+- fail: msg="Failed to execute the script /db2u/scripts/apply-db2cfg-settings.sh --setting all on DB2 instance(s11.5.8.0-cn3 and newer))"
   when:
     - prepare_cmds_status.rc != 0
 
 # Run script twice for DB2 standalone
 - name: Check DB2 cfg is take effect
+  when: old_prepare_cmds_status == 0
   shell: |
     oc exec -n {{db2_namespace}} {{db2_pod_name}} -- su -lc '/db2u/scripts/apply-db2cfg-settings.sh | tee /tmp/apply-db2cfg-settings.log' db2inst1
+    oc exec -n {{db2_namespace}} {{db2_pod_name}} -- su -lc 'db2 get db cfg for {{ db2_dbname }} | grep "(CHNGPGS_THRESH) = 40"' db2inst1
+  register: check_cmds_status
+  until: check_cmds_status.rc == 0
+  retries: 5
+  delay: 30 # seconds
+
+- name: Check DB2 cfg is take effect
+  when: prepare_cmds_status == 0
+  shell: |
+    oc exec -n {{db2_namespace}} {{db2_pod_name}} -- su -lc '/db2u/scripts/apply-db2cfg-settings.sh --setting all | tee /tmp/apply-db2cfg-settings.log' db2inst1
     oc exec -n {{db2_namespace}} {{db2_pod_name}} -- su -lc 'db2 get db cfg for {{ db2_dbname }} | grep "(CHNGPGS_THRESH) = 40"' db2inst1
   register: check_cmds_status
   until: check_cmds_status.rc == 0

--- a/ibm/mas_devops/roles/suite_db2_setup_for_manage/tasks/apply-db2-config-settings.yml
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_manage/tasks/apply-db2-config-settings.yml
@@ -27,6 +27,8 @@
   pause:
     minutes: 1
 
+# TODO remove this when s11.5.8.0-cn2 and older no longer supported
+# removed pipe tee in command here to capture the right rc command.
 - name: Run script (for db2 operator s11.5.8.0-cn2 and older) to make changes take effect
   shell: oc exec -n {{db2_namespace}} {{db2_pod_name}} -- su -lc '/db2u/scripts/apply-db2cfg-settings.sh' db2inst1
   register: old_prepare_cmds_status
@@ -40,7 +42,9 @@
   when:
     - prepare_cmds_status.rc != 0
 
-# Run script twice for DB2 standalone
+
+# TODO remove this when s11.5.8.0-cn2 and older no longer supported
+# added duplicate block to make removal easy.
 - name: Check DB2 cfg is take effect
   when: old_prepare_cmds_status == 0
   shell: |
@@ -51,6 +55,7 @@
   retries: 5
   delay: 30 # seconds
 
+# Run script twice for DB2 standalone
 - name: Check DB2 cfg is take effect
   when: prepare_cmds_status == 0
   shell: |

--- a/ibm/mas_devops/roles/suite_db2_setup_for_manage/tasks/apply-db2-config-settings.yml
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_manage/tasks/apply-db2-config-settings.yml
@@ -40,13 +40,14 @@
 
 - fail: msg="Failed to execute the script /db2u/scripts/apply-db2cfg-settings.sh --setting all on DB2 instance(s11.5.8.0-cn3 and newer))"
   when:
+    - prepare_cmds_status is defined
     - prepare_cmds_status.rc != 0
 
 
 # TODO remove this when s11.5.8.0-cn2 and older no longer supported
 # added duplicate block to make removal easy.
 - name: Check DB2 cfg is take effect
-  when: old_prepare_cmds_status == 0
+  when: old_prepare_cmds_status.rc == 0
   shell: |
     oc exec -n {{db2_namespace}} {{db2_pod_name}} -- su -lc '/db2u/scripts/apply-db2cfg-settings.sh | tee /tmp/apply-db2cfg-settings.log' db2inst1
     oc exec -n {{db2_namespace}} {{db2_pod_name}} -- su -lc 'db2 get db cfg for {{ db2_dbname }} | grep "(CHNGPGS_THRESH) = 40"' db2inst1
@@ -57,7 +58,9 @@
 
 # Run script twice for DB2 standalone
 - name: Check DB2 cfg is take effect
-  when: prepare_cmds_status == 0
+  when: 
+    - prepare_cmds_status is defined
+    - prepare_cmds_status.rc == 0
   shell: |
     oc exec -n {{db2_namespace}} {{db2_pod_name}} -- su -lc '/db2u/scripts/apply-db2cfg-settings.sh --setting all | tee /tmp/apply-db2cfg-settings.log' db2inst1
     oc exec -n {{db2_namespace}} {{db2_pod_name}} -- su -lc 'db2 get db cfg for {{ db2_dbname }} | grep "(CHNGPGS_THRESH) = 40"' db2inst1


### PR DESCRIPTION
/db2u/scripts/apply-db2cfg-settings.sh now requires an option.
