### PR TITLE
[patch] fix mas entitlement default vars

### DIFF
--- a/ibm/mas_devops/roles/aibroker/tasks/aibroker/main.yml
+++ b/ibm/mas_devops/roles/aibroker/tasks/aibroker/main.yml
@@ -24,8 +24,8 @@
     name: ibm.mas_devops.install_operator
   vars:
     namespace: "{{ aibroker_namespace }}"
-    icr_username: "{{ ibm_entitlement_username }}"
-    icr_password: "{{ ibm_entitlement_key }}"
+    icr_username: "{{ mas_entitlement_username }}"
+    icr_password: "{{ mas_entitlement_key }}"
     catalog_source: "{{ mas_catalog_source }}"
     operator_group: "{{ lookup('template', 'templates/aibroker/operator-group.yml.j2') }}"
     subscription: "{{ lookup('template', 'templates/aibroker/subscription.yml.j2') }}"

--- a/ibm/mas_devops/roles/kmodels/defaults/main.yml
+++ b/ibm/mas_devops/roles/kmodels/defaults/main.yml
@@ -3,13 +3,26 @@
 mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
 mas_config_dir: "{{ lookup('env', 'MAS_CONFIG_DIR') }}"
 
-# Main variables
-ibm_entitlement_username: "{{ lookup('env','IBM_ENTITLEMENT_USERNAME') }}"
-ibm_entitlement_key: "{{ lookup('env', 'IBM_ENTITLEMENT_KEY') }}"
+# #Regcred variables 
+# TODO: i dont think these are needed can we delete it?
+# Having mas_entitlement_username and mas_entitlement_key is enough
+# icr_username: "{{ lookup('env','ICR_USERNAME') }}"
+# icr_password: "{{ lookup('env','ICR_PASSWORD') }}"
 
-#Regcred variables
-icr_username: "{{ lookup('env','ICR_USERNAME') }}"
-icr_password: "{{ lookup('env','ICR_PASSWORD') }}"
+# Source container registry
+# -----------------------------------------------------------------------------
+mas_icr_cp: "{{ lookup('env', 'MAS_ICR_CP') | default('cp.icr.io/cp', true) }}"
+mas_icr_cpopen: "{{ lookup('env', 'MAS_ICR_CPOPEN') | default('icr.io/cpopen', true) }}"
+
+# MAS Entitlement
+# -----------------------------------------------------------------------------
+mas_entitlement_username: "{{ lookup('env', 'MAS_ENTITLEMENT_USERNAME') | default('cp', true) }}"
+ibm_entitlement_key: "{{ lookup('env', 'IBM_ENTITLEMENT_KEY') }}"
+mas_entitlement_key: "{{ lookup('env', 'MAS_ENTITLEMENT_KEY') | default(ibm_entitlement_key, true) }}"
+
+# MAS Annotation block
+# -----------------------------------------------------------------------------
+mas_annotations: "{{ lookup('env', 'MAS_ANNOTATIONS') | default(None, true) }}"
 
 #km-s3-secret variables
 aws_access_key_id: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') }}"

--- a/ibm/mas_devops/roles/kmodels/defaults/main.yml
+++ b/ibm/mas_devops/roles/kmodels/defaults/main.yml
@@ -3,12 +3,6 @@
 mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
 mas_config_dir: "{{ lookup('env', 'MAS_CONFIG_DIR') }}"
 
-# #Regcred variables 
-# TODO: i dont think these are needed can we delete it?
-# Having mas_entitlement_username and mas_entitlement_key is enough
-# icr_username: "{{ lookup('env','ICR_USERNAME') }}"
-# icr_password: "{{ lookup('env','ICR_PASSWORD') }}"
-
 # Source container registry
 # -----------------------------------------------------------------------------
 mas_icr_cp: "{{ lookup('env', 'MAS_ICR_CP') | default('cp.icr.io/cp', true) }}"

--- a/ibm/mas_devops/roles/kmodels/templates/regcred-secret.json.j2
+++ b/ibm/mas_devops/roles/kmodels/templates/regcred-secret.json.j2
@@ -1,9 +1,9 @@
 {
   "auths": {
     "icr.io": {
-      "username": "{{ icr_username }}",
-      "password": "{{ icr_password }}",
-      "auth": "{{ (icr_username ~ ':' ~ icr_password) | b64encode }}"
+      "username": "{{ mas_entitlement_username }}",
+      "password": "{{ mas_entitlement_key }}",
+      "auth": "{{ (mas_entitlement_username ~ ':' ~ mas_entitlement_key) | b64encode }}"
     }
   }
 }

--- a/ibm/mas_devops/roles/odh/defaults/main.yml
+++ b/ibm/mas_devops/roles/odh/defaults/main.yml
@@ -3,6 +3,17 @@
 mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
 mas_config_dir: "{{ lookup('env', 'MAS_CONFIG_DIR') }}"
 
