### PR TITLE
[minor] Allow Suite SSO CR settings to be configured at install time - MASCORE-2125

### DIFF
--- a/ibm/mas_devops/roles/suite_install/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_install/defaults/main.yml
@@ -9,6 +9,22 @@ mas_channel: "{{ lookup('env', 'MAS_CHANNEL') }}"
 mas_domain: "{{ lookup('env', 'MAS_DOMAIN') }}"
 mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
 
+# SSO Configuration
+# -----------------------------------------------------------------------------
+idle_timeout: "{{ lookup('env', 'IDLE_TIMEOUT') | default(1800, true) }}"
+idp_session_timeout: "{{ lookup('env', 'IDP_SESSION_TIMEOUT') | default('12h', true) }}"
+access_token_timeout: "{{ lookup('env', 'ACCESS_TOKEN_TIMEOUT') | default('30m', true) }}"
+refresh_token_timeout: "{{ lookup('env', 'REFRESH_TOKEN_TIMEOUT') | default('12h', true) }}"
+default_idp: "{{ lookup('env', 'DEFAULT_IDP') | default('local', true) }}"
+seamless_login: "{{ lookup('env', 'SEAMLESS_LOGIN')| default(False, true) }}"
+default_sso_cookie_name: "ltpatoken2_{{ mas_instance_id }}"
+
+sso_cookie_name: "{{ lookup('env', 'SSO_COOKIE_NAME') | default(default_sso_cookie_name, true) }}"
+allow_default_sso_cookie_name: "{{ lookup('env', 'ALLOW_DEFAULT_SSO_COOKIE_NAME')| default(False, true) }}"
+use_only_custom_cookie_name: "{{ lookup('env', 'USE_ONLY_CUSTOM_COOKIE_NAME')| default(True, true) }}"
+disable_ltpa_cookie: "{{ lookup('env', 'DISABLE_LTPA_COOKIE')| default(False, true) }}"
+allow_custom_cache_key: "{{ lookup('env', 'ALLOW_CUSTOM_CACHE_KEY')| default(False, true) }}"
+
 # Certificate Management
 # -----------------------------------------------------------------------------
 mas_cluster_issuer: "{{ lookup('env', 'MAS_CLUSTER_ISSUER') }}"

--- a/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
+++ b/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
@@ -18,6 +18,19 @@ metadata:
 {% endif %}
 spec:
   certManagerNamespace: "{{ cert_manager_cluster_resource_namespace }}"
+  sso:
+    accessTokenTimeout: "{{ access_token_timeout }}"
+    defaultIDP: "{{ default_idp }}"
+    idleTimeout: "{{ idle_timeout | int }}"
+    idpSessionTimeout: "{{ idp_session_timeout }}"
+    refreshTokenTimeout: "{{ refresh_token_timeout }}"
+    seamlessLogin: "{{ seamless_login | bool }}"
+    ssoCookieName: "{{ sso_cookie_name }}"
+    allowDefaultSsoCookieName: "{{ allow_default_sso_cookie_name }}"
+    useOnlyCustomCookieName: "{{ use_only_custom_cookie_name }}"
+    disableLtpaCookie: "{{ disable_ltpa_cookie }}"
+    allowCustomCacheKey: "{{ allow_custom_cache_key }}"
+    
 {% if mas_cluster_issuer is defined and mas_cluster_issuer != '' %}
   certificateIssuer:
     name: "{{ mas_cluster_issuer }}"


### PR DESCRIPTION
## Description
This PR will allow suite SSO CR setting to be configured at install time using cli.

## Related Issues
- https://jsw.ibm.com/browse/MASCORE-2125

## How Has This Been Tested?
I set up a personal FYRE environment and followed the MAS installation process to configure both default and personal settings. Please refer to the images below for details:
![image](https://github.com/user-attachments/assets/0661fc10-d6f2-41db-a789-0d221c7d97e7)
![image](https://github.com/user-attachments/assets/8e265967-7c40-42ec-bb23-569323b69e07)
![image](https://github.com/user-attachments/assets/1323d007-6827-4a3c-b05d-788dbbded726)
![image](https://github.com/user-attachments/assets/331f220e-adba-4eb9-863a-087844e01489)
![image](https://github.com/user-attachments/assets/5fbeef21-8b54-4f48-ace6-844a42533e4b)

