### PR TITLE
[patch] Formating pre-versions to be comparable with reconciled versions in Operators

### DIFF
--- a/ibm/mas_devops/plugins/filter/filters.py
+++ b/ibm/mas_devops/plugins/filter/filters.py
@@ -369,6 +369,15 @@ def _setSystemProperties(data, meaweb_value, oslc_rest_value, webapp_value, rest
     sb_list.append(sb)
   return sb_list
 
+def format_pre_version_with_plus(data):
+  """
+  Versions in format 9.0.0-pre.stable-3757 cannot be used to compare with the version
+  reconciled by operators, which is in format 9.0.0-pre.stable+3757. This function is to
+  format version to make it comparable (replacing last "-" by "+")
+  """
+  if "pre" not in data or data.count("-") < 2:
+    return data
+  return data[::-1].replace("-", "+", 1)[::-1]
 
 class FilterModule(object):
   def filters(self):
@@ -388,4 +397,5 @@ class FilterModule(object):
       'setManageDoclinksProperties': setManageDoclinksProperties,
       'setManageFsDoclinksProperties': setManageFsDoclinksProperties,
       'setSystemProperties': _setSystemProperties,
+      'format_pre_version_with_plus': format_pre_version_with_plus
     }

--- a/ibm/mas_devops/plugins/filter/filters.py
+++ b/ibm/mas_devops/plugins/filter/filters.py
@@ -372,12 +372,22 @@ def _setSystemProperties(data, meaweb_value, oslc_rest_value, webapp_value, rest
 def format_pre_version_with_plus(data):
   """
   Versions in format 9.0.0-pre.stable-3757 cannot be used to compare with the version
-  reconciled by operators, which is in format 9.0.0-pre.stable+3757. This function is to
+  reconciled by suite operator, which is in format 9.0.0-pre.stable+3757. This function is to
   format version to make it comparable (replacing last "-" by "+")
   """
   if "pre" not in data or data.count("-") < 2:
     return data
   return data[::-1].replace("-", "+", 1)[::-1]
+
+def format_pre_version_without_buildid(data):
+  """
+  Versions in format 9.0.0-pre.stable-3757 cannot be used to compare with the version
+  reconciled by application operators, which is in format 9.0.0-pre.stable+3757. This function is to
+  format version to make it comparable (removing build id part at the end)
+  """
+  if "pre" not in data or data.count("-") < 2:
+    return data
+  return data[:data.rfind("-")]
 
 class FilterModule(object):
   def filters(self):
@@ -397,5 +407,6 @@ class FilterModule(object):
       'setManageDoclinksProperties': setManageDoclinksProperties,
       'setManageFsDoclinksProperties': setManageFsDoclinksProperties,
       'setSystemProperties': _setSystemProperties,
-      'format_pre_version_with_plus': format_pre_version_with_plus
+      'format_pre_version_with_plus': format_pre_version_with_plus,
+      'format_pre_version_without_buildid': format_pre_version_without_buildid
     }

--- a/ibm/mas_devops/roles/suite_app_upgrade/tasks/upgrade.yml
+++ b/ibm/mas_devops/roles/suite_app_upgrade/tasks/upgrade.yml
@@ -60,7 +60,7 @@
 # We want to strip off the "v" prefix from the version while we do this
 - name: "upgrade : Lookup operator version for ibm-mas"
   set_fact:
-    updated_opcon_version: "{{ updated_opcon.resources[0].metadata.name.split('.v')[1] | ibm.mas_devops.format_pre_version_with_plus }}"
+    updated_opcon_version: "{{ updated_opcon.resources[0].metadata.name.split('.v')[1] | ibm.mas_devops.format_pre_version_without_buildid }}"
 
 - name: "upgrade : Debug Operator Version"
   debug:

--- a/ibm/mas_devops/roles/suite_app_upgrade/tasks/upgrade.yml
+++ b/ibm/mas_devops/roles/suite_app_upgrade/tasks/upgrade.yml
@@ -60,7 +60,7 @@
 # We want to strip off the "v" prefix from the version while we do this
 - name: "upgrade : Lookup operator version for ibm-mas"
   set_fact:
-    updated_opcon_version: "{{ updated_opcon.resources[0].metadata.name.split('.v')[1] | ibm.mas_devops.parse_preversion_using_plus }}"
+    updated_opcon_version: "{{ updated_opcon.resources[0].metadata.name.split('.v')[1] | ibm.mas_devops.format_pre_version_with_plus }}"
 
 - name: "upgrade : Debug Operator Version"
   debug:

--- a/ibm/mas_devops/roles/suite_app_upgrade/tasks/upgrade.yml
+++ b/ibm/mas_devops/roles/suite_app_upgrade/tasks/upgrade.yml
@@ -60,7 +60,7 @@
 # We want to strip off the "v" prefix from the version while we do this
 - name: "upgrade : Lookup operator version for ibm-mas"
   set_fact:
-    updated_opcon_version: "{{ updated_opcon.resources[0].metadata.name.split('.v')[1] }}"
+    updated_opcon_version: "{{ updated_opcon.resources[0].metadata.name.split('.v')[1] | ibm.mas_devops.parse_preversion_using_plus }}"
 
 - name: "upgrade : Debug Operator Version"
   debug:

--- a/ibm/mas_devops/roles/suite_upgrade/tasks/upgrade.yml
+++ b/ibm/mas_devops/roles/suite_upgrade/tasks/upgrade.yml
@@ -61,7 +61,7 @@
 # We want to strip off the "v" prefix from the version while we do this
 - name: "upgrade : Lookup operator version for ibm-mas"
   set_fact:
-    updated_opcon_version: "{{ updated_opcon.resources[0].metadata.name.split('.v')[1] }}"
+    updated_opcon_version: "{{ updated_opcon.resources[0].metadata.name.split('.v')[1] | ibm.mas_devops.format_pre_version_with_plus }}"
 
 - name: "upgrade : Debug Operator Version"
   debug:


### PR DESCRIPTION
Format functions used in upgrade roles (suite and apps) used to make "pre" versions comparable with the ones in CR