### PR TITLE
[patch] Add missing condition in wait for logstash

### DIFF
--- a/ibm/mas_devops/roles/eck/tasks/install.yml
+++ b/ibm/mas_devops/roles/eck/tasks/install.yml
@@ -133,6 +133,7 @@
     template: "templates/elastic/logstash.yml.j2"
 
 - name: "Wait for Logstash be ready (60s delay)"
+  when: eck_enable_logstash
   kubernetes.core.k8s_info:
     api_version: logstash.k8s.elastic.co/v1alpha1
     kind: Logstash


### PR DESCRIPTION
This update adds `when: eck_enable_logstash` clause to the step that waits for logstash server to be ready, without it the role used without logstash enabled will hang indefinitely.