### PR TITLE
[patch] create mongodb troubleshooting section

### DIFF
--- a/ibm/mas_devops/roles/mongodb/README.md
+++ b/ibm/mas_devops/roles/mongodb/README.md
@@ -164,11 +164,22 @@ Example Playbook
     - ibm.mas_devops.mongodb
 ```
 
+Troubleshooting
+-------------------------------------------------------------------------------
+
+!!! important
+    Please be cautious while performing any of the troubleshooting steps outlined below. It is important to understand that the MongoDB Community operator persists data within Persistent Volume Claims. These claims should not be removed inadvertent deletion of the `mongoce` namespace could result in data loss.
+
+### MongoDB Replica Set Pods Will Not Start
+
+MongoDB 5 has introduced new platform specific requirements. Please consult the [Platform Support Notes](https://www.mongodb.com/docs/manual/administration/production-notes/#x86_64) for detailed information. 
+
+
+### CA Certificate Renewal
+
 !!! warning
     If the MongoDB CA Certificate expires the MongoDB replica set will become unusable. Replica set members will not be able to communicate with each other and client applications (i.e. Maximo Application Suite components) will not be to connect.
 
-CA Certificate Renewal
--------------------------------------------------------------------------------
 
 In order to renew the CA Certificate used by the MongoDB replica set the following steps must be taken:
 
@@ -184,15 +195,24 @@ The following steps illustrate the process required to renew the CA Certificate,
 The first step is to stop the Mongo replica set and MongoDb CE Operator pod.
 
 ```bash
-#!/bin/bash
-
 oc project mongoce
-
 oc delete deployment mongodb-kubernetes-operator
-oc delete statefulset mas-mongo-ce
 ```
-Make sure all pods in the `mongoce` namespace have terminated and then execute the following to remove
-the old Mongo configuration:
+
+!!! important
+    Make sure the MongoDB Community operator pod has terminated before proceeding.
+
+
+```bash
+oc delete statefulset mas-mongo-ce
+
+```
+
+!!! important
+    Make sure all pods in the `mongoce` namespace have terminated before proceeding
+
+
+Remove expired CA Certificate and Server Certificate resources. Clean up MongoDB Community configuration and then run the `mongodb` role.
 
 ```bash
 oc delete certificate mongo-ca-crt

--- a/ibm/mas_devops/roles/mongodb/README.md
+++ b/ibm/mas_devops/roles/mongodb/README.md
@@ -174,6 +174,13 @@ Troubleshooting
 
 MongoDB 5 has introduced new platform specific requirements. Please consult the [Platform Support Notes](https://www.mongodb.com/docs/manual/administration/production-notes/#x86_64) for detailed information. 
 
+It is of particular importance to confirm that the AVX instruction set is exposed or available to the MongoDB workloads. This can easily be determined by entering any running pod on the same OpenShift cluster where MongoDB replica set members are failing to start. Once inside of a running pod the following command can be executed to confirm if the AVX instruction set is available:
+
+```bash
+cat /proc/cpuinfo | grep flags | grep avx
+```
+
+If `avx` is not found in the available `flags` then either the physical processor hosting the OpenShift cluster does not provide the AVX instruction set or the virtual host configuration is not exposing the AVX instruction set. If the latter is suspected the virtual hosting documentation should be referenced for details on how to expose the AVX instruction set.  
 
 ### CA Certificate Renewal
 


### PR DESCRIPTION
# create mongodb troubleshooting section

- Refactor current information about MongoDB Community operator CA renewal into a specific MongoDB troubleshooting section. 
- Add specific information related to MongoDB v5 and above related to platform requirements
- Specifically point out that MongoDB 5+ requires the AVX instruction set