### PR TITLE
[patch] Don't do a second lookup when retrieving access info

### DIFF
--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/ipi.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/ipi.yml
@@ -169,7 +169,7 @@
   set_fact:
     login_password: "{{ lookup('file', ipi_config_dir+'/auth/kubeadmin-password') }}"
     login_user: "kubeadmin"
-    login_server: "https://api.{{ lookup('env', 'CLUSTER_NAME') | default('', True) }}.{{ lookup('env','IPI_BASE_DOMAIN') }}:6443"
+    login_server: "https://api.{{ cluster_name }}.{{ ipi_base_domain }}:6443"
 
 - name: "ipi : Print the access info"
   debug:


### PR DESCRIPTION
Breaks when importing the role into a playbook that sets `vars` instead of using environment variables.