### PR TITLE
[patch] Updates ocp_verify to display notReady resources in error

### DIFF
--- a/ibm/mas_devops/plugins/action/verify_workloads.py
+++ b/ibm/mas_devops/plugins/action/verify_workloads.py
@@ -98,5 +98,5 @@ class ActionModule(ActionBase):
           )
         else:
           display.v(f"Failure: allResourcesHealthy={allResourcesHealthy}")
-          raise AnsibleError(f"""Error: Below {resourceName} are not healthy:
-                             {'\n'.join(notReady)}""")
+          errorMsg = f"Error: Below {resourceName} are not healthy: {'\n'.join(notReady)}"
+          raise AnsibleError(errorMsg)

--- a/ibm/mas_devops/plugins/action/verify_workloads.py
+++ b/ibm/mas_devops/plugins/action/verify_workloads.py
@@ -98,4 +98,5 @@ class ActionModule(ActionBase):
           )
         else:
           display.v(f"Failure: allResourcesHealthy={allResourcesHealthy}")
-          raise AnsibleError(f"Error: One or more {resourceName} are not healthy")
+          raise AnsibleError(f"Error: Below {resourceName} are not healthy:
+                             {notReady}")

--- a/ibm/mas_devops/plugins/action/verify_workloads.py
+++ b/ibm/mas_devops/plugins/action/verify_workloads.py
@@ -20,7 +20,7 @@ class ActionModule(ActionBase):
         deployments = dynaClient.resources.get(api_version="v1", kind='Deployment')
         sts = dynaClient.resources.get(api_version="v1", kind='StatefulSet')
 
-        depResult = self._checkResources(deployments, "Deployments", 3, 60)
+        depResult = self._checkResources(deployments, "Deployments", retries, delay)
         stsResult = self._checkResources(sts, "StatefulSets", retries, delay)
 
         return dict(

--- a/ibm/mas_devops/plugins/action/verify_workloads.py
+++ b/ibm/mas_devops/plugins/action/verify_workloads.py
@@ -98,5 +98,5 @@ class ActionModule(ActionBase):
           )
         else:
           display.v(f"Failure: allResourcesHealthy={allResourcesHealthy}")
-          raise AnsibleError(f"Error: Below {resourceName} are not healthy:
-                             {notReady}")
+          raise AnsibleError(f"""Error: Below {resourceName} are not healthy:
+                             {'\n'.join(notReady)}""")


### PR DESCRIPTION
### Description:
This PR updates verify_workloads.py to include the name of deployments and statefulsets in the Error message which are not healthy.

### Related Links:
https://jsw.ibm.com/browse/MASCORE-3352

### Testing:
Tested in a fyre cluster: https://dashboard.masdev.wiotp.sl.hursley.ibm.com/tests/core3352/testsuite/ibm-mas-devops/post-install-verify

<img width="1193" alt="Screenshot 2024-08-01 at 16 01 18" src="https://github.com/user-attachments/assets/964456aa-09f6-41e7-86fa-53f0325e0c2d">
