### PR TITLE
[patch] Fix cert-manager default provider in readme

### DIFF
--- a/ibm/mas_devops/roles/cert_manager/README.md
+++ b/ibm/mas_devops/roles/cert_manager/README.md
@@ -32,7 +32,7 @@ Choose which flavour of Certificate Manager to install; IBM (`ibm`), or Red Hat 
 
 - Optional
 - Environment Variable: `CERT_MANAGER_PROVIDER`
-- Default: `ibm`
+- Default: `redhat`
 
 
 Example Playbook


### PR DESCRIPTION
Fix for https://github.com/ibm-mas/ansible-devops/issues/1235