### PR TITLE
[patch] Fix condition that sets cert_manager_cluster_resource_namespace (part 2)

### DIFF
--- a/ibm/mas_devops/roles/suite_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_install/tasks/main.yml
@@ -140,9 +140,11 @@
 
 # 4. Determine version of cert-manager in use on the cluster
 # -----------------------------------------------------------------------------
+# if cert_manager_cluster_resource_namespace is not set then 
+# run 'detect_cert_manager' task to set it as this will be needed to be set in Suite CR
 - name: Detect Certificate Manager installation
   include_tasks: "{{ role_path }}/../../common_tasks/detect_cert_manager.yml"
-  when: cert_manager_cluster_resource_namespace is not defined or cert_manager_cluster_resource_namespace != ''
+  when: cert_manager_cluster_resource_namespace is not defined or cert_manager_cluster_resource_namespace == ''
 
 # 5. Provide debug information
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/suite_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_install/tasks/main.yml
@@ -140,7 +140,7 @@
 
 # 4. Determine version of cert-manager in use on the cluster
 # -----------------------------------------------------------------------------
-# if cert_manager_cluster_resource_namespace is not set then 
+# if cert_manager_cluster_resource_namespace is not set then
 # run 'detect_cert_manager' task to set it as this will be needed to be set in Suite CR
 - name: Detect Certificate Manager installation
   include_tasks: "{{ role_path }}/../../common_tasks/detect_cert_manager.yml"


### PR DESCRIPTION
Minor fix on the condition that checks if `cert_manager_cluster_resource_namespace` is empty, this property must be defined.

Then it will run `detect_cert_manager` task that is supposed to detect if and which namespace cert-manager is installed and also set `cert_manager_cluster_resource_namespace` if not yet defined.