### PR TITLE
[patch] support for apply-db2-config-settings.yml script in newer db2 operators

### DIFF
--- a/ibm/mas_devops/roles/suite_db2_setup_for_manage/tasks/apply-db2-config-settings.yml
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_manage/tasks/apply-db2-config-settings.yml
@@ -28,7 +28,7 @@
     minutes: 1
 
 - name: Run script to make changes take effect
-  shell: oc exec -n {{db2_namespace}} {{db2_pod_name}} -- su -lc '/db2u/scripts/apply-db2cfg-settings.sh | tee /tmp/apply-db2cfg-settings.log' db2inst1
+  shell: oc exec -n {{db2_namespace}} {{db2_pod_name}} -- su -lc '/db2u/scripts/apply-db2cfg-settings.sh --setting all | tee /tmp/apply-db2cfg-settings.log' db2inst1
   register: prepare_cmds_status
 
 - fail: msg="Failed to execute the script /db2u/scripts/apply-db2cfg-settings.sh on DB2 instance"
@@ -38,7 +38,7 @@
 # Run script twice for DB2 standalone
 - name: Check DB2 cfg is take effect
   shell: |
-    oc exec -n {{db2_namespace}} {{db2_pod_name}} -- su -lc '/db2u/scripts/apply-db2cfg-settings.sh | tee /tmp/apply-db2cfg-settings.log' db2inst1
+    oc exec -n {{db2_namespace}} {{db2_pod_name}} -- su -lc '/db2u/scripts/apply-db2cfg-settings.sh --setting all | tee /tmp/apply-db2cfg-settings.log' db2inst1
     oc exec -n {{db2_namespace}} {{db2_pod_name}} -- su -lc 'db2 get db cfg for {{ db2_dbname }} | grep "(CHNGPGS_THRESH) = 40"' db2inst1
   register: check_cmds_status
   until: check_cmds_status.rc == 0


### PR DESCRIPTION
/db2u/scripts/apply-db2cfg-settings.sh requires mandatory option now with db2 operator s11.5.8.0-cn3 and newer
the older version doesn't require or check for options, so this works on both old & new db2 operator.