### PR TITLE
[patch] Set Red Hat Certificate Manager by default

### DIFF
--- a/ibm/mas_devops/roles/cert_manager/defaults/main.yml
+++ b/ibm/mas_devops/roles/cert_manager/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Certificate Manager variables
 cert_manager_action: "{{ lookup('env', 'CERT_MANAGER_ACTION') | default('install', true) }}"
-cert_manager_provider: "{{ lookup('env', 'CERT_MANAGER_PROVIDER') | default('ibm', true) }}"
+cert_manager_provider: "{{ lookup('env', 'CERT_MANAGER_PROVIDER') | default('redhat', true) }}"
 
 cert_manager_defaults:
   redhat:


### PR DESCRIPTION
This PR changes Red Hat Certificate Manager as default provider for certificate management in MAS across ansible-devops. IBM certificate manager will be migrated automatically once Red Hat version is installed.