### PR TITLE
 Default to patch version bump when no commit prefix provided

### DIFF
--- a/build/bin/initbuild.sh
+++ b/build/bin/initbuild.sh
@@ -61,14 +61,14 @@ else
 
     PATCH_COUNT=`grep -ciF '[patch]' $GITHUB_WORKSPACE/.changelog`
     echo "Patch commits : ${PATCH_COUNT}"
-  fi
 
-  if [ "$MAJOR_COUNT" -gt "0" ]; then
-    SEMVER_RELEASE_LEVEL="major"
-  elif [ "$MINOR_COUNT" -gt "0" ]; then
-    SEMVER_RELEASE_LEVEL="minor"
-  elif [ "$PATCH_COUNT" -gt "0" ]; then
-    SEMVER_RELEASE_LEVEL="patch"
+    if [ "$MAJOR_COUNT" -gt "0" ]; then
+      SEMVER_RELEASE_LEVEL="major"
+    elif [ "$MINOR_COUNT" -gt "0" ]; then
+      SEMVER_RELEASE_LEVEL="minor"
+    elif [ "$PATCH_COUNT" -gt "0" ]; then
+      SEMVER_RELEASE_LEVEL="patch"
+    fi
   fi
 
   echo "RELEASE LEVEL = ${SEMVER_RELEASE_LEVEL}"
@@ -82,7 +82,8 @@ else
     semver bump ${SEMVER_RELEASE_LEVEL} ${SEMVER_LAST_TAG} > $VERSION_FILE
     echo "Configuring semver for ${SEMVER_RELEASE_LEVEL} bump from ${SEMVER_LAST_TAG} to $(cat $VERSION_FILE)"
   else
-    semver bump build build.$GITHUB_RUN_ID > $VERSION_FILE
+    # Default to a patch revision
+    semver bump patch ${SEMVER_LAST_TAG} > $VERSION_FILE
     echo "Configuring semver for rebuild of ${SEMVER_LAST_TAG}: $(cat $VERSION_FILE)"
   fi
 fi


### PR DESCRIPTION
This update allows the build system to build a branch when there's no patch/minor/major commit ... we will assume that the update is a patch update by default.
