### PR TITLE
[patch] Lookup cluster ingress certificate secret based on IngressController

### DIFF
--- a/ibm/mas_devops/common_tasks/get_signed_ingress_cert.yml
+++ b/ibm/mas_devops/common_tasks/get_signed_ingress_cert.yml
@@ -6,7 +6,7 @@
     ocp_ingress_tls_secret_name: "{{ lookup('env', 'OCP_INGRESS_TLS_SECRET_NAME') | default('router-certs-default', True) }}"
   when: ocp_ingress_tls_secret_name is not defined
 
-- name: "Lookup for {{ ocp_ingress_tls_secret_name }} secret"
+- name: "1st attempt: Lookup for {{ ocp_ingress_tls_secret_name }} secret"
   no_log: true
   k8s_info:
     api_version: v1
@@ -24,76 +24,139 @@
     cluster_ingress_secret_name: "{{ ocp_ingress_tls_secret_name }}"
     cluster_ingress_tls_crt: "{{ router_certs_default_secret.resources[0].data['tls.crt'] | b64decode }}"
 
+- debug:
+    msg:
+      - "Cluster Ingress Cert Secret Name ...... {{ cluster_ingress_secret_name if (cluster_ingress_secret_name is defined) else '1st attempt missed' }}"
+
 # 2. Lookup for secret named after cluster ingress
 # -----------------------------------------------------------------------------
-- name: Get cluster subdomain
-  when: found_router_default_secret is not defined
-  kubernetes.core.k8s_info:
-    api_version: config.openshift.io/v1
-    kind: Ingress
-    name: cluster
-  register: cluster_subdomain
+- when:
+    - cluster_ingress_secret_name is not defined or
+      cluster_ingress_tls_crt is not defined
+  block:
+    - name: Get cluster subdomain
+      when: found_router_default_secret is not defined
+      kubernetes.core.k8s_info:
+        api_version: config.openshift.io/v1
+        kind: Ingress
+        name: cluster
+      register: cluster_subdomain
 
-- name: Lookup for cluster ingress secret
-  when:
-    - found_router_default_secret is not defined
-    - cluster_subdomain.resources is defined
-    - cluster_subdomain.resources | length > 0
-  no_log: true
-  k8s_info:
-    api_version: v1
-    kind: Secret
-    name: "{{ cluster_subdomain.resources[0].spec.domain | regex_search('[^.]*')  }}"
-    namespace: openshift-ingress
-  register: cluster_ingress_secret
+    - name: "2nd attempt : Lookup for cluster ingress secret based on Ingress/cluster"
+      when:
+        - cluster_subdomain.resources is defined
+        - cluster_subdomain.resources | length > 0
+      no_log: true
+      k8s_info:
+        api_version: v1
+        kind: Secret
+        name: "{{ cluster_subdomain.resources[0].spec.domain | regex_search('[^.]*') }}fdsfdsfsd"
+        namespace: openshift-ingress
+      register: cluster_ingress_secret
 
-- name: "Record that we have found the cluster ingress cert secret"
-  when:
-    - found_router_default_secret is not defined
-    - cluster_ingress_secret is defined
-    - cluster_ingress_secret.resources | length > 0
-  set_fact:
-    found_cluster_ingress_secret: true
-    cluster_ingress_secret_name: "{{ cluster_subdomain.resources[0].spec.domain | regex_search('[^.]*')  }}"
-    cluster_ingress_tls_crt: "{{ cluster_ingress_secret.resources[0].data['tls.crt'] | b64decode }}"
+    - name: "Record that we have found the cluster ingress cert secret"
+      when:
+        - cluster_ingress_secret is defined
+        - cluster_ingress_secret.resources | length > 0
+      set_fact:
+        found_cluster_ingress_secret: true
+        cluster_ingress_secret_name: "{{ cluster_subdomain.resources[0].spec.domain | regex_search('[^.]*')  }}"
+        cluster_ingress_tls_crt: "{{ cluster_ingress_secret.resources[0].data['tls.crt'] | b64decode }}"
 
