### PR TITLE
[patch] Correct Manage versions

### DIFF
--- a/ibm/mas_devops/common_vars/casebundles/v8-240130-amd64.yml
+++ b/ibm/mas_devops/common_vars/casebundles/v8-240130-amd64.yml
@@ -50,8 +50,8 @@ mas_iot_version:
   8.11.x: 8.8.4   # Updated
   8.9.x: 8.6.9    # No Update
 mas_manage_version:
-  8.10.x: 8.6.8   # Updated
-  8.11.x: 8.7.3   # Updated
+  8.10.x: 8.6.9   # Updated
+  8.11.x: 8.7.4   # Updated
   8.9.x: 8.5.9    # No Update
 mas_monitor_version:
   8.10.x: 8.10.6  # No Update


### PR DESCRIPTION
Manifest vars for Jan catalog contain the incorrect versions of ibm-mas-manage, this update corrects them:

- 8.10.x: 8.6.9
- 8.11.x: 8.7.4