### PR TITLE
[patch] Handle custom storage capacities in Mongo update

### DIFF
--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/check-mongo-exists.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/check-mongo-exists.yml
@@ -37,9 +37,12 @@
       set_fact:
         existing_mongo_version: "{{ existing_mongodb.resources[0].spec.version }}"
 
+    # MongoDb version strings are (currently) always in the format {single_digit}.{single_digit} so
+    # we can avoid the regex problems seen previously by using a simple substring function to
+    # get the minor version string from the first three characters of the full version string
     - name: Set existing_mongo_minor_version
       set_fact:
-        existing_mongo_minor_version: "{{ existing_mongo_version | regex_search('(?<=)(.*)(?=...)') }}"
+        existing_mongo_minor_version: "{{ existing_mongo_version[:3] }}"
 
     - include_tasks: tasks/determine-ibmcatalog-tag.yml
 

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/check-mongo-exists.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/check-mongo-exists.yml
@@ -29,9 +29,12 @@
       - "Existing MongoDb version ........ {{ existing_mongodb.resources[0].spec.version | default('Not found', true) }}"
 
 - block:
-    - name: Set existing_mongo_storage_class
+    # Note: this step assumes that the data volume is always defined before the logs volume.  We could/should improve this TBH.
+    - name: Set existing_mongo_storage_class & capacity
       set_fact:
         existing_mongo_storage_class: "{{ existing_mongodb.resources[0].spec.statefulSet.spec.volumeClaimTemplates[0].spec.storageClassName }}"
+        existing_mongodb_storage_capacity_data: "{{ existing_mongodb.resources[0].spec.statefulSet.spec.volumeClaimTemplates[0].spec.resources.requests.storage }}"
+        existing_mongodb_storage_capacity_logs: "{{ existing_mongodb.resources[0].spec.statefulSet.spec.volumeClaimTemplates[1].spec.resources.requests.storage }}"
 
     - name: Set existing_mongo_version
       set_fact:

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/install.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/install.yml
@@ -31,6 +31,16 @@
       - "The selected storage class {{ mongodb_storage_class }} does not match the existing storage class in use {{ existing_mongo_storage_class }}"
       - "This role is unable to modify the storage used by an existing MongoDb installation"
 
+# Also, override default/selected storage capacity based on what is currently selected
+# The storage capacity used in the statefulset can not be changed
+- name: Use existing storage capacity
+  when:
+    - existing_mongodb_storage_capacity_data is defined
+    - existing_mongodb_storage_capacity_logs is defined
+  set_fact:
+    mongodb_storage_capacity_data: "{{ existing_mongodb_storage_capacity_data }}"
+    mongodb_storage_capacity_logs: "{{ existing_mongodb_storage_capacity_logs }}"
+
 
 # 3. Perform upgrade from 4.2 to 4.4 if necessary
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
When updating a Mongo instance, the current process does not take into account the scenario where the storage capacity is different from the default value of `20Gi`.

This also fixes an issue with the Mongo version detection regex.
- #1157