-# 3. Lookup for secret based on the cluster name
+    - debug:
+        msg:
+          - "Cluster Ingress Cert Secret Name ...... {{ cluster_ingress_secret_name if (cluster_ingress_secret_name is defined) else '2nd attempt missed' }}"
+
+# 3. If still not found, lookup for cluster ingress secret based on ingresscontroller
+# -----------------------------------------------------------------------------
+- when:
+    - cluster_ingress_secret_name is not defined or
+      cluster_ingress_tls_crt is not defined
+  block:
+    - name: "3rd attempt: Lookup for cluster ingress secret based on IngressController default"
+      kubernetes.core.k8s_info:
+        api_version: operator.openshift.io/v1
+        kind: IngressController
+        name: default
+        namespace: openshift-ingress-operator
+      register: cluster_ingresscontroller_lookup
+
+    - when:
+        - cluster_ingresscontroller_lookup.resources is defined and cluster_ingresscontroller_lookup.resources | length > 0
+        - cluster_ingresscontroller_lookup.resources[0].spec.defaultCertificate.name
+      block:
+        - name: Set default secret name containing cluster's ingress certificate based on IngressController default
+          set_fact:
+            cluster_ingress_secret_name: "{{ cluster_ingresscontroller_lookup.resources[0].spec.defaultCertificate.name }}"
+
+        - name: Lookup default secret name containing cluster's ingress certificate based on IngressController default
+          when: cluster_ingress_secret_name is defined and cluster_ingress_secret_name | length > 0
+          k8s_info:
+            api_version: v1
+            kind: Secret
+            name: "{{ cluster_ingress_secret_name }}"
+            namespace: openshift-ingress
+          register: cluster_ingress_default_secret
+
+        - name: "Record that we have found the default cluster ingress cert secret"
+          when:
+            - cluster_ingress_default_secret.resources is defined
+            - cluster_ingress_default_secret.resources | length > 0
+          set_fact:
+            found_cluster_ingress_secret: true
+            cluster_ingress_tls_crt: "{{ cluster_ingress_default_secret.resources[0].data['tls.crt'] | b64decode }}"
+
+        - debug:
+            msg:
+              - "Cluster Ingress Cert Secret Name ...... {{ cluster_ingress_secret_name if (cluster_ingress_secret_name is defined) else '3rd attempt missed' }}"
+
+# 4. Lookup for secret based on the cluster name
 # -----------------------------------------------------------------------------
 # ROSA, TechZone, and some IPI Installs use this convention
-- name: Get all TLS secrets
-  when:
-    - found_router_default_secret is not defined
-    - found_cluster_ingress_secret is not defined
-  k8s_info:
-    api_version: v1
-    kind: Secret
-    namespace: openshift-ingress
-    field_selectors:
-      - type=kubernetes.io/tls
-  register: cluster_primary_secrets
+- when:
+    - cluster_ingress_secret_name is not defined or
+      cluster_ingress_tls_crt is not defined
+  block:
+    - name: Get all TLS secrets
+      k8s_info:
+        api_version: v1
+        kind: Secret
+        namespace: openshift-ingress
+        field_selectors:
+          - type=kubernetes.io/tls
+      register: cluster_primary_secrets
 
