### PR TITLE
[patch] Update AMQ Streams default Kafka version to 3.7

### DIFF
--- a/ibm/mas_devops/roles/kafka/defaults/main.yaml
+++ b/ibm/mas_devops/roles/kafka/defaults/main.yaml
@@ -11,7 +11,7 @@ kafka_defaults:
     operator_name: "strimzi-kafka-operator"
     alias_name: "Strimzi"
   redhat:
-    version: "3.5.0"
+    version: "3.7.0"
     namespace: "amq-streams"
     operator_name: "amq-streams"
     alias_name: "Red Hat AMQ Streams"


### PR DESCRIPTION
With the current version of AMQ Streams selected by default here, the latest version of the operator fails with:
```
'Unsupported Kafka.spec.kafka.version: 3.5.0. Supported versions are: [3.6.0, 3.7.0]'
```
Bumping the version of AMQ streams to 3.7.0 to be compatible.