### PR TITLE
[patch] add kubebuilder/kube-rbac-proxy extras image for Amlen v1.0.3

### DIFF
--- a/ibm/mas_devops/roles/mirror_extras_prepare/vars/amlen_1.0.3.yml
+++ b/ibm/mas_devops/roles/mirror_extras_prepare/vars/amlen_1.0.3.yml
@@ -9,3 +9,8 @@ extra_images:
     registry: quay.io
     digest: sha256:1c65cc6211019f35364552f4ed331cbec45425e4f21e737eda7dfc88d453057e
     tag: 1.0.3
+
+  - name: kubebuilder/kube-rbac-proxy
+    registry: gcr.io
+    digest: sha256:0df4ae70e3bd0feffcec8f5cdb428f4abe666b667af991269ec5cb0bbda65869
+    tag: 1.0.3


### PR DESCRIPTION
slack thread - https://ibm-watson-iot.slack.com/archives/C02PUHKQB5L/p1709027799764109

In Amlen v.1.0.3, we are using digest for this kube-rbac-proxy image. so it needs to be added to the extras image content.

![Screenshot 2024-02-27 at 11 00 49](https://github.com/ibm-mas/ansible-devops/assets/728940/563f4a4a-727c-425a-b210-444f4c399faf)
