### PR TITLE
[patch] change to use SingleStack and IPv6 only when ipv6_test is true

### DIFF
--- a/ibm/mas_devops/roles/suite_install/README.md
+++ b/ibm/mas_devops/roles/suite_install/README.md
@@ -87,7 +87,7 @@ For examples refer to the [BestEfforts reference configuration in the MAS CLI](h
 - Default: None
 
 ### enable_IPv6
-Boolean variable that indicates whether it is to install in an IPv6-enabled environment.  If it is true, the suite CR will have the PreferDualStack for ipFamilyPolicy and ["IPv6", "IPv4"] for ipFamilies.  These ipFamily properties will be populated to all the services. This is currently available only in internal fyre clusters at the RTP site for testing purpose.
+Boolean variable that indicates whether it is to install in an IPv6-enabled environment.  If it is true, the suite CR will have the SingleStack for ipFamilyPolicy and ["IPv6"] for ipFamilies.  These ipFamily properties will be populated to all the services. This is currently available only in internal fyre clusters at the RTP site for testing purpose.
 
 - Optional
 - Environment Variable: `ENABLE_IPv6`,

--- a/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
+++ b/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
@@ -57,6 +57,6 @@ spec:
 {% endif %}
 {% if enable_ipv6 is defined and enable_ipv6 == true %}
     services:
-      ipFamilyPolicy: "PreferDualStack"
-      ipFamilies: ["IPv6", "IPv4"]
+      ipFamilyPolicy: "SingleStack"
+      ipFamilies: ["IPv6"]
 {% endif %}


### PR DESCRIPTION
The default ipFamilyPolicy and ipFamilies are now changed to SingleStack and IPv6 to better test IPv6-only configurations.