### PR TITLE
[patch] add install in the DRO_ACTION list

### DIFF
--- a/ibm/mas_devops/roles/dro/tasks/main.yml
+++ b/ibm/mas_devops/roles/dro/tasks/main.yml
@@ -9,7 +9,7 @@
 # the input variables
 - name: Assert DRO_ACTION values
   assert:
-    that: dro_action in ["install-dro", "uninstall"]
+    that: dro_action in ["install", "install-dro", "uninstall"]
     fail_msg: "Incorrect value set for DRO_ACTION"
   when: dro_action is defined and (dro_action | length > 0)
 


### PR DESCRIPTION
## Description:
DRO install failing with the asseert as `install` is passed from the uds_action. https://github.com/ibm-mas/cli/blob/master/tekton/src/tasks/dependencies/uds.yml.j2#L118

TASK [ibm.mas_devops.dro : Assert DRO_ACTION values] ***************************
fatal: [localhost]: FAILED! => changed=false 
  assertion: dro_action in ["install-dro", "uninstall"]
  evaluated_to: false
  msg: Incorrect value set for DRO_ACTION

