### PR TITLE
[patch] Introduce env variable to control walkme setting

### DIFF
--- a/ibm/mas_devops/roles/suite_install/README.md
+++ b/ibm/mas_devops/roles/suite_install/README.md
@@ -91,6 +91,12 @@ When set to `true` will result in the creation of `filebeat-output` Secret in th
 - Environment Variable: `ECK_ENABLE_LOGSTASH`
 - Default: `false`
 
+### mas_enable_walkme
+Boolean variable that indicates whether to enable guided tour.
+
+- Optional
+- Environment Variable: `MAS_ENABLE_WALKME`
+- Default: `true`
 
 Role Variables - Superuser Account
 -------------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/suite_install/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_install/defaults/main.yml
@@ -140,3 +140,7 @@ eck_enable_logstash: "{{ lookup('env', 'ECK_ENABLE_LOGSTASH') | default('false',
 # -----------------------------------------------------------------------------
 mas_superuser_username: "{{ lookup('env', 'MAS_SUPERUSER_USERNAME') }}"
 mas_superuser_password: "{{ lookup('env', 'MAS_SUPERUSER_PASSWORD') }}"
+
+# Configure guided tour
+# -----------------------------------------------------------------------------
+enable_walkme: "{{ lookup('env', 'ENABLE_WALKME') }}"

--- a/ibm/mas_devops/roles/suite_install/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_install/defaults/main.yml
@@ -143,4 +143,4 @@ mas_superuser_password: "{{ lookup('env', 'MAS_SUPERUSER_PASSWORD') }}"
 
 # Configure guided tour
 # -----------------------------------------------------------------------------
-mas_enable_walkme: "{{ lookup('env', 'MAS_ENABLE_WALKME') }}"
+mas_enable_walkme: "{{ lookup('env', 'MAS_ENABLE_WALKME') | default('true', true) | bool }}"

--- a/ibm/mas_devops/roles/suite_install/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_install/defaults/main.yml
@@ -143,4 +143,4 @@ mas_superuser_password: "{{ lookup('env', 'MAS_SUPERUSER_PASSWORD') }}"
 
 # Configure guided tour
 # -----------------------------------------------------------------------------
-enable_walkme: "{{ lookup('env', 'ENABLE_WALKME') }}"
+mas_enable_walkme: "{{ lookup('env', 'MAS_ENABLE_WALKME') }}"

--- a/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
+++ b/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
@@ -76,9 +76,9 @@ spec:
       allowCustomCacheKey: {{ allow_custom_cache_key | bool }}
     {% endif %}
 
-    {% if enable_walkme is defined and enable_walkme != '' %}
-      walkme: {{  enable_walkme  }}
-    {% endif %}
+{% if enable_walkme is defined and enable_walkme != '' %}
+    walkme: {{ enable_walkme }}
+{% endif %}
 
 {% if mas_channel != '8.7.x' and mas_channel != '8.8.x' %}
     manualCertMgmt: {{  mas_manual_cert_mgmt  }}

--- a/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
+++ b/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
@@ -76,6 +76,10 @@ spec:
       allowCustomCacheKey: {{ allow_custom_cache_key | bool }}
     {% endif %}
 
+    {% if enable_walkme is defined and enable_walkme != '' %}
+      walkme: {{  enable_walkme  }}
+    {% endif %}
+
 {% if mas_channel != '8.7.x' and mas_channel != '8.8.x' %}
     manualCertMgmt: {{  mas_manual_cert_mgmt  }}
 {% endif %}

--- a/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
+++ b/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
@@ -76,8 +76,8 @@ spec:
       allowCustomCacheKey: {{ allow_custom_cache_key | bool }}
     {% endif %}
 
-{% if enable_walkme is defined and enable_walkme != '' %}
-    walkme: {{ enable_walkme }}
+{% if mas_enable_walkme is defined and mas_enable_walkme != '' %}
+    walkme: {{ mas_enable_walkme }}
 {% endif %}
 
 {% if mas_channel != '8.7.x' and mas_channel != '8.8.x' %}

--- a/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
+++ b/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
@@ -76,8 +76,8 @@ spec:
       allowCustomCacheKey: {{ allow_custom_cache_key | bool }}
     {% endif %}
 
-{% if mas_enable_walkme is defined and mas_enable_walkme != '' %}
-    walkme: {{ mas_enable_walkme }}
+{% if mas_enable_walkme is defined and mas_enable_walkme == false %}
+    walkme: "disabled"
 {% endif %}
 
 {% if mas_channel != '8.7.x' and mas_channel != '8.8.x' %}


### PR DESCRIPTION
There is a system setting for "Guided Tours" (spec->settings->walkme) in Suite CR. It is enabled by default and can be configured from the admin UI. Due to the pop of "what's new" some of the UI test cases from Manage are failing, hence, that needs to be turned off for all fvt environments by default. As a fix, an environment variable (MAS_ENABLE_WALKME) has been introduced to control the 'walkme' setting. FVT pipelines need to use this env to disable the setting. 

Testing: Changes have been tested locally as well as on the pfvt (fyre-envs) env.

Bug details and snap shots of the FVT run can be found here: MASCORE-3444