-# This will lookup for cluster's ingress secret name that matches a given label
-# Depending on the cluster's provider, it will try to use substrings to find the
-# exact secret's name i.e for ARO clusters, the cluster's ingress secret name
-# will end with '-ingress'
-- name: "Find Cluster Primary Secret"
-  when:
-    - found_router_default_secret is not defined
-    - found_cluster_ingress_secret is not defined
-    - cluster_primary_secrets is defined
-    - cluster_primary_secrets.resources is defined
-    - cluster_primary_secrets.resources | length > 0
-    - (item.metadata.name.endswith("-primary-cert-bundle-secret")) or
-      (item.metadata.name.endswith("-ingress")) or
-      (item.metadata.name == "letsencrypt-certs")
-  set_fact:
-    found_cluster_primary_secret: true
-    cluster_ingress_secret_name: "{{ item.metadata.name }}"
-    cluster_ingress_tls_crt: "{{ item.data['tls.crt'] | b64decode }}"
-  with_items:
-    - "{{ cluster_primary_secrets.resources }}"
-  loop_control:
-    label: "{{ item.metadata.name }}"
+    # This will lookup for cluster's ingress secret name that matches a given label
+    # Depending on the cluster's provider, it will try to use substrings to find the
+    # exact secret's name i.e for ARO clusters, the cluster's ingress secret name
+    # will end with '-ingress'
+    - name: "4th attempt: Lookup for cluster ingress secret based on ROSA, TechZone, and some IPI Installs name convention"
+      when:
+        - cluster_primary_secrets is defined
+        - cluster_primary_secrets.resources is defined
+        - cluster_primary_secrets.resources | length > 0
+        - (item.metadata.name.endswith("-primary-cert-bundle-secret")) or
+          (item.metadata.name.endswith("-ingress")) or
+          (item.metadata.name == "letsencrypt-certs")
+      set_fact:
+        found_cluster_primary_secret: true
+        cluster_ingress_secret_name: "{{ item.metadata.name }}"
+        cluster_ingress_tls_crt: "{{ item.data['tls.crt'] | b64decode }}"
+      with_items:
+        - "{{ cluster_primary_secrets.resources }}"
+      loop_control:
+        label: "{{ item.metadata.name }}"
+
+    - debug:
+        msg:
+          - "Cluster Ingress Cert Secret Name ...... {{ cluster_ingress_secret_name if (cluster_ingress_secret_name is defined) else '4th attempt missed' }}"
+
+- name: "Assert one way or another cluster ingress secret has been found"
+  assert:
+    that:
+      - cluster_ingress_secret_name is defined
+      - cluster_ingress_tls_crt is defined
+    fail_msg: "Cluster ingress secret was not automatically found, please 'export OCP_INGRESS_TLS_SECRET_NAME' to point to the secret name in 'openshift-ingress' namespace that contains cluster ingress TLS certificates."
 
 # Break up the certificate into an array
 - name: "Extract certificate chain into a variable"
@@ -125,7 +188,7 @@
     - cluster_ingress_tls_crt is defined
     - cluster_ingress_tls_crt | length > 0
 
-# 4. Log which (if any) secret was found
+# 5. Log which (if any) secret was found
 # -----------------------------------------------------------------------------
 # If at least one of the secrets exist, then all good.  If none of the
 # secrets are found, then fail with a message

--- a/ibm/mas_devops/common_tasks/get_signed_ingress_cert.yml
+++ b/ibm/mas_devops/common_tasks/get_signed_ingress_cert.yml
@@ -6,7 +6,7 @@
     ocp_ingress_tls_secret_name: "{{ lookup('env', 'OCP_INGRESS_TLS_SECRET_NAME') | default('router-certs-default', True) }}"
   when: ocp_ingress_tls_secret_name is not defined
 
-- name: "1st attempt: Lookup for {{ ocp_ingress_tls_secret_name }} secret"
+- name: "1st attempt : Lookup for {{ ocp_ingress_tls_secret_name }} secret"
   no_log: true
   k8s_info:
     api_version: v1
@@ -42,7 +42,7 @@
         name: cluster
       register: cluster_subdomain
 
-    - name: "2nd attempt : Lookup for cluster ingress secret based on Ingress/cluster"
+    - name: "2nd attempt : Lookup for cluster ingress secret based on Ingress cluster"
       when:
         - cluster_subdomain.resources is defined
         - cluster_subdomain.resources | length > 0
@@ -73,7 +73,7 @@
     - cluster_ingress_secret_name is not defined or
       cluster_ingress_tls_crt is not defined
   block:
-    - name: "3rd attempt: Lookup for cluster ingress secret based on IngressController default"
+    - name: "3rd attempt : Lookup for cluster ingress secret based on IngressController default"
       kubernetes.core.k8s_info:
         api_version: operator.openshift.io/v1
         kind: IngressController
@@ -130,7 +130,7 @@
     # Depending on the cluster's provider, it will try to use substrings to find the
     # exact secret's name i.e for ARO clusters, the cluster's ingress secret name
     # will end with '-ingress'
-    - name: "4th attempt: Lookup for cluster ingress secret based on ROSA, TechZone, and some IPI Installs name convention"
+    - name: "4th attempt : Lookup for cluster ingress secret based on ROSA, TechZone, and some IPI Installs name convention"
       when:
         - cluster_primary_secrets is defined
         - cluster_primary_secrets.resources is defined

