### PR TITLE
[patch] set installIBMCatalogSource to false to avoid creating opencloud-operators catalog source.

### DIFF
--- a/ibm/mas_devops/roles/dro/tasks/install-dro/main.yml
+++ b/ibm/mas_devops/roles/dro/tasks/install-dro/main.yml
@@ -68,11 +68,6 @@
     fail_msg: "Provide IBM Entitlement Key, Access https://myibm.ibm.com/products-services/containerlibrary using your IBMId to access your entitlement key"
   when: (rm_sec.resources is defined) and (rm_sec.resources | length == 0)
 
-- name: "Create Secret redhat-marketplace-pull-secret"
-  kubernetes.core.k8s:
-    definition: "{{ lookup('template', 'templates/rhm-pull-secret.yml.j2') }}"
-  when: (rm_sec.resources is defined) and (rm_sec.resources | length == 0)
-
 
 # 4.1 Load PodTemplates configuration
 # -----------------------------------------------------------------------------
@@ -220,47 +215,17 @@
     wait_timeout: 120
   when: (rmo_subscription.resources is defined) and (rmo_subscription.resources | length == 0)
 
-# Accept License
+# Apply MarketplaceConfig CR
 # -----------------------------------------------------------------------------
-- name: Get MarketplaceConfig
-  kubernetes.core.k8s_info:
-    api_version: marketplace.redhat.com/v1alpha1
-    kind: MarketplaceConfig
-    namespace: redhat-marketplace
-    name: marketplaceconfig
-  register: marketplacecfg
-  until:
-    - "{{ marketplacecfg.resources|length > 0 }}"
-  retries: 20
-  delay: 20 # seconds
+- name: Create MarketplaceConfig CR
+  kubernetes.core.k8s:
+    definition: "{{ lookup('template', 'templates/MarketplaceConfig-cr.yml.j2') }}"
 
-- name: "Accept marketplaceconfig license"
-  kubernetes.core.k8s_json_patch:
-    api_version: marketplace.redhat.com/v1alpha1
-    kind: MarketplaceConfig
-    namespace: redhat-marketplace
-    name: marketplaceconfig
-    patch:
-      - op: "replace"
-        path: "/spec/license/accept"
-        value: true
-
-
-# 6. Set Disconnected
-# -----------------------------------------------------------------------------
-- name: "Patch marketplaceconfig for airgap install"
-  kubernetes.core.k8s_json_patch:
-    api_version: marketplace.redhat.com/v1alpha1
-    kind: MarketplaceConfig
-    namespace: redhat-marketplace
-    name: marketplaceconfig
-    patch:
-      - op: "replace"
-        path: "/spec/isDisconnected"
-        value: "{{ airgap_install }}"
-    wait_timeout: 60
-    wait: yes
-  when: airgap_install
+# Create DRO Pull Secret
+- name: "Create Secret redhat-marketplace-pull-secret"
+  kubernetes.core.k8s:
+    definition: "{{ lookup('template', 'templates/rhm-pull-secret.yml.j2') }}"
+  when: (rm_sec.resources is defined) and (rm_sec.resources | length == 0)
 
 # 7. Check deployment status
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/dro/templates/MarketplaceConfig-cr.yml.j2
+++ b/ibm/mas_devops/roles/dro/templates/MarketplaceConfig-cr.yml.j2
@@ -1,0 +1,12 @@
+---
+# Create MarketplaceConfig CR -  Set Accept License to True and installIBMCatalogSource to False 
+apiVersion: marketplace.redhat.com/v1alpha1
+kind: MarketplaceConfig
+metadata:
+    name: marketplaceconfig
+    namespace: redhat-marketplace
+spec:
+    installIBMCatalogSource: false
+    isDisconnected: {{ airgap_install }}
+    license:
+        accept: true


### PR DESCRIPTION
https://jsw.ibm.com/browse/MASCORE-1433

 - remove the Edit MarketplaceConfig CR logic 
 - Create the CR with correct Values and apply to the cluster
 - Move the DRO pull-secret creation after applying the MarketplaceConfig CR