### PR TITLE
[patch] Corrected path to determine-storage-classes task in ocp_cluster_monitoring role

### DIFF
--- a/ibm/mas_devops/roles/ocp_cluster_monitoring/tasks/install.yml
+++ b/ibm/mas_devops/roles/ocp_cluster_monitoring/tasks/install.yml
@@ -3,7 +3,7 @@
 # 1. Load default storage classes (if not provided by the user)
 # -----------------------------------------------------------------------------
 - name: "install : Determine storage classes"
-  include_tasks: tasks/install/determine-storage-classes.yml
+  include_tasks: tasks/determine-storage-classes.yml
 
 
 # 2. Debug settings


### PR DESCRIPTION
The path to the determine-storage-classes is incorrect.