### PR TITLE
[patch] Bump strimzi v0.40 supported kafka versions up to 3.7.0

### DIFF
--- a/ibm/mas_devops/roles/kafka/defaults/main.yaml
+++ b/ibm/mas_devops/roles/kafka/defaults/main.yaml
@@ -6,7 +6,7 @@ kafka_action: "{{ lookup('env', 'KAFKA_ACTION') | default('install', true) }}"
 amq_exists: false # initialize variable
 kafka_defaults:
   strimzi:
-    version: "3.5.1" # Supported versions are: [3.4.0, 3.4.1, 3.5.0, 3.5.1]
+    version: "3.7.0" # Supported versions for strimzi-cluster-operator.v0.40.0 are: [3.6.0, 3.6.1, 3.7.0]
     namespace: "strimzi"
     operator_name: "strimzi-kafka-operator"
     alias_name: "Strimzi"


### PR DESCRIPTION
Looks like `community-operators` catalog is now installing strimzi-cluster-operator.v0.40.0 (released [yesterday](https://github.com/strimzi/strimzi-kafka-operator/commit/223552bff5143bd69448500f87096555e37175bf)) with `stable channel` which only supports [3.6.0, 3.6.1, 3.7.0] versions whereas our current default version is `3.5.1` so kafka task will fail with 'Unsupported Kafka.spec.kafka.version: 3.5.1. Supported versions are: [3.6.0, 3.6.1, 3.7.0]' ... 

