### PR TITLE
[patch] Mongo update does not require upgrade confirmation flag

### DIFF
--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/validate-upgrade.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/validate-upgrade.yml
@@ -35,14 +35,18 @@
 
 # This would validate that we only upgrade to v5.0 if 'target_mongodb_version' matches v5.0 minor version and 'mongodb_v5_upgrade: true'
 - name: "Assert that the Mongo v5 upgrade has been triggered"
-  when: target_mongodb_version | regex_search('(?<=)(.*)(?=...)') == '5.0'
+  when:
+    - existing_mongo_minor_version is version_compare('5.0', '<')"
+    - target_mongodb_version | regex_search('(?<=)(.*)(?=...)') == '5.0'
   assert:
     that: mongodb_v5_upgrade
     fail_msg: "Your current mongo version is {{ existing_mongo_version }}, in order to upgrade to version {{ target_mongodb_version }}, you must set 'mongodb_v5_upgrade': true"
 
 # This would validate that we only upgrade to v6.0 if 'target_mongodb_version' matches v6.0 minor version and 'mongodb_v6_upgrade: true'
 - name: "Assert that the Mongo v6 upgrade has been triggered"
-  when: target_mongodb_version | regex_search('(?<=)(.*)(?=...)') == '6.0'
+  when:
+    - existing_mongo_minor_version is version_compare('6.0', '<')"
+    - target_mongodb_version | regex_search('(?<=)(.*)(?=...)') == '6.0'
   assert:
     that: mongodb_v6_upgrade
     fail_msg: "Your current mongo version is {{ existing_mongo_version }}, in order to upgrade to version {{ target_mongodb_version }}, you must set 'mongodb_v6_upgrade': true"

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/validate-upgrade.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/validate-upgrade.yml
@@ -36,7 +36,7 @@
 # This would validate that we only upgrade to v5.0 if 'target_mongodb_version' matches v5.0 minor version and 'mongodb_v5_upgrade: true'
 - name: "Assert that the Mongo v5 upgrade has been triggered"
   when:
-    - existing_mongo_minor_version is version_compare('5.0', '<')"
+    - existing_mongo_minor_version is version_compare('5.0', '<')
     - target_mongodb_version | regex_search('(?<=)(.*)(?=...)') == '5.0'
   assert:
     that: mongodb_v5_upgrade
@@ -45,7 +45,7 @@
 # This would validate that we only upgrade to v6.0 if 'target_mongodb_version' matches v6.0 minor version and 'mongodb_v6_upgrade: true'
 - name: "Assert that the Mongo v6 upgrade has been triggered"
   when:
-    - existing_mongo_minor_version is version_compare('6.0', '<')"
+    - existing_mongo_minor_version is version_compare('6.0', '<')
     - target_mongodb_version | regex_search('(?<=)(.*)(?=...)') == '6.0'
   assert:
     that: mongodb_v6_upgrade


### PR DESCRIPTION
`mongodb_v5_upgrade` and `mongodb_v6_upgrade` parameters only need to be set to confirm major version upgrades, but currently they are required for any version change.