### PR TITLE
[patch] Fix mongo compatibility matrix logic and validations

### DIFF
--- a/ibm/mas_devops/roles/mongodb/defaults/main.yml
+++ b/ibm/mas_devops/roles/mongodb/defaults/main.yml
@@ -116,20 +116,12 @@ custom_labels: "{{ lookup('env', 'CUSTOM_LABELS') | default(None, true) | string
 mongodb_v5_upgrade: "{{ lookup('env', 'MONGODB_V5_UPGRADE') | default(false, true) | bool }}"
 mongodb_v6_upgrade: "{{ lookup('env', 'MONGODB_V6_UPGRADE') | default(false, true) | bool }}"
 
-# this matrix will be used to define 'mongo_compatible_target_version' which lists the mongodb versions that are feature compatible with the mapped mongo minor version
-# mongo_feature_compatibility_matrix_default:
-#   "4.2":
-#     - "4.4.21"
-#   "4.4":
-#     - "5.0.21"
-#     - "5.0.23"
-#   "5.0":
-#     - "5.0.23"
-#     - "6.0.10"
-#   "6.0":
-#     - "6.0.10"
-
+# This matrix will define the mongodb upgrade compatibility mapping version
+# Example:
+# If `existing_mongo_version: 4.4.21` then the `target_mongodb_version` must be `5.0.21` or `5.0.23`
 mongo_compatible_target_version:
+  "4.2.23":
+    - "4.4.21"
   "4.4.21":
     - "5.0.21"
     - "5.0.23"
@@ -138,19 +130,3 @@ mongo_compatible_target_version:
     - "6.0.10"
   "5.0.23":
     - "6.0.10"
-
-# # allow upgrading to mongo v5 if existing version match with target version based on the following matrix
-# # example: if 'mongodb_existing_version': '4.4.21' then allow upgrade to 'mongodb_target_version: '5.0.21' or '5.0.23'
-# allow_mongo_v5_upgrade_matrix:
-#   "5.0.23": # to
-#     - "5.0.21" # from
-#     - "4.4.21"
-#   "5.0.21": # to
-#     - "4.4.21" # from
-
-# # allow upgrading to mongo v6 if existing version match with target version based on the following matrix
-# # example: if 'mongodb_existing_version': '5.0.21' or '5.0.23' then allow upgrade to 'mongodb_target_version: '6.0.10'
-# allow_mongo_v6_upgrade_matrix:
-#   "6.0.10":
-#     - "5.0.23"
-#     - "5.0.21"

--- a/ibm/mas_devops/roles/mongodb/defaults/main.yml
+++ b/ibm/mas_devops/roles/mongodb/defaults/main.yml
@@ -118,7 +118,7 @@ mongodb_v6_upgrade: "{{ lookup('env', 'MONGODB_V6_UPGRADE') | default(false, tru
 # This matrix will define and validate the mongodb upgrade compatibility mapping version.
 # Therefore this must be updated whenever a new mongodb version is supported.
 # Only allow Mongo upgrades to be next compatible minor (or patch) version.
-# Example: 
+# Example:
 # If `existing_mongo_version: 4.4.21` then the `target_mongodb_version` must be `5.0.21` or `5.0.23`.
 # Otherwise the code will validate there is an incompatibility in the version to be upgraded and it will fail prior starting the upgrade process.
 mongo_compatible_target_version:

--- a/ibm/mas_devops/roles/mongodb/defaults/main.yml
+++ b/ibm/mas_devops/roles/mongodb/defaults/main.yml
@@ -116,9 +116,10 @@ custom_labels: "{{ lookup('env', 'CUSTOM_LABELS') | default(None, true) | string
 mongodb_v5_upgrade: "{{ lookup('env', 'MONGODB_V5_UPGRADE') | default(false, true) | bool }}"
 mongodb_v6_upgrade: "{{ lookup('env', 'MONGODB_V6_UPGRADE') | default(false, true) | bool }}"
 
