### PR TITLE
[patch] Fix condition that sets cert_manager_cluster_resource_namespace

### DIFF
--- a/ibm/mas_devops/common_tasks/detect_cert_manager.yml
+++ b/ibm/mas_devops/common_tasks/detect_cert_manager.yml
@@ -53,6 +53,7 @@
   set_fact:
     cert_manager_namespace: "{{ cert_manager_webhook_lookup.stdout }}"
 
+# If 'cert_manager_cluster_resource_namespace' is not yet defined then set it to same value as 'cert_manager_namespace'
 - name: Set Certificate Manager Cluster Resource namespace (if not set)
   set_fact:
     cert_manager_cluster_resource_namespace: "{{ cert_manager_namespace }}"

--- a/ibm/mas_devops/roles/suite_dns/tasks/run.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/run.yml
@@ -3,7 +3,8 @@
 # -----------------------------------------------------------------------------
 # Ensure cert manager is installed prior continuing as this role will install
 # v1alpha1.acme.cis.ibm.com apiservice which requires cert manager to be running
-- include_tasks: "{{ role_path }}/../../common_tasks/detect_cert_manager.yml"
+- name: Detect Certificate Manager installation
+  include_tasks: "{{ role_path }}/../../common_tasks/detect_cert_manager.yml"
   when: cert_manager_namespace is not defined or cert_manager_namespace | length == 0
 
 # 2. Run provider task

--- a/ibm/mas_devops/roles/suite_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_install/tasks/main.yml
@@ -140,8 +140,9 @@
 
 # 4. Determine version of cert-manager in use on the cluster
 # -----------------------------------------------------------------------------
-- include_tasks: "{{ role_path }}/../../common_tasks/detect_cert_manager.yml"
-  when: cert_manager_namespace is not defined or cert_manager_namespace | length == 0
+- name: Detect Certificate Manager installation
+  include_tasks: "{{ role_path }}/../../common_tasks/detect_cert_manager.yml"
+  when: cert_manager_cluster_resource_namespace is not defined or cert_manager_cluster_resource_namespace != ''
 
 # 5. Provide debug information
 # -----------------------------------------------------------------------------
@@ -159,6 +160,7 @@
       - "MAS domain .................... {{ mas_domain }}"
       - "MAS ICR cp content ............ {{ mas_icr_cp }}"
       - "MAS ICR cpopen content ........ {{ mas_icr_cpopen }}"
+      - "Cert Manager namespace ........ {{ cert_manager_cluster_resource_namespace }}"
       - "MAS Cluster Issuer ............ {{ mas_cluster_issuer }}"
       - "IPv6 Enabled .................. {{ enable_ipv6 }}"
 


### PR DESCRIPTION
The condition to run `detect_cert_manager` task in `suite_install` had a bug... we should use `cert_manager_cluster_resource_namespace` in that condition as this is the var that must be set in order to set it properly in Suite CR, but we were using `cert_manager_namespace` var instead which is not used at all in that role.

`detect_cert_manager` task is supposed to detect if and which namespace cert-manager is installed and also set `cert_manager_cluster_resource_namespace` if not yet defined.