### PR TITLE
[patch] Skip common-services v3 install if v4 is already installed

### DIFF
--- a/ibm/mas_devops/roles/common_services/defaults/main.yml
+++ b/ibm/mas_devops/roles/common_services/defaults/main.yml
@@ -3,3 +3,4 @@ common_services_action: "{{ lookup('env', 'COMMON_SERVICES_ACTION') | default('i
 
 common_services_catalog_source: "{{ lookup('env', 'COMMON_SERVICES_CATALOG_SOURCE') | default('ibm-operator-catalog', true) }}"
 common_services_channel: "{{ lookup('env', 'COMMON_SERVICES_CHANNEL') | default('', true) }}"
+is_v4_installed: false

--- a/ibm/mas_devops/roles/common_services/tasks/main.yml
+++ b/ibm/mas_devops/roles/common_services/tasks/main.yml
@@ -25,11 +25,10 @@
     msg:
       - "IBM Common Services current channel installed ................. {{ cpfs_installed_channel | default('None', true) }}"
 
-
 # If common services is already installed with version equal/higher than v4, then skip common services v3 installation
 - name: "Execute the chosen action"
   ansible.builtin.include_tasks:
     file: "tasks/actions/{{ common_services_action }}.yml"
-  when: 
+  when:
     - common_services_action != "none"
     - not is_v4_installed

--- a/ibm/mas_devops/roles/common_services/tasks/main.yml
+++ b/ibm/mas_devops/roles/common_services/tasks/main.yml
@@ -1,5 +1,35 @@
 ---
+# This checks if ibm-common-services-operator is installed and if so retrieves the channel that is installed i.e 'v4.3'
+- name: "Check if ibm-common-service-operator is installed"
+  shell: oc get subs -A | grep ibm-common-service-operator | awk '{print $5}'
+  register: common_services_sub_channel_info
+
+- name: "Set existing ibm-common-service-operator channel"
+  set_fact:
+    cpfs_installed_channel: "{{ common_services_sub_channel_info.stdout | regex_search(regex) }}"
+  vars:
+    regex: "(?<=v)(.*)"
+
+- debug:
+    var: cpfs_installed_channel
+
+- name: "Check if ibm-common-service-operator v4 is installed"
+  set_fact:
+    is_v4_installed: "{{ cpfs_installed_channel is defined and cpfs_installed_channel is version('4.0','>=') }}"
+  when:
+    - cpfs_installed_channel is defined
+    - cpfs_installed_channel | length > 0
+
+- name: "Debug - IBM Common Services action: {{ common_services_action }}"
+  debug:
+    msg:
+      - "IBM Common Services current channel installed ................. {{ cpfs_installed_channel | default('None', true) }}"
+
+
+# If common services is already installed with version equal/higher than v4, then skip common services v3 installation
 - name: "Execute the chosen action"
   ansible.builtin.include_tasks:
     file: "tasks/actions/{{ common_services_action }}.yml"
-  when: common_services_action != "none"
+  when: 
+    - common_services_action != "none"
+    - not is_v4_installed

--- a/ibm/mas_devops/roles/cp4d/tasks/prereq-check/check-cpfs-version.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/prereq-check/check-cpfs-version.yml
@@ -23,9 +23,6 @@
       set_fact:
         common_services_channel: "{{ common_services_manifest_info.resources[0].status.defaultChannel }}"
 
-- debug:
-    msg:
-
 - name: "Assert that IBM Cloud Pak Foundational Services is compatible with Cloud Pak for Data version {{ cpd_product_version }}"
   assert:
     that: cpfs_installed_version is version_compare(cpfs_version, '>=')


### PR DESCRIPTION
add a check in `common_services role` in ansible-devops to check if v4 version of cpfs is already installed
if it is then skip `common_services` v3 install
this will add a safe guard on our side when we enable cpd 4.8
we don't want `common_services` role to run when v4 is already installed because if v3 is attempted to be installed in an env with v4 already installed, it will mess things up

Tests via mas install cmd in cli showing it is skipping the v3 install:

<img width="1120" alt="image" src="https://github.com/ibm-mas/ansible-devops/assets/31037381/31bc7347-0de5-42a7-8344-ee9ea1f1a5c7">

Ultimately it's easier to skip that directly in the ansible-devops rather than anticipate all possible conditions that we should cover to skip this in mas cli logic.