-# This matrix will define the mongodb upgrade compatibility mapping version
-# Example:
-# If `existing_mongo_version: 4.4.21` then the `target_mongodb_version` must be `5.0.21` or `5.0.23`
+# This matrix will define the mongodb upgrade compatibility mapping version.
+# Therefore this must be updated whenever a new mongodb version is supported.
+# Only allow Mongo upgrades to be next compatible minor (or patch) version.
+# Example: If `existing_mongo_version: 4.4.21` then the `target_mongodb_version` must be `5.0.21` or `5.0.23`.
 mongo_compatible_target_version:
   "4.2.23":
     - "4.4.21"
@@ -128,5 +129,9 @@ mongo_compatible_target_version:
   "5.0.21":
     - "5.0.23"
     - "6.0.10"
+    - "6.0.12"
   "5.0.23":
     - "6.0.10"
+    - "6.0.12"
+  "6.0.10":
+    - "6.0.12"

--- a/ibm/mas_devops/roles/mongodb/defaults/main.yml
+++ b/ibm/mas_devops/roles/mongodb/defaults/main.yml
@@ -111,15 +111,16 @@ custom_labels: "{{ lookup('env', 'CUSTOM_LABELS') | default(None, true) | string
 
 # Mongo upgrade flags
 # If identified that there's an existing Mongo that might lead to a v5 or v6 upgrade
-# the following flags just be set to confirm the upgrades otherwise the role will fail
-# and not proceed with the upgrade.
+# the following flags must be set to confirm the upgrades otherwise the role will fail and not proceed with the upgrade.
 mongodb_v5_upgrade: "{{ lookup('env', 'MONGODB_V5_UPGRADE') | default(false, true) | bool }}"
 mongodb_v6_upgrade: "{{ lookup('env', 'MONGODB_V6_UPGRADE') | default(false, true) | bool }}"
 
-# This matrix will define the mongodb upgrade compatibility mapping version.
+# This matrix will define and validate the mongodb upgrade compatibility mapping version.
 # Therefore this must be updated whenever a new mongodb version is supported.
 # Only allow Mongo upgrades to be next compatible minor (or patch) version.
-# Example: If `existing_mongo_version: 4.4.21` then the `target_mongodb_version` must be `5.0.21` or `5.0.23`.
+# Example: 
+# If `existing_mongo_version: 4.4.21` then the `target_mongodb_version` must be `5.0.21` or `5.0.23`.
+# Otherwise the code will validate there is an incompatibility in the version to be upgraded and it will fail prior starting the upgrade process.
 mongo_compatible_target_version:
   "4.2.23":
     - "4.4.21"

--- a/ibm/mas_devops/roles/mongodb/defaults/main.yml
+++ b/ibm/mas_devops/roles/mongodb/defaults/main.yml
@@ -117,7 +117,13 @@ mongodb_v5_upgrade: "{{ lookup('env', 'MONGODB_V5_UPGRADE') | default(false, tru
 mongodb_v6_upgrade: "{{ lookup('env', 'MONGODB_V6_UPGRADE') | default(false, true) | bool }}"
 
 mongo_compatibility_matrix_default:
-  "4.2": "4.4.21"
-  "4.4": "5.0.21"
-  "5.0": "6.0.10"
-  "6.0": "6.0.10"
+  "4.2":
+    - "4.4.21"
+  "4.4":
+    - "5.0.21"
+    - "5.0.23"
+  "5.0":
+    - "5.0.23"
+    - "6.0.10"
+  "6.0":
+    - "6.0.10"

--- a/ibm/mas_devops/roles/mongodb/defaults/main.yml
+++ b/ibm/mas_devops/roles/mongodb/defaults/main.yml
@@ -116,14 +116,41 @@ custom_labels: "{{ lookup('env', 'CUSTOM_LABELS') | default(None, true) | string
 mongodb_v5_upgrade: "{{ lookup('env', 'MONGODB_V5_UPGRADE') | default(false, true) | bool }}"
 mongodb_v6_upgrade: "{{ lookup('env', 'MONGODB_V6_UPGRADE') | default(false, true) | bool }}"
 
