### PR TITLE
CPD 4.8.0 casebundle definition

### DIFF
--- a/ibm/mas_devops/common_vars/casebundles/v8-XXXXXX-amd64 copy.yml
+++ b/ibm/mas_devops/common_vars/casebundles/v8-XXXXXX-amd64 copy.yml
@@ -1,0 +1,35 @@
+---
+# Below details corresponds to Cloud Pak For Data 4.8.0 bundle image tags to be mirrored
+# Add this to whatever catalog / case bundle file that starts enabling CPD 4.8.0 to be installed by default
+
+# Dependencies
+# -----------------------------------------------------------------------------
+ibm_licensing_version: 4.2.2                 # Operator version 4.2.2 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-licensing)
+common_svcs_version: 4.3.0                   # Operator version 4.3.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+cp4d_platform_version: 4.0.0+20231213.115030 # Operator version 5.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/4.0.0%2B20231213.115030)
+
+db2u_version: 5.6.2                          # Operator version 110509.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
+events_version: 4.9.0                        # Operator version 4.9.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)
+uds_version: 2.0.12                          # Operator version 2.0.12
+sls_version: 3.8.1                           # Operator version 3.8.1
+tsm_version: 1.5.3                           # Operator version 1.5.3
+dd_version: 1.1.7                            # Operator version 1.1.7
+appconnect_version: 6.2.0                    # Operator version 6.2.0
+wsl_version: 8.0.0                           # Operator version 8.0.0
+wml_version: 8.0.0                           # Operator version 5.0.0
+spark_version: 8.0.0                         # Operator version 5.0.0
+cognos_version: 25.0.0                       # Operator version 25.0.0
+
+# Watson discovery and its dependencies
+# Match corresponding case version for default versions in the catalog source
+# -----------------------------------------------------------------------------
+wd_version: 7.0.0                            # Operator version 7.0.0
+model_train_version: 1.2.11                  # Operator version 1.1.13
+elasticsearch_version: 1.1.1845              # Operator version 1.1.1845
+couchdb_version: 1.0.13                      # Operator version 2.2.1
+
+
+# Default Cloud Pak for Data version
+# ------------------------------------------------------------------------------
+cpd_product_version_default: 4.8.0
+cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default(cpd_product_version_default, true) }}"


### PR DESCRIPTION
**Keep in draft until CPD 4.8 is formally claimed support**

Details in this PR corresponds to Cloud Pak For Data 4.8.0 bundle image tags to be mirrored.
Since we are uncertain still regarding which monthly patch this will be claimed support, we need to add the details contained here to whatever catalog / case bundle file that starts enabling CPD 4.8.0 to be installed by default