### PR TITLE
[patch] Add openshift-cert-manager-operator to ISC

### DIFF
--- a/ibm/mas_devops/roles/mirror_ocp/README.md
+++ b/ibm/mas_devops/roles/mirror_ocp/README.md
@@ -11,25 +11,25 @@ Four actions are supported:
 Three **Catalogs** are mirrored, containing the following content:
 
 ### certified-operator-index
-- crunchy-postgres-operator (required by ibm.mas_devops.uds role)
-- gpu-operator-certified (required by ibm.mas_devops.nvidia_gpu role)
-- kubeturbo-certified (required by ibm.mas_devops.kubeturbo role)
-- ibm-metrics-operator (required by ibm.mas_devops.dro role)
-- ibm-data-reporter-operator (required by ibm.mas_devops.dro role)
+1. crunchy-postgres-operator (required by ibm.mas_devops.uds role)
+2. gpu-operator-certified (required by ibm.mas_devops.nvidia_gpu role)
+3. kubeturbo-certified (required by ibm.mas_devops.kubeturbo role)
+4. ibm-metrics-operator (required by ibm.mas_devops.dro role)
+5. ibm-data-reporter-operator (required by ibm.mas_devops.dro role)
 
 ### community-operator-index
-- grafana-operator (required by ibm.mas_devops.cluster_monitoring role)
-- opentelemetry-operator (required by ibm.mas_devops.cluster_monitoring role)
-- strimzi-kafka-operator (required by ibm.mas_devops.kafka role)
+1. grafana-operator (required by ibm.mas_devops.cluster_monitoring role)
+2. opentelemetry-operator (required by ibm.mas_devops.cluster_monitoring role)
+3. strimzi-kafka-operator (required by ibm.mas_devops.kafka role)
 
 ### redhat-operator-index
-- amq-streams (required by ibm.mas_devops.kafka role)
-- openshift-pipelines-operator-rh (required by the MAS CLI)
-- nfd (required by ibm.mas_devops.nvidia_gpu role)
-- aws-efs-csi-driver-operator (required by ibm.mas_devops.ocp_efs role)
-- local-storage-operator (required by ibm.mas_devops.ocs role)
-- odf-operator (required by ibm.mas_devops.ocs role)
-
+1. amq-streams (required by ibm.mas_devops.kafka role)
+2. openshift-pipelines-operator-rh (required by the MAS CLI)
+3. nfd (required by ibm.mas_devops.nvidia_gpu role)
+4. aws-efs-csi-driver-operator (required by ibm.mas_devops.ocp_efs role)
+5. local-storage-operator (required by ibm.mas_devops.ocs role)
+6. odf-operator (required by ibm.mas_devops.ocs role)
+7. openshift-cert-manager-operator (required by ibm.mas_devops.cert_manager role)
 
 Requirements
 -------------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -48,9 +48,6 @@ mirror:
         - name: grafana-operator  #  Required by ibm.mas_devops.cluster_monitoring role
           channels:
             - name: v4
-            # We don't use the v5 channel, but oc-mirror fails when the default channel is not included
-            # - https://access.redhat.com/solutions/7013461
-            # - https://issues.redhat.com/browse/OCPBUGS-385
             - name: v5
         - name: opentelemetry-operator  # Required by ibm.mas_devops.cluster_monitoring role
           channels:
@@ -80,4 +77,7 @@ mirror:
         - name: odf-operator  # Required by ibm.mas_devops.ocs role
           channels:
             - name: stable-{{ ocp_release }}
+        - name: openshift-cert-manager-operator  # Required by ibm.mas_devops.cert_manager role
+          channels:
+            - name: stable-v1
 {% endif %}


### PR DESCRIPTION
Attempting to install MAS in a disconnected environment when using the offline Red Hat catalogs generated by the `mirror_ocp` role will fail due to a missing package: `openshift-cert-manager-operator`.

```
  status:
    conditions:
    - message: 'constraints not satisfiable: no operators found from catalog redhat-operators
        in namespace openshift-marketplace referenced by subscription openshift-cert-manager-operator,
        subscription openshift-cert-manager-operator exists'
      reason: ConstraintsNotSatisfiable
      status: "True"
      type: ResolutionFailed
    - lastTransitionTime: "2024-02-18T11:24:53Z"
      message: targeted catalogsource openshift-marketplace/redhat-operators missing
      reason: UnhealthyCatalogSourceFound
      status: "True"
      type: CatalogSourcesUnhealthy
    lastUpdated: "2024-02-18T11:24:53Z"
```

This update adds the missing package to our `ImageSetConfiguration`.