### PR TITLE
[patch] wait for marketplaceConfig to be ready before applying the CR

### DIFF
--- a/ibm/mas_devops/roles/dro/tasks/install-dro/main.yml
+++ b/ibm/mas_devops/roles/dro/tasks/install-dro/main.yml
@@ -215,6 +215,25 @@
     wait_timeout: 120
   when: (rmo_subscription.resources is defined) and (rmo_subscription.resources | length == 0)
 
+# Wait until the marketplaceconfigs CRD is available
+- name: "Wait until the marketplaceconfigs CRD is available"
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    name: "marketplaceconfigs.marketplace.redhat.com"
+    kind: CustomResourceDefinition
+    wait: yes
+    wait_sleep: 10
+    wait_timeout: 300 # 5 mins until we give up waiting for the CRD to get into the expected state
+    wait_condition:
+      type: NamesAccepted
+      status: "True"
+  register: mpc_crd_info
+  retries: 120 # ~approx 5 minutes before we give up waiting for the CRD to be created
+  delay: 5 # seconds
+  until:
+    - mpc_crd_info.resources is defined
+    - mpc_crd_info.resources | length > 0
+
 # Apply MarketplaceConfig CR
 # -----------------------------------------------------------------------------
 - name: Create MarketplaceConfig CR


### PR DESCRIPTION
 fix fvt failures. 
 

 slack discussions on this issue
 https://ibm-watson-iot.slack.com/archives/C031Q7W21FZ/p1706014726848299
 
 - wait for marketplaceConfig to be ready before  applying the CR
 
Manual testing passed. 
 
![image](https://github.com/ibm-mas/ansible-devops/assets/110647904/f09a1f97-5da4-4b97-8cef-1a6e076a3a44)
