### PR TITLE
[patch] Guard that when provisioning fyre the site is specified and supported

### DIFF
--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/fyre.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/fyre.yml
@@ -9,6 +9,8 @@
       - fyre_product_id is defined and fyre_product_id != ""
       - fyre_username is defined and fyre_username != ""
       - fyre_password is defined and fyre_password != ""
+      - fyre_site is defined and fyre_site != ""
+      - fyre_site is in ['svl','rtp']
 
 - name: "fyre : Fail if required properties are not provided (quickburn)"
   when: fyre_quota_type == "quick_burn"


### PR DESCRIPTION
We check that when provisioning in fyre that a valid site has been entered