### PR TITLE
[patch] Sanitize inputs that may contain special characters by base64…

### DIFF
--- a/ibm/mas_devops/roles/cos/templates/ibm/objectstoragecfg.yml.j2
+++ b/ibm/mas_devops/roles/cos/templates/ibm/objectstoragecfg.yml.j2
@@ -11,9 +11,9 @@ metadata:
     "{{ key }}": "{{ value }}"
 {% endfor %}
 {% endif %}
-stringData:
-  username: "ibmcloud-iam-apikey"
-  password: "{{ cos_password }}"
+data:
+  username: "{{ 'ibmcloud-iam-apikey' | b64encode }}"
+  password: "{{ cos_password | b64encode }}"
 ---
 apiVersion: config.mas.ibm.com/v1
 kind: ObjectStorageCfg

--- a/ibm/mas_devops/roles/cp4d_service/templates/wd/wdscfg.yml.j2
+++ b/ibm/mas_devops/roles/cp4d_service/templates/wd/wdscfg.yml.j2
@@ -15,9 +15,9 @@ metadata:
   namespace: "mas-{{ mas_instance_id }}-assist"
 ---
 apiVersion: v1
-stringData:
-  password: "{{ cpd_admin_password }}"
-  username: "{{ cpd_admin_username }}"
+data:
+  password: "{{ cpd_admin_password | b64encode }}"
+  username: "{{ cpd_admin_username | b64encode }}"
 kind: Secret
 metadata:
   name: assist-watson-discovery-credentials

--- a/ibm/mas_devops/roles/db2/templates/suite_jdbccfg.yml.j2
+++ b/ibm/mas_devops/roles/db2/templates/suite_jdbccfg.yml.j2
@@ -11,9 +11,9 @@ metadata:
     "{{ key }}": "{{ value }}"
 {% endfor %}
 {% endif %}
-stringData:
-  username: "{{db2_jdbc_username}}"
-  password: "{{jdbc_instance_password}}"
+data:
+  username: "{{db2_jdbc_username | b64encode}}"
+  password: "{{jdbc_instance_password | b64encode}}"
 ---
 apiVersion: config.mas.ibm.com/v1
 kind: JdbcCfg

--- a/ibm/mas_devops/roles/gencfg_jdbc/templates/jdbccfg.yml.j2
+++ b/ibm/mas_devops/roles/gencfg_jdbc/templates/jdbccfg.yml.j2
@@ -11,9 +11,9 @@ metadata:
     "{{ key }}": "{{ value }}"
 {% endfor %}
 {% endif %}
-stringData:
-  username: "{{db_username}}"
-  password: "{{jdbc_instance_password}}"
+data:
+  username: "{{db_username | b64encode}}"
+  password: "{{jdbc_instance_password | b64encode}}"
 ---
 apiVersion: config.mas.ibm.com/v1
 kind: JdbcCfg

--- a/ibm/mas_devops/roles/gencfg_mongo/templates/suite_mongocfg.yml.j2
+++ b/ibm/mas_devops/roles/gencfg_mongo/templates/suite_mongocfg.yml.j2
@@ -12,9 +12,9 @@ metadata:
     "{{ key }}": "{{ value }}"
 {% endfor %}
 {% endif %}
-stringData:
-  username: "{{ mongodb_admin_username }}"
-  password: "{{ mongodb_admin_password }}"
+data:
+  username: "{{ mongodb_admin_username | b64encode }}"
+  password: "{{ mongodb_admin_password | b64encode }}"
 ---
 # Mongo configuration for MAS
 apiVersion: config.mas.ibm.com/v1

--- a/ibm/mas_devops/roles/gencfg_watsonstudio/templates/wscfg.yml.j2
+++ b/ibm/mas_devops/roles/gencfg_watsonstudio/templates/wscfg.yml.j2
@@ -10,9 +10,9 @@ metadata:
     {{key}}: "{{value}}"
 {% endfor %}
 {% endif %}
-stringData:
-  password: "{{ cpd_admin_password }}"
-  username: "{{ cpd_admin_username }}"
+data:
+  password: "{{ cpd_admin_password | b64encode }}"
+  username: "{{ cpd_admin_username | b64encode }}"
 ---
 apiVersion: config.mas.ibm.com/v1
 kind: WatsonStudioCfg

--- a/ibm/mas_devops/roles/kafka/templates/aws/mskcfg.yml.j2
+++ b/ibm/mas_devops/roles/kafka/templates/aws/mskcfg.yml.j2
@@ -11,9 +11,9 @@ metadata:
     "{{key}}": "{{value}}"
 {% endfor %}
 {% endif %}
-stringData:
-  username: "{{aws_kafka_user_name}}"
-  password: "{{aws_kafka_user_password}}"
+data:
+  username: "{{aws_kafka_user_name | b64encode}}"
+  password: "{{aws_kafka_user_password | b64encode}}"
 ---
 apiVersion: config.mas.ibm.com/v1
 kind: KafkaCfg

--- a/ibm/mas_devops/roles/kafka/templates/redhat/kafkacfg.yml.j2
+++ b/ibm/mas_devops/roles/kafka/templates/redhat/kafkacfg.yml.j2
@@ -11,9 +11,9 @@ metadata:
     "{{ key }}": "{{ value }}"
 {% endfor %}
 {% endif %}
