### PR TITLE
[minor] Add playbook to convert OCP to a disconnected install

### DIFF
--- a/ibm/mas_devops/playbooks/ocp_convert_to_disconnected.yml
+++ b/ibm/mas_devops/playbooks/ocp_convert_to_disconnected.yml
@@ -1,0 +1,21 @@
+---
+- hosts: localhost
+  any_errors_fatal: true
+
+  vars:
+    ocp_operatorhub_disable_redhat_sources: true
+
+    ocp_release: 4.12
+    setup_redhat_release: true
+    setup_redhat_catalogs: true
+
+    registry_private_host: "{{ lookup('env', 'REGISTRY_PRIVATE_HOST') }}"
+    registry_private_port: "{{ lookup('env', 'REGISTRY_PRIVATE_PORT') }}"
+    registry_private_ca_file: "{{ lookup('env', 'REGISTRY_PRIVATE_CA_FILE') }}"
+    registry_username: "{{ lookup('env', 'REGISTRY_USERNAME') }}"
+    registry_password: "{{ lookup('env', 'REGISTRY_PASSWORD') }}"
+
+  roles:
+    - ibm.mas_devops.ocp_config
+    - ibm.mas_devops.ocp_contentsourcepolicy
+    - ibm.mas_devops.ocp_simulate_disconnected_network

--- a/ibm/mas_devops/playbooks/ocp_convert_to_disconnected.yml
+++ b/ibm/mas_devops/playbooks/ocp_convert_to_disconnected.yml
@@ -5,7 +5,7 @@
   vars:
     ocp_operatorhub_disable_redhat_sources: true
 
-    ocp_release: 4.12
+    ocp_release: "{{ lookup('env', 'OCP_RELEASE') | default('4.12', true) }}"
     setup_redhat_release: true
     setup_redhat_catalogs: true
 

--- a/ibm/mas_devops/roles/ocp_contentsourcepolicy/tasks/trust.yml
+++ b/ibm/mas_devops/roles/ocp_contentsourcepolicy/tasks/trust.yml
@@ -5,6 +5,7 @@
 - name: Read the CA cert
   set_fact:
     registry_private_ca_crt: "{{ lookup('file', registry_private_ca_file) }}"
+  no_log: true
 
 
 # 2. Create configmap containing the CA cert of our airgap registry
@@ -13,6 +14,7 @@
   kubernetes.core.k8s:
     apply: yes
     template: 'templates/configmap.yml.j2'
+  no_log: true
 
 
 # 3. Patch cluster config to use this configmap in spec.additionalTrustedCA

--- a/ibm/mas_devops/roles/ocp_contentsourcepolicy/tasks/update-pull-secret-dev.yml
+++ b/ibm/mas_devops/roles/ocp_contentsourcepolicy/tasks/update-pull-secret-dev.yml
@@ -12,6 +12,7 @@
       - "}"
   set_fact:
     new_secret_dev: "{{ content | join('') }}"
+  no_log: true
 
 # 1.2 Find the existing secret, and we are going to modify it rather than replace
 - name: "update-pull-secret-dev : Retrieve existing pull-secret content"
@@ -21,6 +22,7 @@
     name: pull-secret
     namespace: openshift-config
   register: pullsecret
+  no_log: true
 
 - name: "update-pull-secret-dev : Get the original cred secrets"
   set_fact:
@@ -52,6 +54,7 @@
       data:
         .dockerconfigjson: "{{ new_secret_string | to_json | b64encode }}"
   register: secretUpdateResult
+  no_log: true
 
 - name: "update-pull-secret-dev : Debug change state"
   debug:

--- a/ibm/mas_devops/roles/ocp_contentsourcepolicy/tasks/update-pull-secret-dev.yml
+++ b/ibm/mas_devops/roles/ocp_contentsourcepolicy/tasks/update-pull-secret-dev.yml
@@ -31,11 +31,13 @@
 - name: "update-pull-secret-dev : Get the dockerconfigjson info"
   set_fact:
     secret_string: '{{ original_secret[".dockerconfigjson"] | b64decode | from_json }}'
+  no_log: true
 
 # 1.3 Append our new credentials to the secret
 - name: "update-pull-secret-dev : Combine new secret content"
   set_fact:
     new_secret_string: '{{ secret_string | combine( new_secret_dev, recursive=True) }}'
+  no_log: true
 
 # 1.4. Overwrite the secret
 - name: "update-pull-secret-dev : Update new pull-secret"

--- a/ibm/mas_devops/roles/ocp_contentsourcepolicy/tasks/update-pull-secret.yml
+++ b/ibm/mas_devops/roles/ocp_contentsourcepolicy/tasks/update-pull-secret.yml
@@ -12,6 +12,7 @@
       - "}"
   set_fact:
     new_secret: "{{ content | join('') }}"
+  no_log: true
 
 # 1.2 Find the existing secret, and we are going to modify it rather than replace
 - name: "update-pull-secret : Retrieve existing pull-secret content"
@@ -21,6 +22,7 @@
     name: pull-secret
     namespace: openshift-config
   register: pullsecret
+  no_log: true
 
 - name: "update-pull-secret : Get the original cred secrets"
   set_fact:
@@ -36,6 +38,7 @@
 - name: "update-pull-secret : Combine new secret content"
   set_fact:
     new_secret_string: '{{ secret_string | combine( new_secret, recursive=True) }}'
+  no_log: true
 
 # 1.4. Overwrite the secret
 - name: "update-pull-secret : Update new pull-secret"
@@ -50,6 +53,7 @@
       data:
         .dockerconfigjson: "{{ new_secret_string | to_json | b64encode }}"
   register: secretUpdateResult
+  no_log: true
 
 - name: "update-pull-secret : Debug change state"
   debug:

--- a/ibm/mas_devops/roles/ocp_contentsourcepolicy/tasks/update-pull-secret.yml
+++ b/ibm/mas_devops/roles/ocp_contentsourcepolicy/tasks/update-pull-secret.yml
@@ -33,6 +33,7 @@
 - name: "update-pull-secret : Get the dockerconfigjson info"
   set_fact:
     secret_string: '{{ original_secret[".dockerconfigjson"] | b64decode | from_json }}'
+  no_log: true
 
 # 1.3 Append our new credentials to the secret
 - name: "update-pull-secret : Combine new secret content"


### PR DESCRIPTION
This update adds a new playbook that can be used to easily convert an online OCP install to an offline install.