### PR TITLE
[patch] fix gencfg_mongo template

### DIFF
--- a/ibm/mas_devops/roles/gencfg_mongo/templates/suite_mongocfg.yml.j2
+++ b/ibm/mas_devops/roles/gencfg_mongo/templates/suite_mongocfg.yml.j2
@@ -42,6 +42,6 @@ spec:
     hosts:
       {{ mongodb_hosts | indent(6) }}
 {%- if mongo_certs is defined and mongo_certs | length > 0 %}
-    certificates:
-      {{ mongo_certs | indent(width=6, first=False) }}
+  certificates:
+    {{ mongo_certs | indent(width=4, first=False) }}
 {%- endif %}


### PR DESCRIPTION
Fix description
----
Currently, the generated mongocfg file by gencfg_mongo file is not valid for sls role. 

With current mongocfg file, validation will fail at task sls Task **_Override MongoDb facts bases on mongocfg_**. The reason is that on sls template **`templates/mongo-certificates.yml.j2`** it will look for the certificates in mongocfg[1].spec.certificates. Currently, gencfg_mongo sets the certificates as follows: mongocfg[1].spec.config.certificates. 

This small tweak on gencfg_mongo`templates/suite_mongocfg.yml.j2` will take care of setting mongocfg yaml the way sls role expects it to. 


Validated MongoCfg after modification:
```
...
spec:
  displayName: "External MongoDB in 'mas-cpst3-core' namespace"
  type: external
  config:
    configDb: admin
    retryWrites: true
    authMechanism: DEFAULT
    credentials:
      secretName: mongodb-cpst3-admin
    hosts:
      - host: mas-mongo-ce-0.mas-mongo-ce-svc.mongoce.svc.cluster.local
        port: 27017
      - host: mas-mongo-ce-1.mas-mongo-ce-svc.mongoce.svc.cluster.local
        port: 27017
      - host: mas-mongo-ce-2.mas-mongo-ce-svc.mongoce.svc.cluster.local
        port: 27017
  certificates:
    - alias: "part1"
      crt: |
        -----BEGIN CERTIFICATE-----
        MIIBwDCCAWagAwIBAgIRAO1iISQhNG5Yzf9IQGwzv7wwCgYIKoZIzj0EAwIwFzEV
        MBMGA1UEAxMMbW9uZ28tY2EtY3J0MB4XDTI0MDEyNzAyMDgyMFoXDTQ0MDEyMjAy
        MDgyMFowFzEVMBMGA1UEAxMMbW9uZ28tY2EtY3J0MFkwEwYHKoZIzj0CAQYIKoZI
        zj0DAQcDQgAE/ly2ZUq/ElJdGxaoAAy85SX4K0pfA0oe00jGmgB/TfklADa4OSTh
        EOgyprMs8rLRd++AwDBfS+OtX6TJrqr/faOBkjCBjzAOBgNVHQ8BAf8EBAMCAqQw
        DwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUu4efi0DwQNWyVFI4HQ5Piz9kWQUw
        TQYDVR0RBEYwRIIsKi5tYXMtbW9uZ28tY2Utc3ZjLm1vbmdvY2Uuc3ZjLmNsdXN0
        ZXIubG9jYWyCCTEyNy4wLjAuMYIJbG9jYWxob3N0MAoGCCqGSM49BAMCA0gAMEUC
        IHeUUBIgm1s+W3M0nLz8pZGVaxgPsbhXPIqOWMwiHvpKAiEA7DDuPlmZFDgvFGjD
        vKj8xqgmouuLQPqo903oHvwvSYw=
        -----END CERTIFICATE-----

```