### PR TITLE
[patch] Reduce ocp_verify timeout

### DIFF
--- a/ibm/mas_devops/roles/ocp_verify/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_verify/tasks/main.yml
@@ -27,7 +27,7 @@
 - name: Check Subscription Status
   when: verify_subscriptions
   ibm.mas_devops.verify_subscriptions:
-    retries: 60 # Allow up to 5 hours
+    retries: 25 # Allow up to 2 hours
     delay: 300 # 5 minutes
 
 # 4. Wait for all deployments & statefulsets in all namespaces to be healthy
@@ -35,7 +35,7 @@
 - name: Check Deployment & StatefulSet Status
   when: verify_workloads
   ibm.mas_devops.verify_workloads:
-    retries: 200 # Allow up to 10 hours
+    retries: 40 # Allow up to 3 hours
     delay: 300 # 5 minutes
 
 # 5. Check for router and ingress secrets


### PR DESCRIPTION
Tested in fvt811x (run 2922), fvtstable (run 2925) and fvtcpd (run 2919)