### PR TITLE
[patch] Check ODLM is installed prior disabling certmanager operand request

### DIFF
--- a/ibm/mas_devops/roles/cert_manager/tasks/prereqs-migration.yml
+++ b/ibm/mas_devops/roles/cert_manager/tasks/prereqs-migration.yml
@@ -14,17 +14,9 @@
       data:
         cert_manager_cluster_resource_namespace: ibm-common-services
 
-# 2. Delete IBM Certificate Manager resources - OperandRequest
-# -----------------------------------------------------------------------------
-- name: "prereqs-migration: Delete IBM Cert-Manager OperandRequest"
-  kubernetes.core.k8s:
-    state: absent
-    template: "templates/ibm/ibm-cert-manager.yml"
-    wait: yes
-    wait_timeout: 600
-
-# 3. Delete IBM Certificate Manager resources - Default custom resource
+# 2. Delete IBM Certificate Manager resources - Default custom resource
 # This will delete all IBM Certificate Manager pods but will keep the ibm-cert-manager-operator (still going to be needed to delegate requests to Red Hat Certificate Manager)
+# Delete CertManager CR prior deleting OperandRequest otherwise both might end up stuck in terminating status
 # -----------------------------------------------------------------------------
 - name: "prereqs-migration: Delete the IBM Cert-Manager default Custom Resource"
   kubernetes.core.k8s:
@@ -33,6 +25,15 @@
     kind: "CertManager"
     name: "default"
     wait: true
+    wait_timeout: 600 # 10 minutes
+
+# 3. Delete IBM Certificate Manager resources - OperandRequest
+# -----------------------------------------------------------------------------
+- name: "prereqs-migration: Delete IBM Cert-Manager OperandRequest"
+  kubernetes.core.k8s:
+    state: absent
+    template: "templates/ibm/ibm-cert-manager.yml"
+    wait: yes
     wait_timeout: 600 # 10 minutes
 
 - name: "prereqs-migration: Wait for cert-manager-webhook deployment to be terminated"

--- a/ibm/mas_devops/roles/cert_manager/tasks/provider/redhat/install.yml
+++ b/ibm/mas_devops/roles/cert_manager/tasks/provider/redhat/install.yml
@@ -27,11 +27,25 @@
 
 # 2. Disable IBM Cert Manager OperandRequest
 # -----------------------------------------------------------------------------
+# Check if Operand Deployment Lifecycle Manager is installed
+# If Operand Deployment Lifecycle Manager is not installed
+# then no point on disabling IBM cert manager OperandRequest
+- name: "install : Check if ODLM is installed"
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    name: operand-deployment-lifecycle-manager
+    namespace: "ibm-common-services"
+    kind: Deployment
+  register: odlm_lookup
+
 # This step will configure ibm-cert-manager-operator to make use of a
 # self managed CNCF cert-manager, so that no additional operands are installed.
 # Add deployCSCertManagerOperands: "false" to the data.
 # Using 'merge' just in case the configmap is already present
 - name: "install: Disable IBM Cert Manager OperandRequest via ibm-ccp-config"
+  when:
+    - odlm_lookup.resources is defined
+    - odlm_lookup.resources | length > 0
   kubernetes.core.k8s:
     merge_type: merge
     template: "templates/{{ cert_manager_provider }}/ibm-cpp-configmap.yml.j2"


### PR DESCRIPTION
1. Added a fix for Red Hat certificate manager install where we were trying to disable the operand request from `ibm-common-services` namespace but there might be cases where the `ibm-common-services` namespace will not be present yet and cert-manager role will fail at this point. So the fix will ensure that the ODLM is installed first prior trying to disable the OperandRequest by adding the ibm-cpp-config config map.
2. Changed the order of how IBM cert-manager resources are deleted during the red hat migration because deleting operand request will cause certmanager custom resource to also be deleted, and in some cases both might end up being stuck in terminating status due certmanager cr taking too long to be gone. So deleting certmanager custom resource first might simplify the debugging work in case troubleshooting is needed.