### PR TITLE
[patch] remove the missing update-digest-map task reference

### DIFF
--- a/ibm/mas_devops/roles/ibm_catalogs/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/ibm_catalogs/tasks/install/main.yml
@@ -30,12 +30,6 @@
       include_vars:
         file: "{{ role_path }}/../../common_vars/casebundles/{{ mas_catalog_version }}.yml"
 
-    # If we are updating the catalog in an airgap environment, we first have to
-    # update the image digest configmaps, otherwise when the operators update
-    # they will not be able to use digests for the new images.
-    - name: "Update digest maps ahead of catalog update"
-      include_tasks: tasks/install/update-digest-maps.yml
-
     - name: "Create IBM offline catalog"
       kubernetes.core.k8s:
         template: templates/offline-catalog.yml.j2


### PR DESCRIPTION
Remove the reference to the deleted tasks as part of major changes - https://github.com/ibm-mas/ansible-devops/pull/1233/files#diff-5a3be8443a58558655f0f07948c2dbfccfb9ccf250174fd13bf8594896f6fed3

This is a blocker on airgap install.