### PR TITLE
[patch] Fix IBM Cloud cert chain assertion

### DIFF
--- a/ibm/mas_devops/roles/configure_manage_eventstreams/tasks/retrieve-es-certs.yml
+++ b/ibm/mas_devops/roles/configure_manage_eventstreams/tasks/retrieve-es-certs.yml
@@ -13,4 +13,4 @@
 
 - name: "Assert IBM es certificate content exists"
   assert:
-    that: "{{ es_tls_crt | length == 3 }}"
+    that: "{{ es_tls_crt | length > 1  }}" # must contain at least leaf and intermediate cert

--- a/ibm/mas_devops/roles/kafka/tasks/provider/ibm/retrieve-eventstreams-certs.yml
+++ b/ibm/mas_devops/roles/kafka/tasks/provider/ibm/retrieve-eventstreams-certs.yml
@@ -16,4 +16,4 @@
 
 - name: "Assert IBM Event Streams certificate content exists"
   assert:
-    that: "{{ es_tls_crt | length == 3 }}"
+    that: "{{ es_tls_crt | length > 1 }}" # must contain at least leaf and intermediate cert

--- a/ibm/mas_devops/roles/suite_manage_customer_files_config/tasks/retrieve-cos-certs.yml
+++ b/ibm/mas_devops/roles/suite_manage_customer_files_config/tasks/retrieve-cos-certs.yml
@@ -16,7 +16,7 @@
 - name: "Assert IBM COS certificate content exists - if applicable"
   when: cos_type == 'ibm'
   assert:
-    that: "{{ cos_tls_crt | length == 3 }}"
+    that: "{{ cos_tls_crt | length > 1 }}" # must contain at least leaf and intermediate cert
 
 - name: "Assert AWS certificate content exists - if applicable"
   when: cos_type == 'aws'

--- a/ibm/mas_devops/roles/suite_manage_doclinks_config/tasks/retrieve-cos-certs.yml
+++ b/ibm/mas_devops/roles/suite_manage_doclinks_config/tasks/retrieve-cos-certs.yml
@@ -16,7 +16,7 @@
 - name: "Assert IBM COS certificate content exists - if applicable"
   when: mas_manage_doclinks_provider == 'ibm'
   assert:
-    that: "{{ cos_tls_crt | length == 3 }}"
+    that: "{{ cos_tls_crt | length > 1 }}" # must contain at least leaf and intermediate cert
 
 - name: "Assert AWS certificate content exists - if applicable"
   when: mas_manage_doclinks_provider == 'aws'

--- a/ibm/mas_devops/roles/suite_manage_logging_config/tasks/retrieve-cos-certs.yml
+++ b/ibm/mas_devops/roles/suite_manage_logging_config/tasks/retrieve-cos-certs.yml
@@ -16,7 +16,7 @@
 - name: "Assert IBM COS certificate content exists - if applicable"
   when: cos_type == 'ibm'
   assert:
-    that: "{{ cos_tls_crt | length == 3 }}"
+    that: "{{ cos_tls_crt | length > 1 }}" # must contain at least leaf and intermediate cert
 
 - name: "Assert AWS certificate content exists - if applicable"
   when: cos_type == 'aws'


### PR DESCRIPTION
Looks like IBM Cloud has finally removed the broken intermediate cert from Let's Encrypt chain... the assertion is failing because it always expected 3 pieces in the cert chain but now it only has 2