### PR TITLE
[patch] Return empty list if no certs in manage_certificates

### DIFF
--- a/ibm/mas_devops/roles/suite_manage_import_certs_config/templates/imported-certs.yml.j2
+++ b/ibm/mas_devops/roles/suite_manage_import_certs_config/templates/imported-certs.yml.j2
@@ -2,4 +2,6 @@
 - alias: "{{ manage_certificates_aliases[loop.index0] | default(manage_certificates_alias_prefix+(loop.index - existing_manage_imported_certs_aliases | length)|string) }}"
   crt: |- 
     {{ cert | indent(4) }}
+{% else %}
+[]
 {% endfor %}


### PR DESCRIPTION
Patch for #1419 -- if no imported certs (I suspect because we use LetsEncrypt?), return an empty list instead of an empty string (invalid type).