-mongo_compatibility_matrix_default:
-  "4.2":
-    - "4.4.21"
-  "4.4":
+# this matrix will be used to define 'mongo_compatible_target_version' which lists the mongodb versions that are feature compatible with the mapped mongo minor version
+# mongo_feature_compatibility_matrix_default:
+#   "4.2":
+#     - "4.4.21"
+#   "4.4":
+#     - "5.0.21"
+#     - "5.0.23"
+#   "5.0":
+#     - "5.0.23"
+#     - "6.0.10"
+#   "6.0":
+#     - "6.0.10"
+
+mongo_compatible_target_version:
+  "4.4.21":
     - "5.0.21"
     - "5.0.23"
-  "5.0":
+  "5.0.21":
     - "5.0.23"
     - "6.0.10"
-  "6.0":
+  "5.0.23":
     - "6.0.10"
+
+# # allow upgrading to mongo v5 if existing version match with target version based on the following matrix
+# # example: if 'mongodb_existing_version': '4.4.21' then allow upgrade to 'mongodb_target_version: '5.0.21' or '5.0.23'
+# allow_mongo_v5_upgrade_matrix:
+#   "5.0.23": # to
+#     - "5.0.21" # from
+#     - "4.4.21"
+#   "5.0.21": # to
+#     - "4.4.21" # from
+
+# # allow upgrading to mongo v6 if existing version match with target version based on the following matrix
+# # example: if 'mongodb_existing_version': '5.0.21' or '5.0.23' then allow upgrade to 'mongodb_target_version: '6.0.10'
+# allow_mongo_v6_upgrade_matrix:
+#   "6.0.10":
+#     - "5.0.23"
+#     - "5.0.21"

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/check-mongo-exists.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/check-mongo-exists.yml
@@ -51,18 +51,6 @@
         file: "{{ role_path }}/../../common_vars/casebundles/{{ catalog_tag }}.yml"
       when: stat_result is defined and stat_result.stat.exists
 
-    # # holds the expected target mongo version that is feature compatible with the existing mongo instance version
-    # # mongo extras version are picked up from the catalog if available or uses defaults.
-    # - name: Set mongo_compatible_target_version
-    #   set_fact:
-    #     mongo_compatible_target_version: "{{ allow_mongo_upgrade_matrix[existing_mongo_version] }}"
-    #   # vars:
-    #   #   mongo_feature_compatibility_matrix:
-    #   #     "4.2": "{{ mongo_extras_version_4 | default(mongo_compatibility_matrix_default['4.2'], true) }}"
-    #   #     "4.4": "{{ mongo_extras_version_5 | default(mongo_compatibility_matrix_default['4.4'], true) }}"
-    #   #     "5.0": "{{ mongo_extras_version_6 | default(mongo_compatibility_matrix_default['5.0'], true) }}"
-    #   #     "6.0": "{{ mongo_extras_version_6 | default(mongo_compatibility_matrix_default['6.0'], true) }}"
-
   when:
     - existing_mongodb.resources[0].spec.version is defined
     - existing_mongodb.resources[0].spec.version | length > 0

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/check-mongo-exists.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/check-mongo-exists.yml
@@ -51,17 +51,17 @@
         file: "{{ role_path }}/../../common_vars/casebundles/{{ catalog_tag }}.yml"
       when: stat_result is defined and stat_result.stat.exists
 
