### PR TITLE
[patch] replace deprecated "graph" type with "timeseries" and update the mongo isprimary query on the mongo dashboard

### DIFF
--- a/ibm/mas_devops/roles/kafka/templates/redhat/grafana-json/kafka-exporter.json
+++ b/ibm/mas_devops/roles/kafka/templates/redhat/grafana-json/kafka-exporter.json
@@ -797,7 +797,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -900,7 +900,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -1004,7 +1004,7 @@
           "sort": 2,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -1108,7 +1108,7 @@
           "sort": 2,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",

--- a/ibm/mas_devops/roles/kafka/templates/redhat/grafana-json/kafka-zookeeper.json
+++ b/ibm/mas_devops/roles/kafka/templates/redhat/grafana-json/kafka-zookeeper.json
@@ -277,7 +277,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -548,7 +548,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -646,7 +646,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -744,7 +744,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -844,7 +844,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -941,7 +941,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -1038,7 +1038,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -1135,7 +1135,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -1234,7 +1234,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -1332,7 +1332,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -1430,7 +1430,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -1528,7 +1528,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",

--- a/ibm/mas_devops/roles/kafka/templates/redhat/grafana-json/kafka.json
+++ b/ibm/mas_devops/roles/kafka/templates/redhat/grafana-json/kafka.json
@@ -808,7 +808,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -908,7 +908,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -1008,7 +1008,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -1108,7 +1108,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -1206,7 +1206,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -1304,7 +1304,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -1402,7 +1402,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -1501,7 +1501,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -1975,7 +1975,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -2075,7 +2075,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -2182,7 +2182,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -2288,7 +2288,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -2387,7 +2387,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -2487,7 +2487,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -2587,7 +2587,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -2687,7 +2687,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -2787,7 +2787,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -2886,7 +2886,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",

--- a/ibm/mas_devops/roles/mongodb/templates/community/dashboards/json/mongodb-overview-grafana.json
+++ b/ibm/mas_devops/roles/mongodb/templates/community/dashboards/json/mongodb-overview-grafana.json
@@ -1203,7 +1203,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "mongodb_repl_ismaster{cl_name=~\"$cluster\"}",
+              "expr": "mongodb_repl_isWritablePrimary{cl_name=~\"$cluster\"}",
               "instant": true,
               "interval": "",
               "legendFormat": "{{pod}}",
@@ -1284,7 +1284,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -1386,7 +1386,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -1509,7 +1509,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -1622,7 +1622,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -1725,7 +1725,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -1861,7 +1861,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -1984,7 +1984,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2202,7 +2202,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2309,7 +2309,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2421,7 +2421,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2518,7 +2518,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2615,7 +2615,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2729,7 +2729,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2858,7 +2858,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2970,7 +2970,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -3067,7 +3067,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -3164,7 +3164,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -3276,7 +3276,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -3373,7 +3373,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -3470,7 +3470,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -3567,7 +3567,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -3664,7 +3664,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -3761,7 +3761,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -3898,7 +3898,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -4011,7 +4011,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -4109,7 +4109,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -4207,7 +4207,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -4343,7 +4343,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -4440,7 +4440,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -4537,7 +4537,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -4682,7 +4682,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -4780,7 +4780,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -4892,7 +4892,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -4989,7 +4989,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -5086,7 +5086,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -5191,7 +5191,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -5288,7 +5288,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -5385,7 +5385,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -5497,7 +5497,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -5602,7 +5602,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -5723,7 +5723,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -5844,7 +5844,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -5997,7 +5997,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -6135,7 +6135,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -6241,7 +6241,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -6355,7 +6355,7 @@
             "sort": 2,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",


### PR DESCRIPTION
In grafana 5 several dashboards in Mongo and Kafka roles have deprecation warnings.  The "graph" type has been deprecated and should be replaced with "timeseries".  

In addition, the `mongodb_repl_ismaster` prometheus metric query has been replaced with `mongodb_repl_isWritablePrimary` in recent versions of Mongo.  The Grafana dashboard has been updated accordingly.