### PR TITLE
[major] Delete all CertManager CRDs with cert-manager uninstall

### DIFF
--- a/ibm/mas_devops/roles/cert_manager/README.md
+++ b/ibm/mas_devops/roles/cert_manager/README.md
@@ -34,6 +34,7 @@ Choose which flavour of Certificate Manager to install; IBM (`ibm`), or Red Hat 
 - Environment Variable: `CERT_MANAGER_PROVIDER`
 - Default: `redhat`
 
+**Note:** Certificate Manager is a cluster-wide dependency, therefore be really careful when uninstalling it as this might be used by several applications and dependencies installed in the cluster.
 
 Example Playbook
 -------------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/cert_manager/tasks/provider/redhat/uninstall.yml
+++ b/ibm/mas_devops/roles/cert_manager/tasks/provider/redhat/uninstall.yml
@@ -19,3 +19,17 @@
     name: "{{ cert_manager_namespace }}"
     wait: yes
     wait_timeout: 600
+
+# Delete Certificate CRDs
+# -------------------------------------------------------------------------------------
+- name: "uninstall : Delete Red Hat Certificate Manager CRDs"
+  kubernetes.core.k8s:
+    state: absent
+    api_version: "apiextensions.k8s.io/v1"
+    kind: "CustomResourceDefinition"
+    name: "{{ item }}.cert-manager.io"
+  loop:
+    - certificates
+    - certificaterequests
+    - clusterissuers
+    - issuers


### PR DESCRIPTION
This PR addresses problems found in https://github.com/ibm-mas/cli/issues/868

It is all about including Certificate Manager CRD to be deleted in `cert_manager role` during `uninstall` action. Without that, during common services reinstall, ibm common services operator will lookup Certificate CRD and will find it and think certmanager is installed and call cert manager webhook pod (which is not present because it was deleted during certmanager uninstall) and then fail to proceed with ibm-common-services reinstall...

Tests done:

<img width="1025" alt="image" src="https://github.com/ibm-mas/ansible-devops/assets/31037381/c3df5bfa-29d3-4717-b431-3ce7d34fcbcb">


CertManager CRDs before uninstall:

<img width="631" alt="image" src="https://github.com/ibm-mas/ansible-devops/assets/31037381/f15ebc0e-90ef-41f6-831a-c3bdaedb1cf7">


All Certmanager CRDs are  gone:

<img width="642" alt="image" src="https://github.com/ibm-mas/ansible-devops/assets/31037381/4ace0d4c-115f-4535-8330-08177204cf2d">


Then, re-running `mas install` command after a `mas uninstall` allows reinstalling ibm common services and cert-manager just fine:

<img width="866" alt="image" src="https://github.com/ibm-mas/ansible-devops/assets/31037381/5106f47f-ab46-46b1-b9f2-794b71a11286">
