### PR TITLE
[patch] Remove common_services role from oneclick_core 

### DIFF
--- a/ibm/mas_devops/playbooks/oneclick_core.yml
+++ b/ibm/mas_devops/playbooks/oneclick_core.yml
@@ -39,7 +39,6 @@
   roles:
     # 1. Install cluster-scoped dependencies (e.g. Cert-Manager, Operator Catalogs) & Grafana
     - ibm.mas_devops.ibm_catalogs
-    - ibm.mas_devops.common_services
     - ibm.mas_devops.cert_manager
     - ibm.mas_devops.grafana
 


### PR DESCRIPTION
Common_services role is not required for core any more. it serves no purpose currently. 
Common_services is only installed as part of cp4d. CP4D role will install common-services v4.3.0.

This will resolve airgap issue.