-stringData:
-  username: "{{ kafka_user_name }}"
-  password: "{{ kafka_user_password }}"
+data:
+  username: "{{ kafka_user_name | b64encode }}"
+  password: "{{ kafka_user_password | b64encode }}"
 ---
 apiVersion: config.mas.ibm.com/v1
 kind: KafkaCfg

--- a/ibm/mas_devops/roles/kafka/templates/redhat/masuser.yml.j2
+++ b/ibm/mas_devops/roles/kafka/templates/redhat/masuser.yml.j2
@@ -5,9 +5,9 @@ type: Opaque
 metadata:
   name: maskafka-credentials
   namespace: "{{ kafka_namespace }}"
-stringData:
-  username: "{{ kafka_user_name }}"
-  password: "{{ kafka_user_password }}"
+data:
+  username: "{{ kafka_user_name | b64encode }}"
+  password: "{{ kafka_user_password | b64encode }}"
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaUser

--- a/ibm/mas_devops/roles/mongodb/templates/aws/docdb_instance_user_credentials_secret.yaml.j2
+++ b/ibm/mas_devops/roles/mongodb/templates/aws/docdb_instance_user_credentials_secret.yaml.j2
@@ -8,6 +8,6 @@ metadata:
     avp.kubernetes.io/path: "project/mmas/data/automation/{{cluster_name}}/{{mas_instance_id}}/mongocfg"
   name: "mongodb-{{docdb_mongo_instance_name}}-credentials"
   namespace: "mas-{{mas_instance_id}}-core"
-stringData:
-  username: {{ docdb_instance_username }}
-  password: {{ docdb_final_instance_password }}
+data:
+  username: {{ docdb_instance_username | b64encode }}
+  password: {{ docdb_final_instance_password | b64encode }}

--- a/ibm/mas_devops/roles/mongodb/templates/community/suite_mongocfg.yml.j2
+++ b/ibm/mas_devops/roles/mongodb/templates/community/suite_mongocfg.yml.j2
@@ -12,9 +12,9 @@ metadata:
     "{{ key }}": "{{ value }}"
 {% endfor %}
 {% endif %}
-stringData:
-  username: admin
-  password: "{{ mongodb_admin_password }}"
+data:
+  username: "{{ 'admin' | b64encode }}"
+  password: "{{ mongodb_admin_password | b64encode }}"
 ---
 # Mongo configuration for MAS
 apiVersion: config.mas.ibm.com/v1

--- a/ibm/mas_devops/roles/mongodb/templates/ibm/suite_mongocfg.yml.j2
+++ b/ibm/mas_devops/roles/mongodb/templates/ibm/suite_mongocfg.yml.j2
@@ -11,9 +11,9 @@ metadata:
     "{{ key }}": "{{ value }}"
 {% endfor %}
 {% endif %}
-stringData:
-  username: "{{ mongo_instance_info.resource.adminuser }}"
-  password: "{{ ibm_mongo_admin_password }}"
+data:
+  username: "{{ mongo_instance_info.resource.adminuser | b64encode }}"
+  password: "{{ ibm_mongo_admin_password | b64encode }}"
 ---
 apiVersion: config.mas.ibm.com/v1
 kind: MongoCfg

--- a/ibm/mas_devops/roles/sls/templates/mongo-secret.yml.j2
+++ b/ibm/mas_devops/roles/sls/templates/mongo-secret.yml.j2
@@ -10,6 +10,6 @@ metadata:
     "{{ key }}": "{{ value }}"
 {% endfor %}
 {% endif %}
-stringData:
-  username: "{{ mongodb.username }}"
-  password: "{{ mongodb.password }}"
+data:
+  username: "{{ mongodb.username | b64encode }}"
+  password: "{{ mongodb.password | b64encode }}"

--- a/ibm/mas_devops/roles/suite_install/templates/secret-superuser.yml.j2
+++ b/ibm/mas_devops/roles/suite_install/templates/secret-superuser.yml.j2
@@ -5,6 +5,6 @@ type: opaque
 metadata:
   name: {{ mas_instance_id }}-credentials-superuser
   namespace: "{{ mas_namespace }}"
-stringData:
-  username: {{ mas_superuser_username }}
-  password: {{ mas_superuser_password }}
+data:
+  username: {{ mas_superuser_username | b64encode }}
+  password: {{ mas_superuser_password | b64encode }}

--- a/ibm/mas_devops/roles/turbonomic/templates/turbonomic-secret.yml.j2
+++ b/ibm/mas_devops/roles/turbonomic/templates/turbonomic-secret.yml.j2
@@ -10,6 +10,6 @@ metadata:
     "{{ key }}": "{{ value }}"
 {% endfor %}
 {% endif %}
-stringData:
-  password: "{{ turbonomic_password }}"
-  username: "{{ turbonomic_username }}"
+data:
+  password: "{{ turbonomic_password | b64encode }}"
+  username: "{{ turbonomic_username | b64encode }}"


### PR DESCRIPTION
#1397 -- If inputs contain special characters (e.g. `{{`), they will be mistaken for template parameters.