### PR TITLE
[patch] Support update from Mongo v4.2.6

### DIFF
--- a/ibm/mas_devops/roles/mongodb/defaults/main.yml
+++ b/ibm/mas_devops/roles/mongodb/defaults/main.yml
@@ -122,6 +122,8 @@ mongodb_v6_upgrade: "{{ lookup('env', 'MONGODB_V6_UPGRADE') | default(false, tru
 # If `existing_mongo_version: 4.4.21` then the `target_mongodb_version` must be `5.0.21` or `5.0.23`.
 # Otherwise the code will validate there is an incompatibility in the version to be upgraded and it will fail prior starting the upgrade process.
 mongo_compatible_target_version:
+  "4.2.6":
+    - "4.4.21"
   "4.2.23":
     - "4.4.21"
   "4.4.21":


### PR DESCRIPTION
Currently `4.2.23` is only support 4.2.x version we can update from, but very early MAS installs may still be on `4.2.6` so we need to be able to provide an update path for those too.