### PR TITLE
[patch] remove grafana dashboard uids

### DIFF
--- a/ibm/mas_devops/roles/kafka/templates/redhat/dashboards/kafka-exporter.yml.j2
+++ b/ibm/mas_devops/roles/kafka/templates/redhat/dashboards/kafka-exporter.yml.j2
@@ -1729,7 +1729,6 @@ spec:
         },
         "timezone": "browser",
         "title": "Kafka Exported JMX metrics",
-        "uid": "jwPKIsniz",
         "version": 1885
     }
     {% endraw %}

--- a/ibm/mas_devops/roles/kafka/templates/redhat/dashboards/kafka-zookeeper.yml.j2
+++ b/ibm/mas_devops/roles/kafka/templates/redhat/dashboards/kafka-zookeeper.yml.j2
@@ -1695,7 +1695,6 @@ spec:
         },
         "timezone": "",
         "title": "ZooKeeper metrics",
-        "uid": "fc85de600d62d9841e9de00083b24b72",
         "version": 1
     }
     {% endraw %}

--- a/ibm/mas_devops/roles/kafka/templates/redhat/dashboards/kafka.yml.j2
+++ b/ibm/mas_devops/roles/kafka/templates/redhat/dashboards/kafka.yml.j2
@@ -3106,7 +3106,6 @@ spec:
         },
         "timezone": "",
         "title": "Kafka metrics",
-        "uid": "86cc98e66c294b299b37102f0cc74ead",
         "version": 2
     }
     {% endraw %}

--- a/ibm/mas_devops/roles/kafka/templates/redhat/grafana-json/kafka-exporter.json
+++ b/ibm/mas_devops/roles/kafka/templates/redhat/grafana-json/kafka-exporter.json
@@ -1717,6 +1717,5 @@
     },
     "timezone": "browser",
     "title": "Kafka Exported JMX metrics",
-    "uid": "jwPKIsniz",
     "version": 1885
 }

--- a/ibm/mas_devops/roles/kafka/templates/redhat/grafana-json/kafka-zookeeper.json
+++ b/ibm/mas_devops/roles/kafka/templates/redhat/grafana-json/kafka-zookeeper.json
@@ -1683,6 +1683,5 @@
     },
     "timezone": "",
     "title": "ZooKeeper metrics",
-    "uid": "fc85de600d62d9841e9de00083b24b72",
     "version": 1
 }

--- a/ibm/mas_devops/roles/kafka/templates/redhat/grafana-json/kafka.json
+++ b/ibm/mas_devops/roles/kafka/templates/redhat/grafana-json/kafka.json
@@ -3094,6 +3094,5 @@
     },
     "timezone": "",
     "title": "Kafka metrics",
-    "uid": "86cc98e66c294b299b37102f0cc74ead",
     "version": 2
 }

--- a/ibm/mas_devops/roles/mongodb/templates/community/dashboards/json/mongodb-overview-grafana.json
+++ b/ibm/mas_devops/roles/mongodb/templates/community/dashboards/json/mongodb-overview-grafana.json
@@ -6529,6 +6529,5 @@
   "timepicker": {},
   "timezone": "",
   "title": "MongoDB Community",
-  "uid": "eS4BTSq4k",
   "version": 85
 }


### PR DESCRIPTION
## Description
Remove uid from grafana dashboard configuration json to support dashboards in mutliple namespaces

## Related Issues
epic https://jsw.ibm.com/browse/MASCORE-1721

## How Has This Been Tested?
This has been tested in `pfvtpds` personal FVT cluster.