--- a/ibm/mas_devops/common_tasks/get_signed_ingress_cert.yml
+++ b/ibm/mas_devops/common_tasks/get_signed_ingress_cert.yml
@@ -26,7 +26,7 @@
 
 - debug:
     msg:
-      - "Cluster Ingress Cert Secret Name ...... {{ cluster_ingress_secret_name if (cluster_ingress_secret_name is defined) else '1st attempt missed' }}"
+      - "Cluster Ingress Cert Secret Name ...... {{ cluster_ingress_secret_name | default('1st attempt missed', true) }}"
 
 # 2. Lookup for secret named after cluster ingress
 # -----------------------------------------------------------------------------
@@ -65,7 +65,7 @@
 
     - debug:
         msg:
-          - "Cluster Ingress Cert Secret Name ...... {{ cluster_ingress_secret_name if (cluster_ingress_secret_name is defined) else '2nd attempt missed' }}"
+          - "Cluster Ingress Cert Secret Name ...... {{ cluster_ingress_secret_name | default('2nd attempt missed', true) }}"
 
 # 3. If still not found, lookup for cluster ingress secret based on ingresscontroller
 # -----------------------------------------------------------------------------
@@ -108,7 +108,7 @@
 
     - debug:
         msg:
-          - "Cluster Ingress Cert Secret Name ...... {{ cluster_ingress_secret_name if (cluster_ingress_secret_name is defined) else '3rd attempt missed' }}"
+          - "Cluster Ingress Cert Secret Name ...... {{ cluster_ingress_secret_name | default('3rd attempt missed', true) }}"
 
 # 4. Lookup for secret based on the cluster name
 # -----------------------------------------------------------------------------
@@ -149,7 +149,7 @@
 
     - debug:
         msg:
-          - "Cluster Ingress Cert Secret Name ...... {{ cluster_ingress_secret_name if (cluster_ingress_secret_name is defined) else '4th attempt missed' }}"
+          - "Cluster Ingress Cert Secret Name ...... {{ cluster_ingress_secret_name | default('4th attempt missed', true) }}"
 
 - name: "Assert one way or another cluster ingress secret has been found"
   assert:

--- a/ibm/mas_devops/common_tasks/get_signed_ingress_cert.yml
+++ b/ibm/mas_devops/common_tasks/get_signed_ingress_cert.yml
@@ -50,7 +50,7 @@
       k8s_info:
         api_version: v1
         kind: Secret
-        name: "{{ cluster_subdomain.resources[0].spec.domain | regex_search('[^.]*') }}fdsfdsfsd"
+        name: "{{ cluster_subdomain.resources[0].spec.domain | regex_search('[^.]*') }}"
         namespace: openshift-ingress
       register: cluster_ingress_secret
 
@@ -106,9 +106,9 @@
             found_cluster_ingress_secret: true
             cluster_ingress_tls_crt: "{{ cluster_ingress_default_secret.resources[0].data['tls.crt'] | b64decode }}"
 
-        - debug:
-            msg:
-              - "Cluster Ingress Cert Secret Name ...... {{ cluster_ingress_secret_name if (cluster_ingress_secret_name is defined) else '3rd attempt missed' }}"
+    - debug:
+        msg:
+          - "Cluster Ingress Cert Secret Name ...... {{ cluster_ingress_secret_name if (cluster_ingress_secret_name is defined) else '3rd attempt missed' }}"
 
 # 4. Lookup for secret based on the cluster name
 # -----------------------------------------------------------------------------
@@ -192,7 +192,6 @@
 # -----------------------------------------------------------------------------
 # If at least one of the secrets exist, then all good.  If none of the
 # secrets are found, then fail with a message
-
 - name: "Debug cluster certificate secret search"
   debug:
     msg:
@@ -201,13 +200,3 @@
       - "Found Cluster Primary Secret .......... {{ found_cluster_primary_secret | default(False, True) }}"
       - "Cluster Ingress Cert Secret Name ...... {{ cluster_ingress_secret_name | default('missing', True) }}"
       - "Cluster Ingress Cert .................. {{ cluster_ingress_tls_crt | default('missing', True) }}"