-# Main variables
-ibm_entitlement_username: "{{ lookup('env','IBM_ENTITLEMENT_USERNAME') }}"
+# Source container registry
+# -----------------------------------------------------------------------------
+mas_icr_cp: "{{ lookup('env', 'MAS_ICR_CP') | default('cp.icr.io/cp', true) }}"
+mas_icr_cpopen: "{{ lookup('env', 'MAS_ICR_CPOPEN') | default('icr.io/cpopen', true) }}"
+
+# MAS Entitlement
+# -----------------------------------------------------------------------------
+mas_entitlement_username: "{{ lookup('env', 'MAS_ENTITLEMENT_USERNAME') | default('cp', true) }}"
 ibm_entitlement_key: "{{ lookup('env', 'IBM_ENTITLEMENT_KEY') }}"
+mas_entitlement_key: "{{ lookup('env', 'MAS_ENTITLEMENT_KEY') | default(ibm_entitlement_key, true) }}"
+
+# MAS Annotation block
+# -----------------------------------------------------------------------------
+mas_annotations: "{{ lookup('env', 'MAS_ANNOTATIONS') | default(None, true) }}"

--- a/ibm/mas_devops/roles/odh/tasks/authorino-operator.yml
+++ b/ibm/mas_devops/roles/odh/tasks/authorino-operator.yml
@@ -6,8 +6,8 @@
     name: ibm.mas_devops.install_operator
   vars:
     namespace: "{{ openshift_namespace }}"
-    icr_username: "{{ ibm_entitlement_username }}"
-    icr_password: "{{ ibm_entitlement_key }}"
+    icr_username: "{{ mas_entitlement_username }}"
+    icr_password: "{{ mas_entitlement_key }}"
     catalog_source: "{{ serverless_catalog_source }}"
     operator_group: "{{ lookup('template', 'templates/authorino/operator-group.yml.j2') }}"
     subscription: "{{ lookup('template', 'templates/authorino/subscription.yml.j2') }}"

--- a/ibm/mas_devops/roles/odh/tasks/odh-operator.yml
+++ b/ibm/mas_devops/roles/odh/tasks/odh-operator.yml
@@ -6,8 +6,8 @@
     name: ibm.mas_devops.install_operator
   vars:
     namespace: "{{ openshift_namespace }}"
-    icr_username: "{{ ibm_entitlement_username }}"
-    icr_password: "{{ ibm_entitlement_key }}"
+    icr_username: "{{ mas_entitlement_username }}"
+    icr_password: "{{ mas_entitlement_key }}"
     catalog_source: "{{ odh_catalog_source }}"
     operator_group: "{{ lookup('template', 'templates/odh/operator-group.yml.j2') }}"
     subscription: "{{ lookup('template', 'templates/odh/subscription.yml.j2') }}"

--- a/ibm/mas_devops/roles/odh/tasks/serverless-operator.yml
+++ b/ibm/mas_devops/roles/odh/tasks/serverless-operator.yml
@@ -6,8 +6,8 @@
     name: ibm.mas_devops.install_operator
   vars:
     namespace: "{{ serverless_namespace }}"
-    icr_username: "{{ ibm_entitlement_username }}"
-    icr_password: "{{ ibm_entitlement_key }}"
+    icr_username: "{{ mas_entitlement_username }}"
+    icr_password: "{{ mas_entitlement_key }}"
     catalog_source: "{{ serverless_catalog_source }}"
     operator_group: "{{ lookup('template', 'templates/serverless/operator-group.yml.j2') }}"
     subscription: "{{ lookup('template', 'templates/serverless/subscription.yml.j2') }}"

--- a/ibm/mas_devops/roles/odh/tasks/servicemesh-operator.yml
+++ b/ibm/mas_devops/roles/odh/tasks/servicemesh-operator.yml
@@ -6,8 +6,8 @@
     name: ibm.mas_devops.install_operator
   vars:
     namespace: "{{ service_mesh_namespace }}"
-    icr_username: "{{ ibm_entitlement_username }}"
-    icr_password: "{{ ibm_entitlement_key }}"
+    icr_username: "{{ mas_entitlement_username }}"
+    icr_password: "{{ mas_entitlement_key }}"
     catalog_source: "{{ service_mesh_catalog_source }}"
     operator_group: "{{ lookup('template', 'templates/servicemesh/operator-group.yml.j2') }}"
     subscription: "{{ lookup('template', 'templates/servicemesh/subscription.yml.j2') }}"


### PR DESCRIPTION
This PR adds standard ansible vars to set `mas_entitlement_key` and `mas_entitlement_username` properties while creating ibm-entitlement-key secrets