### PR TITLE
[patch] Use correct name of k8s_info library

### DIFF
--- a/ibm/mas_devops/roles/suite_manage_customer_files_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_manage_customer_files_config/tasks/main.yml
@@ -36,7 +36,7 @@
 # Wait for ManageWorkspace CR to reconcile and to be ready
 # ---------------------------------------------------------------------------------------------------------------------
 - name: "Wait for ManageWorkspace to be ready (60s delay)"
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     name: "{{ manage_workspace_cr_name }}"
     namespace: "mas-{{ mas_instance_id }}-manage"


### PR DESCRIPTION
Similar verification steps use `kubernetes.core.k8s_info` instead of `community.kubernetes.k8s_info`