### PR TITLE
[patch] invoke cis certificate-order in batch of 50

### DIFF
--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
@@ -77,6 +77,7 @@
 
 - name: "cis : Order certificate if there no dedicated yet"
   ansible.builtin.shell: |
-    ibmcloud cis certificate-order {{ _cis_domain_id }} --hostnames {{ edge_cert_routes|join(',') }} -i {{ cis_service_name }}
+    ibmcloud cis certificate-order {{ _cis_domain_id }} --hostnames {{ item|join(',') }} -i {{ cis_service_name }}
+  loop: "{{ edge_cert_routes | batch(50) | list }}"
   when:
     - not hasDedicated or _deleted_certificate is defined


### PR DESCRIPTION
This PR has logic to invoke cis certificate-order cli command in batch of 50

Tested in fvt env were we have more than 50 edge certificates to create