### PR TITLE
[patch] Disable logging of docker credentials from mirror_ocp role

### DIFF
--- a/ibm/mas_devops/roles/mirror_ocp/tasks/main.yml
+++ b/ibm/mas_devops/roles/mirror_ocp/tasks/main.yml
@@ -55,6 +55,7 @@
 # 4. Generate new docker config
 # -----------------------------------------------------------------------------
 - name: Generate Docker config
+  no_log: true  # Output contains credentials for all docker registries
   command: >
     jq ".auths[\"{{ registry_public_url }}\"]={\"auth\":\"{{ registry_auth | b64encode }}\"}" "{{ redhat_pullsecret }}"
   register: new_pull_secret


### PR DESCRIPTION
Removes sensitive information (docker registry authentication information) from the `mirror_ocp` role logs.