### PR TITLE
[patch] Fix syntax error in DRO install

### DIFF
--- a/ibm/mas_devops/roles/dro/tasks/main.yml
+++ b/ibm/mas_devops/roles/dro/tasks/main.yml
@@ -34,7 +34,7 @@
 - name: gencfg for new installation
   include_tasks: tasks/gencfg/main.yml
   when:
-    - dro_action not in [uninstall, install]
+    - dro_action not in ["uninstall", "install"]
     - mas_config_dir is defined and mas_config_dir != ""
 
 # Uninstall UDS when DRO_MIGRATION flag is set to True


### PR DESCRIPTION
Fix for this problem introduced in #1203:

```
TASK [ibm.mas_devops.dro : UDS to DRO migration (mas update scenario)] *********
skipping: [localhost] => changed=false 
  false_condition: dro_migration != "" and dro_migration == "true"
  skip_reason: Conditional result was False

TASK [ibm.mas_devops.dro : gencfg for new installation] ************************
fatal: [localhost]: FAILED! => 
  msg: |-
    The conditional check 'dro_action not in [uninstall, install]' failed. The error was: error while evaluating conditional (dro_action not in [uninstall, install]): 'uninstall' is undefined. 'uninstall' is undefined
  
    The error appears to be in '/opt/app-root/lib64/python3.9/site-packages/ansible_collections/ibm/mas_devops/roles/dro/tasks/main.yml': line 34, column 3, but may
    be elsewhere in the file depending on the exact syntax problem.
  
    The offending line appears to be:
  
    # Generate the DRO configuration for MAS
    - name: gencfg for new installation
      ^ here
```