### PR TITLE
[patch] Fix ibm licensing packagemanifest lookup

### DIFF
--- a/ibm/mas_devops/roles/cp4d/tasks/prereqs/install-ibm-licensing.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/prereqs/install-ibm-licensing.yml
@@ -10,11 +10,10 @@
   k8s_info:
     api_version: packages.operators.coreos.com/v1
     kind: PackageManifest
-    name: ibm-licensing-operator-app
     namespace: "{{ cpd_ibm_licensing_catalog_source_namespace }}"
     label_selectors:
-      - "app.kubernetes.io/instance = ibm-licensing-operator"
-      - "catalog = {{ cpd_ibm_licensing_catalog_source_name }}"
+      - app.kubernetes.io/instance=ibm-licensing-operator
+      - catalog={{ cpd_ibm_licensing_catalog_source_name }}
   register: licensing_manifest_info
 
 # we'll get the latest channel available in packagemanifest


### PR DESCRIPTION
Fixes the ibm-licensing package manifest lookup as it's using `label_selectors` we don't need `name` in the `k8s_info` lookup. This can cause the `label_selectors` to be overruled.