### PR TITLE
[patch] add licensing sync cronjob sync frequency in slscfg

### DIFF
--- a/ibm/mas_devops/roles/sls/README.md
+++ b/ibm/mas_devops/roles/sls/README.md
@@ -238,6 +238,13 @@ The URL of the LicenseService to be called when the Maximo Application Suite is 
 - Environment Variable: `SLS_URL`
 - Default Value: None
 
+### mas_license_sync_frequency
+The user license sync cronjob sync frequency between MAS and SLS.
+
+- Optional
+- Environment Variable: `MAS_LICENSE_SYNC_FREQUENCY`
+- Default Value: `*/30 * * * *`
+
 ### sls_tls_crt
 The TLS CA certificate of the LicenseService to be used when the Maximo Application Suite is registered with SLS.  Takes precedence over  `sls_tls_crt_local_file_path`.
 

--- a/ibm/mas_devops/roles/sls/README.md
+++ b/ibm/mas_devops/roles/sls/README.md
@@ -239,7 +239,7 @@ The URL of the LicenseService to be called when the Maximo Application Suite is 
 - Default Value: None
 
 ### mas_license_sync_frequency
-The user license sync cronjob sync frequency between MAS and SLS.
+The sync frequency of user license sync cronjob between Maximo Application Suite and SLS.
 
 - Optional
 - Environment Variable: `MAS_LICENSE_SYNC_FREQUENCY`

--- a/ibm/mas_devops/roles/sls/defaults/main.yml
+++ b/ibm/mas_devops/roles/sls/defaults/main.yml
@@ -44,6 +44,7 @@ entitlement_file: "{{ lookup('env', 'SLS_ENTITLEMENT_FILE') | default(\"\", true
 # SLSCfg generation
 mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
 mas_config_dir: "{{ lookup('env', 'MAS_CONFIG_DIR') }}"
+mas_sync_frequency: "{{ lookup('env', 'MAS_SYNC_FREQUENCY') | default('*/30 * * * *', true) }}"
 
 sls_url: "{{ lookup('env', 'SLS_URL') }}"
 sls_registration_key: "{{ lookup('env', 'SLS_REGISTRATION_KEY') }}"

--- a/ibm/mas_devops/roles/sls/defaults/main.yml
+++ b/ibm/mas_devops/roles/sls/defaults/main.yml
@@ -44,7 +44,7 @@ entitlement_file: "{{ lookup('env', 'SLS_ENTITLEMENT_FILE') | default(\"\", true
 # SLSCfg generation
 mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
 mas_config_dir: "{{ lookup('env', 'MAS_CONFIG_DIR') }}"
-mas_sync_frequency: "{{ lookup('env', 'MAS_SYNC_FREQUENCY') | default('*/30 * * * *', true) }}"
+mas_license_sync_frequency: "{{ lookup('env', 'MAS_LICENSE_SYNC_FREQUENCY') | default('*/30 * * * *', true) }}"
 
 sls_url: "{{ lookup('env', 'SLS_URL') }}"
 sls_registration_key: "{{ lookup('env', 'SLS_REGISTRATION_KEY') }}"

--- a/ibm/mas_devops/roles/sls/templates/slscfg.yml.j2
+++ b/ibm/mas_devops/roles/sls/templates/slscfg.yml.j2
@@ -29,11 +29,11 @@ metadata:
 {% endif %}
 spec:
   displayName: SLS ({{ mas_instance_id }})
-  syncFrequency: "{{ mas_sync_frequency }}"
   config:
     url: "{{ sls_url }}"
     credentials:
       secretName: sls-registration-key
+    syncFrequency: "{{ mas_sync_frequency }}"
   certificates:
     - alias: ca
       crt: |

--- a/ibm/mas_devops/roles/sls/templates/slscfg.yml.j2
+++ b/ibm/mas_devops/roles/sls/templates/slscfg.yml.j2
@@ -29,6 +29,7 @@ metadata:
 {% endif %}
 spec:
   displayName: SLS ({{ mas_instance_id }})
+  syncFrequency: "{{ mas_sync_frequency }}"
   config:
     url: "{{ sls_url }}"
     credentials:

--- a/ibm/mas_devops/roles/sls/templates/slscfg.yml.j2
+++ b/ibm/mas_devops/roles/sls/templates/slscfg.yml.j2
@@ -33,7 +33,7 @@ spec:
     url: "{{ sls_url }}"
     credentials:
       secretName: sls-registration-key
-    syncFrequency: "{{ mas_sync_frequency }}"
+    syncFrequency: "{{ mas_license_sync_frequency }}"
   certificates:
     - alias: ca
       crt: |


### PR DESCRIPTION
Make the licensing sync cronjob sync frequency configable in slscfg.
The default value is  30 min `'*/30 * * * *'`