### PR TITLE
[patch] Set cert aliases to conform to api

### DIFF
--- a/ibm/mas_devops/roles/configure_manage_eventstreams/tasks/main.yml
+++ b/ibm/mas_devops/roles/configure_manage_eventstreams/tasks/main.yml
@@ -99,10 +99,10 @@
         settings:
           deployment:
             importedCerts:
-              - alias: ES_cert1
+              - alias: ES.cert1
                 crt: |-
                   {{ es_tls_crt[1] }}
-              - alias: ES_cert2
+              - alias: ES.cert2
                 crt: |-
                   -----BEGIN CERTIFICATE-----
                   MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw

--- a/ibm/mas_devops/roles/cos/templates/ibm/objectstoragecfg.yml.j2
+++ b/ibm/mas_devops/roles/cos/templates/ibm/objectstoragecfg.yml.j2
@@ -36,7 +36,7 @@ spec:
     credentials:
       secretName: ibmcos-credentials-system
   certificates:
-    - alias: ibmcos-intermediate-cert
+    - alias: ibmcos.intermediate.cert
       crt: |
         -----BEGIN CERTIFICATE-----
         MIIEyDCCA7CgAwIBAgIQDPW9BitWAvR6uFAsI8zwZjANBgkqhkiG9w0BAQsFADBh
@@ -66,7 +66,7 @@ spec:
         chDYABPPTHPbqjc1qCmBaZx2vN4Ye5DUys/vZwP9BFohFrH/6j/f3IL16/RZkiMN
         JCqVJUzKoZHm1Lesh3Sz8W2jmdv51b2EQJ8HmA==
         -----END CERTIFICATE-----
-    - alias: ibmcos-root-cert
+    - alias: ibmcos.root.cert
       crt: |
         -----BEGIN CERTIFICATE-----
         MIIDjjCCAnagAwIBAgIQAzrx5qcRqaC7KGSxHQn65TANBgkqhkiG9w0BAQsFADBh
@@ -90,7 +90,7 @@ spec:
         pLiaWN0bfVKfjllDiIGknibVb63dDcY3fe0Dkhvld1927jyNxF1WW6LZZm6zNTfl
         MrY=
         -----END CERTIFICATE-----
-    - alias: ibmiam-intermediate-cert
+    - alias: ibmiam.intermediate.cert
       crt: |
         -----BEGIN CERTIFICATE-----
         MIIDrzCCApegAwIBAgIQCDvgVpBCRrGhdWrJWZHHSjANBgkqhkiG9w0BAQUFADBh
@@ -114,7 +114,7 @@ spec:
         YSEY1QSteDwsOoBrp+uvFRTp2InBuThs4pFsiv9kuXclVzDAGySj4dzp30d8tbQk
         CAUw7C29C79Fv1C5qfPrmAESrciIxpg0X40KPMbp1ZWVbd4=
         -----END CERTIFICATE-----
-    - alias: ibmiam-root-cert
+    - alias: ibmiam.root.cert
       crt: |
         -----BEGIN CERTIFICATE-----
         MIIDjjCCAnagAwIBAgIQAzrx5qcRqaC7KGSxHQn65TANBgkqhkiG9w0BAQsFADBh

--- a/ibm/mas_devops/roles/kafka/templates/redhat/kafkacfg.yml.j2
+++ b/ibm/mas_devops/roles/kafka/templates/redhat/kafkacfg.yml.j2
@@ -38,6 +38,6 @@ spec:
       secretName: maskafka-credentials
     saslMechanism: SCRAM-SHA-512
   certificates:
-    - alias: "{{ kafka_cluster_name }}-ca"
+    - alias: "{{ kafka_cluster_name }}.ca"
       crt: |
         {{ kafka_bootstrap_cert | indent(8) }}


### PR DESCRIPTION
Some of the cert aliases being set don't conform to the expect value that the MAS API expects. This means it won't be possible to apply (or re-apply) a configured config via the MAS API. For example the kafka role creates the config with an alias of `maskafka-ca`, this is then picked up by the operator with no issue. However if you try to apply this same config via the MAS API (using the values as the payload rather than creating the kube resource) then you get the error:

```
message: 'AIUCO1000E: The request was not valid. Review the constraint violations
  provided [1 violations]'
uuid: fb0a723e-b90f-494f-b722-395e166b647c
violations:
- exception:
    id: AIUCO2008E
    properties:
    - - - '''maskafka-ca'' does not match ''^[.&a-zA-Z0-9]{2,32}$'''
  message: 'AIUCO2008E: Invalid input violation: ["''maskafka-ca'' does not match
    ''^[.&a-zA-Z0-9]{2,32}$''"]'
```

This fix changes the alias name in the relevant configs to contain a `.` rather than a `-` or `_`.