### PR TITLE
[patch] Hide sensitive info in debug logs when mirroring images

### DIFF
--- a/ibm/mas_devops/roles/mirror_extras_prepare/tasks/catalog.yml
+++ b/ibm/mas_devops/roles/mirror_extras_prepare/tasks/catalog.yml
@@ -11,6 +11,7 @@
       --creds "{{ artifactory_username }}:{{ artifactory_token }}" \
       --no-tags)| jq -r '.Digest' \
   register: catalog_lookup
+  no_log: true
 
 - name: "catalog : Set value for dev catalog digest"
   when:
@@ -18,6 +19,7 @@
     - artifactory_token is defined and artifactory_token != ""
   set_fact:
     catalog_digest: "{{ catalog_lookup.stdout }}"
+
 
 # 1. Check for additional required properties
 # -----------------------------------------------------------------------------
@@ -27,7 +29,6 @@
       - catalog_tag is defined and catalog_tag != ""
       - catalog_digest is defined and catalog_digest != ""
     fail_msg: "One or more required properties are missing"
-
 
 - name: "catalog : Load variables"
   include_vars:

--- a/ibm/mas_devops/roles/mirror_images/tasks/main.yml
+++ b/ibm/mas_devops/roles/mirror_images/tasks/main.yml
@@ -22,6 +22,7 @@
   ansible.builtin.template:
     src: templates/auth-secret.json.j2
     dest: "{{ auth_file }}"
+  no_log: true
 
 - name: "{{ manifest_name }} : Debug"
   debug:


### PR DESCRIPTION
Per the title .. adds `no_log: true` to a couple of tasks that otherwise expose sensitive information in the logs.