### PR TITLE
[patch] update db2 role storage class doc for ref to db2 doc

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,1 +1,0 @@
-update the db2 role documenation to add a link to the db2 documentation for reference for the storage classes.

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,0 +1,1 @@
+update the db2 role documenation to add a link to the db2 documentation for reference for the storage classes.

--- a/ibm/mas_devops/roles/db2/README.md
+++ b/ibm/mas_devops/roles/db2/README.md
@@ -136,6 +136,8 @@ Determines if the role should rotate the LDAP password for current LDAP user con
 
 Role Variables - Storage
 -------------------------------------------------------------------------------
+We recommend reviewing the Db2 documentation about the certified storage options for Db2 on Red Hat OpenShift. Please ensure your storage class meets the specified deployment requirements for Db2. https://www.ibm.com/docs/en/db2/11.5?topic=storage-certified-options
+
 ### db2_meta_storage_class
 Storage class used for metadata. This must support ReadWriteMany
 

--- a/ibm/mas_devops/roles/db2/README.md
+++ b/ibm/mas_devops/roles/db2/README.md
@@ -136,7 +136,7 @@ Determines if the role should rotate the LDAP password for current LDAP user con
 
 Role Variables - Storage
 -------------------------------------------------------------------------------
-We recommend reviewing the Db2 documentation about the certified storage options for Db2 on Red Hat OpenShift. Please ensure your storage class meets the specified deployment requirements for Db2. https://www.ibm.com/docs/en/db2/11.5?topic=storage-certified-options
+We recommend reviewing the Db2 documentation about the certified storage options for Db2 on Red Hat OpenShift. Please ensure your storage class meets the specified deployment requirements for Db2. [https://www.ibm.com/docs/en/db2/11.5?topic=storage-certified-options](https://www.ibm.com/docs/en/db2/11.5?topic=storage-certified-options)
 
 ### db2_meta_storage_class
 Storage class used for metadata. This must support ReadWriteMany


### PR DESCRIPTION
update to the db2 role documentation to add a referene to the db2 doc for setup of the storage class.