### PR TITLE
[patch] Fix lookup kafka subscription

### DIFF
--- a/ibm/mas_devops/roles/kafka/tasks/provider/redhat/lookup-supported-kafka-versions.yml
+++ b/ibm/mas_devops/roles/kafka/tasks/provider/redhat/lookup-supported-kafka-versions.yml
@@ -19,6 +19,8 @@
   until:
     - kafka_subscription_lookup.resources is defined
     - kafka_subscription_lookup.resources | length > 0
+    - kafka_subscription_lookup.resources[0].status is defined
+    - kafka_subscription_lookup.resources[0].status.installedCSV is defined
 
 - name: "Assert that {{ kafka_operator_name }} operator is installed"
   assert:


### PR DESCRIPTION
This PR just fixes a minor bug in the strimzi subscription where we were not waiting for `status` property to be present before moving forward.