### PR TITLE
[patch] Ignore failures in ax-wdp-notebooks-api-deploy

### DIFF
--- a/ibm/mas_devops/plugins/action/verify_workloads.py
+++ b/ibm/mas_devops/plugins/action/verify_workloads.py
@@ -38,9 +38,10 @@ class ActionModule(ActionBase):
         # Consider carefully the impact of adding anything here - only add things that are utterly broken
         # AND out of our control to fix!
         ignoredResources = [
-          # Watson Discovery is an unreliable product in general, particularly this deployment, which will often be found in this state indefinitely:
           # [NOTREADY] ibm-cpd/wd-discovery-ranker-rest = 1 replicas/None ready/1 updated/None available
-          "wd-discovery-ranker-rest"
+          # [NOTREADY] ibm-cpd/ax-wdp-notebooks-api-deploy = 1 replicas/None ready/1 updated/None available
+          "wd-discovery-ranker-rest",
+          "ax-wdp-notebooks-api-deploy"
         ]
 
         allResourcesHealthy = False


### PR DESCRIPTION
We are seeing consistent failures for this pod in CP4D to be ready:

```
[NOTREADY] ibm-cpd/ax-wdp-notebooks-api-deploy = 1 replicas/None ready/1 updated/None available
```

It's out of our control to fix this, and it's non-critical to MAS, so failures will be ignored when running workload validation.