### PR TITLE
[patch] Fix DB2 role to use common_tasks/create_subscription.yml

### DIFF
--- a/ibm/mas_devops/roles/db2/tasks/upgrade/run-db2-subscription-upgrade.yml
+++ b/ibm/mas_devops/roles/db2/tasks/upgrade/run-db2-subscription-upgrade.yml
@@ -20,24 +20,13 @@
     kind: OperatorGroup
   register: db2_og_info
 
-# - name: "Update db2 subscription to the new channel"
-#   kubernetes.core.k8s:
-#     api_version: operators.coreos.com/v1alpha1
-#     name: ibm-db2u-operator
-#     namespace: "{{ db2_operator_namespace }}"
-#     kind: Subscription
-#     definition:
-#       spec:
-#         channel: "{{ db2_channel }}"
-#     apply: true
-
 # Leverage that we're upgrading DB2 and check if need to migrate db2 operator from ibm-common-services namespace
-- name: "Update db2 subscription to the new channel in {{ db2_namespace }} namespace"
-  kubernetes.core.k8s:
-    template: templates/db2u_subscription.yml.j2
-    wait: yes
-    wait_timeout: 120
-    apply: true
+- name: "Update Db2 Universal Operator Subscription in {{ db2_namespace }} namespace"
+  include_tasks: "{{ role_path }}/../../common_tasks/create_subscription.yml"
+  vars:
+    subscription_namespace: "{{ db2_namespace }}"
+    package_name: db2u-operator
+    channel_name: "{{ db2_channel }}"
 
 - name: "Pause for a minute before checking subscription status..."
   pause:


### PR DESCRIPTION
Probably due a back merge, the code that uses `template/db2u_subscription.yml.j2` has been added back to the `db2` role... this change fixes the code back to use `common_tasks/create_subscription.yml` to install/update the db2 subscription. Here's the initial commit that [added it](https://github.com/ibm-mas/ansible-devops/commit/c2a2e2d96aa6e2e4d416752e1ea8ac3122db540e)

With the fix, we'll be updating the subscription channel using same common task that is used during the db2 provisioning: https://github.com/ibm-mas/ansible-devops/blob/master/ibm/mas_devops/roles/db2/tasks/install/main.yml#L160