### PR TITLE
[patch] Fix UDS uninstall handling UDS never installed before

### DIFF
--- a/ibm/mas_devops/roles/uds/tasks/uninstall/main.yml
+++ b/ibm/mas_devops/roles/uds/tasks/uninstall/main.yml
@@ -3,9 +3,20 @@
 # ibm-common-services and there may be other services running in this
 # namespace which we do not want to affect.
 
-# 1. Delete AnalyticsProxy and GenerateKey
+# 1. Check whether the UDS CRDs are installed on the cluster
+# -----------------------------------------------------------------------------
+- name: "uninstall: Check for UDS AnalyticsProxy CRD"
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: analyticsproxies.uds.ibm.com
+  register: analyticsproxies_crd
+
+
+# 2. Delete AnalyticsProxy and GenerateKey
 # -----------------------------------------------------------------------------
 - name: "uninstall : Delete the GenerateKey"
+  when: analyticsproxies_crd.resources | length > 0
   kubernetes.core.k8s:
     state: absent
     api_version: uds.ibm.com/v1
@@ -16,6 +27,7 @@
     wait_timeout: 600
 
 - name: "uninstall : Delete the AnalyticsProxy"
+  when: analyticsproxies_crd.resources | length > 0
   kubernetes.core.k8s:
     state: absent
     api_version: uds.ibm.com/v1
@@ -26,9 +38,10 @@
     wait_timeout: 600
 
 
-# 2. Delete the UDS OperandRequest
+# 3. Delete the UDS OperandRequest
 # -----------------------------------------------------------------------------
 - name: "uninstall : Delete UDS OperandRequest"
+  when: analyticsproxies_crd.resources | length > 0
   kubernetes.core.k8s:
     state: absent
     definition: "{{ lookup('template', 'templates/foundation-services/ibm-user-data-services.yml') }}"
@@ -36,9 +49,10 @@
     wait_timeout: 600
 
 
-# 3. Verify that AnalyticsProxy CR is gone
+# 4. Verify that AnalyticsProxy CR is gone
 # -----------------------------------------------------------------------------
 - name: "uninstall : Look for the AnalyticsProxy CR after deletion"
+  when: analyticsproxies_crd.resources | length > 0
   kubernetes.core.k8s_info:
     api_version: uds.ibm.com/v1
     kind: AnalyticsProxy
@@ -47,15 +61,17 @@
   register: verify_uds_delete
 
 - name: "uninstall : Verify the AnalyticsProxy CR was deleted"
+  when: analyticsproxies_crd.resources | length > 0
   assert:
     that:
       - verify_uds_delete.resources is defined
       - verify_uds_delete.resources | length == 0
 
 
-# 4. Verify that GenerateKey CRs are all gone
+# 5. Verify that GenerateKey CRs are all gone
 # -----------------------------------------------------------------------------
 - name: "uninstall : Look for the Suite CR after deletion"
+  when: analyticsproxies_crd.resources | length > 0
   kubernetes.core.k8s_info:
     api_version: uds.ibm.com/v1
     kind: GenerateKey
@@ -64,15 +80,17 @@
   register: verify_genkey_delete
 
 - name: "uninstall : Verify the UDS GenerateKey was deleted"
+  when: analyticsproxies_crd.resources | length > 0
   assert:
     that:
       - verify_genkey_delete.resources is defined
       - verify_genkey_delete.resources | length == 0
 
 
-# 5. Delete the Crunchy Postgres Subscription
+# 6. Delete the Crunchy Postgres Subscription
 # -----------------------------------------------------------------------------
 - name: "uninstall : Delete Crunchy Postgres Subscription"
+  when: analyticsproxies_crd.resources | length > 0
   kubernetes.core.k8s:
     state: absent
     api_version: operators.coreos.com/v1alpha1
@@ -83,9 +101,10 @@
     wait_timeout: 300
 
 
-# 6. Delete the Crunchy Postgres CSV
+# 7. Delete the Crunchy Postgres CSV
 # -----------------------------------------------------------------------------
 - name: "uninstall : Delete crunchy-postgres-operator CSV"
+  when: analyticsproxies_crd.resources | length > 0
   kubernetes.core.k8s:
     state: absent
     api_version: operators.coreos.com/v1alpha1


### PR DESCRIPTION
When performing a MAS uninstall we will try to ensure that both UDS & DRO are removed from the cluster, in the case where UDS has never been previously installed the uninstall will fail because the CRDs are not even registered, so although it already handles "is not currently installed", it can not handle "it has never been installed, ever":

```
TASK [ibm.mas_devops.uds : uninstall : Delete the GenerateKey] *****************
fatal: [localhost]: FAILED! => changed=false 
  msg: Failed to find exact match for uds.ibm.com/v1.GenerateKey by [kind, name, singularName, shortNames]
```