-    # holds the expected target mongo version that is feature compatible with the existing mongo instance version
-    # mongo extras version are picked up from the catalog if available or uses defaults.
-    - name: Set mongo_compatible_target_version
-      set_fact:
-        mongo_compatible_target_version: "{{ mongo_feature_compatibility_matrix[existing_mongo_minor_version] }}"
-      vars:
-        mongo_feature_compatibility_matrix:
-          "4.2": "{{ mongo_extras_version_4 | default(mongo_compatibility_matrix_default['4.2'], true) }}"
-          "4.4": "{{ mongo_extras_version_5 | default(mongo_compatibility_matrix_default['4.4'], true) }}"
-          "5.0": "{{ mongo_extras_version_6 | default(mongo_compatibility_matrix_default['5.0'], true) }}"
-          "6.0": "{{ mongo_extras_version_6 | default(mongo_compatibility_matrix_default['6.0'], true) }}"
+    # # holds the expected target mongo version that is feature compatible with the existing mongo instance version
+    # # mongo extras version are picked up from the catalog if available or uses defaults.
+    # - name: Set mongo_compatible_target_version
+    #   set_fact:
+    #     mongo_compatible_target_version: "{{ allow_mongo_upgrade_matrix[existing_mongo_version] }}"
+    #   # vars:
+    #   #   mongo_feature_compatibility_matrix:
+    #   #     "4.2": "{{ mongo_extras_version_4 | default(mongo_compatibility_matrix_default['4.2'], true) }}"
+    #   #     "4.4": "{{ mongo_extras_version_5 | default(mongo_compatibility_matrix_default['4.4'], true) }}"
+    #   #     "5.0": "{{ mongo_extras_version_6 | default(mongo_compatibility_matrix_default['5.0'], true) }}"
+    #   #     "6.0": "{{ mongo_extras_version_6 | default(mongo_compatibility_matrix_default['6.0'], true) }}"
 
   when:
     - existing_mongodb.resources[0].spec.version is defined

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/install-mongo.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/install-mongo.yml
@@ -312,7 +312,7 @@
     - mongodb_statefulset.resources[0].status.readyReplicas is defined
     - mongodb_statefulset.resources[0].status.readyReplicas ==  (mongodb_replicas|int)
 
-- name: "community : install : Wait for Mongo CR to report correct version"
+- name: "community : install : Wait for Mongo CR to report expected version {{ expected_mongodb_version }}"
   kubernetes.core.k8s_info:
     api_version: mongodbcommunity.mongodb.com/v1
     kind: MongoDBCommunity

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/validate-upgrade.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/validate-upgrade.yml
@@ -7,7 +7,7 @@
     msg:
       - "Minor mongo version ....................... {{ existing_mongo_minor_version }}"
       - "Existing MongoDb version .................. {{ existing_mongo_version }}"
-      - "Compatible Target MongoDb version ......... {{ mongo_compatible_target_version }}"
+      - "Compatible Target MongoDb version ......... {{ mongo_compatible_target_version[existing_mongo_version] }}"
       - "Target MongoDb version .................... {{ target_mongodb_version }}"
 
 # Only allow Mongo upgrades if existing instance is in Running state
@@ -25,7 +25,7 @@
     fail_msg: "Mongo downgrade is not allowed! Current mongo version: {{ existing_mongo_version }}, target mongo version {{ target_mongodb_version }}"
 
 # Only allow Mongo upgrades to be next compatible minor version
-- name: Assert Mongo upgrade compatibility
+- name: "Assert Mongo upgrade compatibility: {{ target_mongodb_version }} must be in {{ mongo_compatible_target_version[existing_mongo_version] }}"
   when: existing_mongo_minor_version != '4.2' # will skip this assertion if mongo v4.2 as we'll assist in the auto upgrade to v4.4 and v5 in a single run
   assert:
     that: target_mongodb_version in mongo_compatible_target_version[existing_mongo_version]
@@ -35,14 +35,14 @@
 
 # This would validate that we only upgrade to v5.0 if 'target_mongodb_version' matches v5.0 minor version and 'mongodb_v5_upgrade: true'
 - name: "Assert that the Mongo v5 upgrade has been triggered"