-
-# COS and UDS roles both require one of these secrets ... can we fix it so that
-# they don't, not sure why they can't create their own certs and need to
-# piggyback off the cluster cert tbh.
-- name: Fail if one of the cluster required secrets does not exist
-  assert:
-    that:
-      - cluster_ingress_secret_name is defined
-      - cluster_ingress_tls_crt is defined
-    fail_msg: "This cluster does not contain any of the secrets known to contain the TLS certificate for the cluster ingress."


### PR DESCRIPTION
Added a 4th option to lookup for the default cluster's ingress secret based on the Cluster Ingress Controller configuration.
This has been useful to address a [customer case](https://ibmsf.lightning.force.com/lightning/r/Case/5003p00002rIG8aAAG/view) that was having issues with a self managed AWS cluster in `ocp_verify` where the ingress certificate was not being found, but the IngressController configuration contained the default ingress certificate secret information.

Also improved the debugging for troubleshooting purposes. If none of the 4th attempts finds the TLS secret, we will assert that before erroring with a `cluster_ingress_tls_crt undefined`

```
TASK [ibm.mas_devops.ocp_verify : Record that we have found the router-certs-default cert secret] **********************************************************************************************************************************************************************************************
skipping: [localhost]

TASK [ibm.mas_devops.ocp_verify : debug] *******************************************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": [
        "Cluster Ingress Cert Secret Name ...... 1st attempt missed"
    ]
}

TASK [ibm.mas_devops.ocp_verify : Get cluster subdomain] ***************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [ibm.mas_devops.ocp_verify : 2nd attempt : Lookup for cluster ingress secret based on Ingress cluster] ************************************************************************************************************************************************************************************
ok: [localhost]

TASK [ibm.mas_devops.ocp_verify : Record that we have found the cluster ingress cert secret] ***************************************************************************************************************************************************************************************************
skipping: [localhost]

TASK [ibm.mas_devops.ocp_verify : debug] *******************************************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": [
        "Cluster Ingress Cert Secret Name ...... 2nd attempt missed"
    ]
}

TASK [ibm.mas_devops.ocp_verify : 3rd attempt : Lookup for cluster ingress secret based on IngressController default] **************************************************************************************************************************************************************************
ok: [localhost]

TASK [ibm.mas_devops.ocp_verify : Set default secret name containing cluster's ingress certificate based on IngressController default] *********************************************************************************************************************************************************
skipping: [localhost]

TASK [ibm.mas_devops.ocp_verify : Lookup default secret name containing cluster's ingress certificate based on IngressController default] ******************************************************************************************************************************************************
skipping: [localhost]

TASK [ibm.mas_devops.ocp_verify : Record that we have found the default cluster ingress cert secret] *******************************************************************************************************************************************************************************************
skipping: [localhost]

TASK [ibm.mas_devops.ocp_verify : debug] *******************************************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": [
        "Cluster Ingress Cert Secret Name ...... 3rd attempt missed"
    ]
}

TASK [ibm.mas_devops.ocp_verify : Get all TLS secrets] *****************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [ibm.mas_devops.ocp_verify : 4th attempt : Lookup for cluster ingress secret based on ROSA, TechZone, and some IPI Installs name convention] **********************************************************************************************************************************************
skipping: [localhost] => (item=pfvtcpdupg-6f1620198115433da1cac8216c06779b-0000) 
skipping: [localhost] => (item=router-metrics-certs-default) 
skipping: [localhost]

TASK [ibm.mas_devops.ocp_verify : debug] *******************************************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": [
        "Cluster Ingress Cert Secret Name ...... 4th attempt missed"
    ]
}

TASK [ibm.mas_devops.ocp_verify : Assert one way or another cluster ingress secret has been found] *********************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {
    "assertion": "cluster_ingress_secret_name is defined",
    "changed": false,
    "evaluated_to": false,
    "msg": "Cluster ingress secret was not automatically found, please 'export OCP_INGRESS_TLS_SECRET_NAME' to point to the secret name in 'openshift-ingress' namespace that contains cluster ingress TLS certificates."
}
```