### PR TITLE
[patch] fix the grafana uninstall namespace code

### DIFF
--- a/ibm/mas_devops/roles/cluster_monitoring/tasks/uninstall/grafana-v4.yml
+++ b/ibm/mas_devops/roles/cluster_monitoring/tasks/uninstall/grafana-v4.yml
@@ -36,4 +36,6 @@
 - name: "uninstall : grafana : Delete Grafana namespace"
   kubernetes.core.k8s:
     state: absent
-    definition: "{{ lookup('template', 'templates/grafana/v4/grafana-namespace.yml.j2') }}"
+    api_version: v1
+    kind: Namespace
+    name: "{{ grafana_v4_namespace }}"

--- a/ibm/mas_devops/roles/cluster_monitoring/tasks/uninstall/grafana-v5.yml
+++ b/ibm/mas_devops/roles/cluster_monitoring/tasks/uninstall/grafana-v5.yml
@@ -36,4 +36,6 @@
 - name: "uninstall : grafana : Delete Grafana namespace"
   kubernetes.core.k8s:
     state: absent
-    definition: "{{ lookup('template', 'templates/grafana/v5/grafana-namespace.yml.j2') }}"
+    api_version: v1
+    kind: Namespace
+    name: "{{ grafana_v5_namespace }}"


### PR DESCRIPTION
Delete grafana namespace without using template file.

Tested by manually running cluster monitoring role to uninstall grafana v4 and v5 in fvtcore