-  when: "{{ target_mongodb_version | regex_search('(?<=)(.*)(?=...)') == '5.0' }}"
+  when: target_mongodb_version | regex_search('(?<=)(.*)(?=...)') == '5.0'
   assert:
     that: mongodb_v5_upgrade
     fail_msg: "Your current mongo version is {{ existing_mongo_version }}, in order to upgrade to version {{ target_mongodb_version }}, you must set 'mongodb_v5_upgrade': true"
 
 # This would validate that we only upgrade to v6.0 if 'target_mongodb_version' matches v6.0 minor version and 'mongodb_v6_upgrade: true'
 - name: "Assert that the Mongo v6 upgrade has been triggered"
-  when: "{{ target_mongodb_version | regex_search('(?<=)(.*)(?=...)') == '6.0' }}"
+  when: target_mongodb_version | regex_search('(?<=)(.*)(?=...)') == '6.0'
   assert:
     that: mongodb_v6_upgrade
     fail_msg: "Your current mongo version is {{ existing_mongo_version }}, in order to upgrade to version {{ target_mongodb_version }}, you must set 'mongodb_v6_upgrade': true"

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/validate-upgrade.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/validate-upgrade.yml
@@ -5,10 +5,10 @@
 - name: "community : validate-upgrade : debug"
   debug:
     msg:
-      - "Target MongoDb version .................... {{ target_mongodb_version }}"
-      - "Compatible Target MongoDb version ......... {{ mongo_compatible_target_version }}"
-      - "Existing MongoDb version .................. {{ existing_mongo_version }}"
       - "Minor mongo version ....................... {{ existing_mongo_minor_version }}"
+      - "Existing MongoDb version .................. {{ existing_mongo_version }}"
+      - "Compatible Target MongoDb version ......... {{ mongo_compatible_target_version }}"
+      - "Target MongoDb version .................... {{ target_mongodb_version }}"
 
 # Only allow Mongo upgrades if existing instance is in Running state
 - name: "Assert existing Mongo is running"
@@ -28,19 +28,21 @@
 - name: Assert Mongo upgrade compatibility
   when: existing_mongo_minor_version != '4.2' # will skip this assertion if mongo v4.2 as we'll assist in the auto upgrade to v4.4 and v5 in a single run
   assert:
-    that: target_mongodb_version in mongo_compatible_target_version
+    that: target_mongodb_version in mongo_compatible_target_version[existing_mongo_version]
     fail_msg:
       - "You have an existing Mongo database instance that is running on version {{ existing_mongo_version }}, which cannot be directly upgraded to version {{ target_mongodb_version }}."
-      - "In order to upgrade your current instance to {{ target_mongodb_version }}, you must first upgrade your Mongo instance version to {{ mongo_compatible_target_version }}."
+      - "In order to upgrade your current instance to {{ target_mongodb_version }}, you must first upgrade your Mongo instance version to {{ mongo_compatible_target_version[existing_mongo_version] }}."
 
+# This would validate that we only upgrade to v5.0 if 'target_mongodb_version' matches v5.0 minor version and 'mongodb_v5_upgrade: true'
 - name: "Assert that the Mongo v5 upgrade has been triggered"
-  when: existing_mongo_minor_version in ['4.2','4.4']
+  when: "{{ target_mongodb_version | regex_search('(?<=)(.*)(?=...)') == '5.0' }}"
   assert:
-    that: mongodb_v5_upgrade # this would validate that we only upgrade to v5.0 if current mongo is either v4.2 or v4.4
-    fail_msg: "Your current mongo version is {{ existing_mongo_version }}, in order to upgrade to version {{ mongo_compatible_target_version }}, you must set 'mongodb_v5_upgrade': true"
+    that: mongodb_v5_upgrade
+    fail_msg: "Your current mongo version is {{ existing_mongo_version }}, in order to upgrade to version {{ target_mongodb_version }}, you must set 'mongodb_v5_upgrade': true"
 
+# This would validate that we only upgrade to v6.0 if 'target_mongodb_version' matches v6.0 minor version and 'mongodb_v6_upgrade: true'
 - name: "Assert that the Mongo v6 upgrade has been triggered"
-  when: existing_mongo_minor_version == '5.0'
+  when: "{{ target_mongodb_version | regex_search('(?<=)(.*)(?=...)') == '6.0' }}"
   assert:
