### PR TITLE
[patch] update default channel for gpu-operator-certified for mirroring

### DIFF
--- a/ibm/mas_devops/roles/cluster_monitoring/templates/grafana/v5/grafana.yml.j2
+++ b/ibm/mas_devops/roles/cluster_monitoring/templates/grafana/v5/grafana.yml.j2
@@ -32,8 +32,8 @@ spec:
                 claimName: mas-grafana-pvc
       strategy:
         type: Recreate
-  # An empty route spec is enough to signal the creation of a default
-  # route to the operator. This can also be used to override defaults
+  # An empty route spec will cause the creation of a default
+  # route by the operator. This can also be used to override defaults
   # in the route spec.
   route:
     spec: {}

--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -27,10 +27,10 @@ mirror:
         - name: gpu-operator-certified  # Required by ibm.mas_devops.nvidia_gpu role
           channels:
             - name: v23.3
-            # We don't use the v23.9 channel, but oc-mirror fails when the default channel is not included
+            # We don't use the v24.3 channel, but oc-mirror fails when the default channel is not included
             # - https://access.redhat.com/solutions/7013461
             # - https://issues.redhat.com/browse/OCPBUGS-385
-            - name: v23.9
+            - name: v24.3
         - name: kubeturbo-certified  # Required by ibm.mas_devops.kubeturbo role
           channels:
             - name: stable


### PR DESCRIPTION
Fix issues with operator image mirroring by including new default channel for gpu-operator-certified

see https://jsw.ibm.com/browse/MASCORE-2623