### PR TITLE
[patch] ObjectStorage config should have type

### DIFF
--- a/ibm/mas_devops/roles/cos/templates/ibm/objectstoragecfg.yml.j2
+++ b/ibm/mas_devops/roles/cos/templates/ibm/objectstoragecfg.yml.j2
@@ -30,6 +30,7 @@ metadata:
 {% endif %}
 spec:
   displayName: IBM Cloud ObjectStorage
+  type: "{{ cos_type }}"
   config:
     url:  "{{ ibmcos_url }}"
     credentials:

--- a/ibm/mas_devops/roles/cos/templates/ocs/objectstoragecfg.yml.j2
+++ b/ibm/mas_devops/roles/cos/templates/ocs/objectstoragecfg.yml.j2
@@ -30,6 +30,7 @@ metadata:
 {% endif %}
 spec:
   displayName: ObjectStorage Config
+  type: "{{ cos_type }}"
   config:
     url:  "{{ ocscos_url }}"
     credentials:


### PR DESCRIPTION
The ObjectStorageConfig being created in the `cos` role should have the `type` set in the spec. This was failing the FVT tests when an existing config was attempted to be reapplied, as the check for the `type` failed. Tested again in https://dashboard.masdev.wiotp.sl.hursley.ibm.com/tests/pfvtajw1304 and this fixes the internalapi tests.