-    that: mongodb_v6_upgrade # this would validate that we only upgrade to v6.0 if current mongo is v5.0
-    fail_msg: "Your current mongo version is {{ existing_mongo_version }}, in order to upgrade to version {{ mongo_compatible_target_version }}, you must set 'mongodb_v6_upgrade': true"
+    that: mongodb_v6_upgrade
+    fail_msg: "Your current mongo version is {{ existing_mongo_version }}, in order to upgrade to version {{ target_mongodb_version }}, you must set 'mongodb_v6_upgrade': true"

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/validate-upgrade.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/validate-upgrade.yml
@@ -31,7 +31,7 @@
     that: target_mongodb_version in mongo_compatible_target_version[existing_mongo_version]
     fail_msg:
       - "You have an existing Mongo database instance that is running on version {{ existing_mongo_version }}, which cannot be directly upgraded to version {{ target_mongodb_version }}."
-      - "In order to upgrade your current instance to {{ target_mongodb_version }}, you must first upgrade your Mongo instance version to {{ mongo_compatible_target_version[existing_mongo_version] }}."
+      - "In order to upgrade your current instance to {{ target_mongodb_version }}, you must first upgrade your Mongo instance version to one of the compatible options: {{ mongo_compatible_target_version[existing_mongo_version] }}."
 
 # This would validate that we only upgrade to v5.0 if 'target_mongodb_version' matches v5.0 minor version and 'mongodb_v5_upgrade: true'
 - name: "Assert that the Mongo v5 upgrade has been triggered"

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/validate-upgrade.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/validate-upgrade.yml
@@ -28,7 +28,7 @@
 - name: Assert Mongo upgrade compatibility
   when: existing_mongo_minor_version != '4.2' # will skip this assertion if mongo v4.2 as we'll assist in the auto upgrade to v4.4 and v5 in a single run
   assert:
-    that: target_mongodb_version == mongo_compatible_target_version
+    that: target_mongodb_version in mongo_compatible_target_version
     fail_msg:
       - "You have an existing Mongo database instance that is running on version {{ existing_mongo_version }}, which cannot be directly upgraded to version {{ target_mongodb_version }}."
       - "In order to upgrade your current instance to {{ target_mongodb_version }}, you must first upgrade your Mongo instance version to {{ mongo_compatible_target_version }}."


### PR DESCRIPTION
This PR tries to simplify the logic that defines and validates the correct and matching versions to be upgraded for MongoDB.
Since now we can upgrade within patch versions (and not only minor versions) the existing code has some gaps that hopefully will be addressed with this change. An issue identified was that we expect that if mongo is version 5.0, the target can only be v6: and does not consider that you could go from 5.0.21 to 5.0.23:
```
fatal: [localhost]: FAILED! => changed=false assertion: target_mongodb_version == mongo_compatible_target_version evaluated_to: false msg: - You have an existing Mongo database instance that is running on version 5.0.21, which cannot be directly upgraded to version 5.0.23. - In order to upgrade your current instance to 5.0.23, you must first upgrade your Mongo instance version to 6.0.12.
```

This adds a new internal variable `mongo_compatible_target_version` that is supposed to map all the possible target mongodb version that is compatible to be upgraded based on the existing mongodb version identified.

This way, the assertion will be bit different:

```
TASK [ibm.mas_devops.mongodb : Assert Mongo upgrade compatibility: 6.0.12 must be in ['5.0.21', '5.0.23']] *****************
fatal: [localhost]: FAILED! => {
    "assertion": "target_mongodb_version in mongo_compatible_target_version[existing_mongo_version]",
    "changed": false,
    "evaluated_to": false,
    "msg": [
        "You have an existing Mongo database instance that is running on version 4.4.21, which cannot be directly upgraded to version 6.0.12.",
        "In order to upgrade your current instance to 6.0.12, you must first upgrade your Mongo instance version to one of the compatible options: ['5.0.21', '5.0.23']."
    ]
}
```