### PR TITLE
[patch] Add retries and debugging statements for Kafka server certificates pulling

### DIFF
--- a/ibm/mas_devops/roles/kafka/tasks/provider/ibm/retrieve-eventstreams-certs.yml
+++ b/ibm/mas_devops/roles/kafka/tasks/provider/ibm/retrieve-eventstreams-certs.yml
@@ -14,8 +14,9 @@
   #elay: 10 
   #until: get_certs_r.rc == 0
 - debug:
-    msg: "{{ get_certs_r.rc }}"
-    msg: "{{ get_certs_r.stdout }}"
+    msg: 
+      - "{{ get_certs_r.rc }}"
+      - "{{ get_certs_r.stdout }}"
 
 - name: "Extract IBM Event Streams certificate content"
   set_fact:

--- a/ibm/mas_devops/roles/kafka/tasks/provider/ibm/retrieve-eventstreams-certs.yml
+++ b/ibm/mas_devops/roles/kafka/tasks/provider/ibm/retrieve-eventstreams-certs.yml
@@ -9,7 +9,7 @@
     cmd: "openssl s_client -servername {{ es_host_name }} -connect {{ es_host_name }}:{{ es_port }} -showcerts </dev/null  2>/dev/null"
   register: get_certs_r
   #ignore_errors: true
-  failed_when: get_certs_r.rc > 0
+  failed_when: get_certs_r.rc != 0
   retries: 5
   delay: 10
   until: get_certs_r.rc == 0

--- a/ibm/mas_devops/roles/kafka/tasks/provider/ibm/retrieve-eventstreams-certs.yml
+++ b/ibm/mas_devops/roles/kafka/tasks/provider/ibm/retrieve-eventstreams-certs.yml
@@ -11,10 +11,10 @@
   #ignore_errors: true
   #failed_when: "get_certs_r.rc > 1"
   #retries: 5
-  #elay: 10 
+  #elay: 10
   #until: get_certs_r.rc == 0
 - debug:
-    msg: 
+    msg:
       - "{{ get_certs_r.rc }}"
       - "{{ get_certs_r.stdout }}"
 

--- a/ibm/mas_devops/roles/kafka/tasks/provider/ibm/retrieve-eventstreams-certs.yml
+++ b/ibm/mas_devops/roles/kafka/tasks/provider/ibm/retrieve-eventstreams-certs.yml
@@ -9,13 +9,12 @@
     cmd: "openssl s_client -servername {{ es_host_name }} -connect {{ es_host_name }}:{{ es_port }} -showcerts </dev/null  2>/dev/null"
   register: get_certs_r
   #ignore_errors: true
-  #failed_when: "get_certs_r.rc > 1"
-  #retries: 5
-  #elay: 10
-  #until: get_certs_r.rc == 0
+  failed_when: get_certs_r.rc > 0
+  retries: 5
+  delay: 10
+  until: get_certs_r.rc == 0
 - debug:
     msg:
-      - "{{ get_certs_r.rc }}"
       - "{{ get_certs_r.stdout }}"
 
 - name: "Extract IBM Event Streams certificate content"

--- a/ibm/mas_devops/roles/kafka/tasks/provider/ibm/retrieve-eventstreams-certs.yml
+++ b/ibm/mas_devops/roles/kafka/tasks/provider/ibm/retrieve-eventstreams-certs.yml
@@ -15,7 +15,7 @@
   until: get_certs_r.rc == 0
 - debug:
     msg:
-      - "{{ get_certs_r.stdout }}"
+      - "Openssl command output .................... {{ get_certs_r.stdout }}"
 
 - name: "Extract IBM Event Streams certificate content"
   set_fact:

--- a/ibm/mas_devops/roles/kafka/tasks/provider/ibm/retrieve-eventstreams-certs.yml
+++ b/ibm/mas_devops/roles/kafka/tasks/provider/ibm/retrieve-eventstreams-certs.yml
@@ -8,7 +8,14 @@
   shell:
     cmd: "openssl s_client -servername {{ es_host_name }} -connect {{ es_host_name }}:{{ es_port }} -showcerts </dev/null  2>/dev/null"
   register: get_certs_r
-  ignore_errors: true
+  #ignore_errors: true
+  #failed_when: "get_certs_r.rc > 1"
+  #retries: 5
+  #elay: 10 
+  #until: get_certs_r.rc == 0
+- debug:
+    msg: "{{ get_certs_r.rc }}"
+    msg: "{{ get_certs_r.stdout }}"
 
 - name: "Extract IBM Event Streams certificate content"
   set_fact:


### PR DESCRIPTION
We're dealing with an inconsistent failure in Kafka where the logs aren't helping, so we're adding more retries to the openssl command and increasing verbosity.

https://jsw.ibm.com/browse/MASCORE-2143

Added logs:

![image](https://github.com/ibm-mas/ansible-devops/assets/107580002/226bcf84-6644-4b69-a09d-f065945345b7)

