### PR TITLE
[minor] Make DRO default in oneclick_core playbook

### DIFF
--- a/docs/playbooks/oneclick-core.md
+++ b/docs/playbooks/oneclick-core.md
@@ -48,7 +48,7 @@ The other values can be left at their defaults.  Finally, click **Generate** and
 - `MAS_CONFIG_DIR` Directory where generated config files will be saved (you may also provide pre-generated config files here)
 - `SLS_LICENSE_ID` The license ID must match the license file available in `SLS_LICENSE_FILE`
 - `SLS_LICENSE_FILE` The path to the location of the license file.
-- `BAS_PROVIDER` Defines UDS or DRO operator to install. Default: UDS [Values: DRO, UDS]
+- `BAS_PROVIDER` Defines UDS or DRO operator to install. Default: DRO [Values: DRO, UDS]
 - `UDS_CONTACT_EMAIL` Defines the email for person to contact for UDS [Required if BAS_PROVIDER is UDS]
 - `UDS_CONTACT_FIRSTNAME` Defines the first name of the person to contact for UDS [Required if BAS_PROVIDER is UDS]
 - `UDS_CONTACT_LASTNAME` Defines the last name of the person to contact for UDS [Required if BAS_PROVIDER is UDS]

--- a/ibm/mas_devops/playbooks/oneclick_core.yml
+++ b/ibm/mas_devops/playbooks/oneclick_core.yml
@@ -34,24 +34,12 @@
         fail_msg: "One or more required environment variables are not defined"
 
     - name: Check for required environment variables for UDS
-      when: (bas_provider =='UDS')
       assert:
         that:
           - lookup('env', 'UDS_CONTACT_EMAIL') != ""
           - lookup('env', 'UDS_CONTACT_FIRSTNAME') != ""
           - lookup('env', 'UDS_CONTACT_LASTNAME') != ""
         fail_msg: "One or more required environment variables are not defined"
-
-
-    - name: Check for required environment variables for DRO
-      when: (bas_provider =='DRO')
-      assert:
-        that:
-          - lookup('env', 'DRO_CONTACT_EMAIL') != ""
-          - lookup('env', 'DRO_CONTACT_FIRSTNAME') != ""
-          - lookup('env', 'DRO_CONTACT_LASTNAME') != ""
-        fail_msg: "One or more required environment variables are not defined"
-
 
   roles:
     # 1. Install cluster-scoped dependencies (e.g. Cert-Manager, Operator Catalogs) & cluster monitoring

--- a/ibm/mas_devops/playbooks/oneclick_core.yml
+++ b/ibm/mas_devops/playbooks/oneclick_core.yml
@@ -16,7 +16,7 @@
     # Workspace Configuration
     mas_workspace_name: "{{ lookup('env', 'MAS_WORKSPACE_NAME') | default('MAS Development', true) }}"
     mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') | default('masdev', true) }}"
-    bas_provider: "{{ lookup('env', 'BAS_PROVIDER') | default('UDS', True) }}"
+    bas_provider: "{{ lookup('env', 'BAS_PROVIDER') | default('DRO', True) }}"
 
   pre_tasks:
     # For the full set of supported environment variables refer to the playbook documentation

--- a/ibm/mas_devops/roles/dro/defaults/main.yml
+++ b/ibm/mas_devops/roles/dro/defaults/main.yml
@@ -15,9 +15,9 @@ dro_crt_path: "{{ lookup('env', 'DRO_CERTIFICATE_PATH') }}"
 # BASCfg generation for DRO
 # -----------------------------------------------------------------------------
 dro_contact:
-  email: "{{ lookup('env', 'DRO_CONTACT_EMAIL') }}"
-  first_name: "{{ lookup('env', 'DRO_CONTACT_FIRSTNAME') }}"
-  last_name: "{{ lookup('env', 'DRO_CONTACT_LASTNAME') }}"
+  email: "{{ lookup('env', 'DRO_CONTACT_EMAIL') | default(lookup('env', 'UDS_CONTACT_EMAIL'), True) }}"
+  first_name: "{{ lookup('env', 'DRO_CONTACT_FIRSTNAME') | default(lookup('env', 'UDS_CONTACT_FIRSTNAME'), True) }}"
+  last_name: "{{ lookup('env', 'DRO_CONTACT_LASTNAME') | default(lookup('env', 'UDS_CONTACT_LASTNAME'), True) }}"
 
 ibm_entitlement_key: "{{ lookup('env', 'IBM_ENTITLEMENT_KEY') }}"
 dro_include_isrg_root_cert: "{{ lookup('env', 'DRO_INCLUDE_ISRG_ROOT_CERT') | default('true', true) | bool }}" # mainly needed for IBM Cloud hosted services


### PR DESCRIPTION
- switch bas_provider to install DRO by default from onclick_core playbook 
- Adjust the DRO contact env variables to look up UDS onces by default if they are not provided by the user to ensure the old flow does not break and users dont have to modify any existing automation. 