### PR TITLE
[patch] During grafana update, get storage config from v4.

### DIFF
--- a/ibm/mas_devops/roles/cluster_monitoring/README.md
+++ b/ibm/mas_devops/roles/cluster_monitoring/README.md
@@ -150,6 +150,7 @@ Example Playbook
     prometheus_storage_class: "ibmc-block-gold"
     prometheus_alertmgr_storage_class: "ibmc-file-gold-gid"
     grafana_instance_storage_class: "ibmc-file-gold-gid"
+    grafana_instance_storage_class: "15Gi"
   roles:
     - ibm.mas_devops.cluster_monitoring
 ```
@@ -163,6 +164,7 @@ To Upgrade from Grafana Operator from V4 to V5
   roles:
     - ibm.mas_devops.cluster_monitoring
 ```
+note that the upgraded v5 grafana inherits the storage class and size from the v4 configuration unless hey are defined as environment variables.
 
 License
 -------------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/cluster_monitoring/README.md
+++ b/ibm/mas_devops/roles/cluster_monitoring/README.md
@@ -164,7 +164,9 @@ To Upgrade from Grafana Operator from V4 to V5
   roles:
     - ibm.mas_devops.cluster_monitoring
 ```
-note that the upgraded v5 grafana inherits the storage class and size from the v4 configuration unless hey are defined as environment variables.
+
+!!! note
+    note that the upgraded v5 grafana inherits the storage class and size from the v4 configuration unless they are defined as environment variables.
 
 License
 -------------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/cluster_monitoring/tasks/update_grafana/determine-storage-config.yml
+++ b/ibm/mas_devops/roles/cluster_monitoring/tasks/update_grafana/determine-storage-config.yml
@@ -12,7 +12,7 @@
   register: grafana_cr_result
 
 - name: "install : determine-storage-classes : Set the Grafana storage class and size"
-  when: grafana_cr_result.resources[0].spec.persistentVolumeClaim is defined 
+  when: grafana_cr_result.resources[0].spec.persistentVolumeClaim is defined
   set_fact:
     grafana_instance_storage_class: "{{ grafana_cr_result.resources[0].spec.persistentVolumeClaim.spec.storageClassName }}"
     grafana_instance_storage_size: "{{ grafana_cr_result.resources[0].spec.persistentVolumeClaim.spec.resources.requests.storage }}"
@@ -30,15 +30,15 @@
   register: grafana_cr_result
 
 - name: "install : determine-storage-classes : Set the Grafana storage class and size"
-  when: 
+  when:
     - grafana_instance_storage_class is not defined or grafana_instance_storage_class == ""
-    - grafana_cr_result.resources[0].spec.dataStorage is defined 
+    - grafana_cr_result.resources[0].spec.dataStorage is defined
   set_fact:
     grafana_instance_storage_class: "{{ grafana_cr_result.resources[0].spec.dataStorage.class }}"
     grafana_instance_storage_size: "{{ grafana_cr_result.resources[0].spec.dataStorage.size }}"
 
 
-# 3. Set Default Grafana Instance Storage Class if not already determined 
+# 3. Set Default Grafana Instance Storage Class if not already determined
 # -----------------------------------------------------------------------------
 - name: "install : determine-storage-classes : Load default storage class information"
   when: grafana_instance_storage_class is not defined or grafana_instance_storage_class == ""
@@ -57,7 +57,7 @@
     grafana_instance_storage_class: "{{ lookup_storageclasses | ibm.mas_devops.defaultStorageClass(default_storage_classes_rwo) }}"
 
 
-# 4. Fail if Grafana Storage Class has not been set 
+# 4. Fail if Grafana Storage Class has not been set
 # -----------------------------------------------------------------------------
 - name: "install : determine-storage-classes : Assert that Grafana Instance storage class has been defined"
   assert:

--- a/ibm/mas_devops/roles/cluster_monitoring/tasks/update_grafana/determine-storage-config.yml
+++ b/ibm/mas_devops/roles/cluster_monitoring/tasks/update_grafana/determine-storage-config.yml
@@ -1,0 +1,74 @@
+---
+# Provide intelligent storage class selection to minimize required user knowledge
+
+# 1. Set Grafana Instance Storage Class and Size from existing V5 Operator
+# -----------------------------------------------------------------------------
+- name: "update_grafana : determine-storage-classes : Get V5 Grafana Instance"
+  kubernetes.core.k8s_info:
+    api_version: grafana.integreatly.org/v1beta1
+    name: mas-grafana
+    namespace: "{{ grafana_v5_namespace }}"
+    kind: Grafana
+  register: grafana_cr_result
+
+- name: "install : determine-storage-classes : Set the Grafana storage class and size"
+  when: grafana_cr_result.resources[0].spec.persistentVolumeClaim is defined 
+  set_fact:
+    grafana_instance_storage_class: "{{ grafana_cr_result.resources[0].spec.persistentVolumeClaim.spec.storageClassName }}"
+    grafana_instance_storage_size: "{{ grafana_cr_result.resources[0].spec.persistentVolumeClaim.spec.resources.requests.storage }}"
+
+
+# 2. Set Grafana Instance Storage Class and Size from existing V4 Operator
+# -----------------------------------------------------------------------------
+- name: "update_grafana : determine-storage-classes : Get V4 Grafana Instance"
+  when: grafana_instance_storage_class is not defined or grafana_instance_storage_class == ""
+  kubernetes.core.k8s_info:
+    api_version: integreatly.org/v1alpha1
+    name: mas-grafana
+    namespace: "{{ grafana_v4_namespace }}"
+    kind: Grafana
+  register: grafana_cr_result
+
+- name: "install : determine-storage-classes : Set the Grafana storage class and size"
+  when: 
+    - grafana_instance_storage_class is not defined or grafana_instance_storage_class == ""
+    - grafana_cr_result.resources[0].spec.dataStorage is defined 
+  set_fact:
+    grafana_instance_storage_class: "{{ grafana_cr_result.resources[0].spec.dataStorage.class }}"
+    grafana_instance_storage_size: "{{ grafana_cr_result.resources[0].spec.dataStorage.size }}"
+
+
+# 3. Set Default Grafana Instance Storage Class if not already determined 
+# -----------------------------------------------------------------------------
+- name: "install : determine-storage-classes : Load default storage class information"
+  when: grafana_instance_storage_class is not defined or grafana_instance_storage_class == ""
+  include_vars: "{{ role_path }}/../../common_vars/default_storage_classes.yml"
+
+- name: Lookup storage classes
+  when: grafana_instance_storage_class is not defined or grafana_instance_storage_class == ""
+  kubernetes.core.k8s_info:
+    api_version: storage.k8s.io/v1
+    kind: StorageClass
+  register: lookup_storageclasses
+
+- name: "install : determine-storage-classes : Default Grafana Instance Storage if still not set"
+  when: grafana_instance_storage_class is not defined or grafana_instance_storage_class == ""
+  set_fact:
+    grafana_instance_storage_class: "{{ lookup_storageclasses | ibm.mas_devops.defaultStorageClass(default_storage_classes_rwo) }}"
+
+
+# 4. Fail if Grafana Storage Class has not been set 
+# -----------------------------------------------------------------------------
+- name: "install : determine-storage-classes : Assert that Grafana Instance storage class has been defined"
+  assert:
+    that: grafana_instance_storage_class is defined and grafana_instance_storage_class != ""
+    fail_msg: "grafana_instance_storage_class cannot be determined"
+
+
+# 5. Debug storage class configuration
+# -----------------------------------------------------------------------------
+- name: "install : determine-storage-classes : Debug grafana storage class configuration"
+  debug:
+    msg:
+      - "Storage class (grafana instance) ....... {{ grafana_instance_storage_class }}"
+      - "Storage size (grafana instance) ....... {{ grafana_instance_storage_size }}"

--- a/ibm/mas_devops/roles/cluster_monitoring/tasks/update_grafana/main.yml
+++ b/ibm/mas_devops/roles/cluster_monitoring/tasks/update_grafana/main.yml
@@ -1,8 +1,9 @@
 ---
-# 1. Load default storage classes (if not provided by the user)
-# -----------------------------------------------------------------------------
-- name: "update_grafana : Determine storage classes"
-  include_tasks: tasks/install/determine-storage-classes.yml
+# 1. Get storage classes, the same as used in Grafana v4 if they are not provided
+# -------------------------------------------------------------------------------
+- name: "update_grafana : Determine storage configuration"
+  include_tasks: tasks/update_grafana/determine-storage-config.yml
+  when: grafana_instance_storage_class is not defined or grafana_instance_storage_class == ""
 
 # 2. Install and configure Grafana v5
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/cluster_monitoring/templates/grafana/v5/grafana.yml.j2
+++ b/ibm/mas_devops/roles/cluster_monitoring/templates/grafana/v5/grafana.yml.j2
@@ -14,14 +14,24 @@ spec:
     log:
       level: warn
       mode: console
-  dataStorage:
-    accessModes:
-    - ReadWriteOnce
-    class: "{{ grafana_instance_storage_class }}"
-    size: "{{ grafana_instance_storage_size }}"
+  persistentVolumeClaim:
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: "{{ grafana_instance_storage_size }}"
+      storageClassName: "{{ grafana_instance_storage_class }}"
   deployment:
-    strategy:
-      type: Recreate
+    spec:
+      template:
+        spec:
+          volumes:
+            - name: grafana-data
+              persistentVolumeClaim:
+                claimName: mas-grafana-pvc
+      strategy:
+        type: Recreate
   # An empty route spec is enough to signal the creation of a default
   # route to the operator. This can also be used to override defaults
   # in the route spec.


### PR DESCRIPTION
Fixing Issue https://jsw.ibm.com/browse/MASCORE-2363

Modify the Grafana update to get the V5 storage class and size from the V4 config and reuse the same values.

This also fixes the Grafana V5 persistent storage configuration which was previously incorrectly set, resulting in grafana deployments with no persistent storage

Tested in personal FVT environment