### PR TITLE
[patch] Optimize Db2 image mirroring

### DIFF
--- a/ibm/mas_devops/playbooks/mirror_dependencies.yml
+++ b/ibm/mas_devops/playbooks/mirror_dependencies.yml
@@ -444,6 +444,7 @@
       vars:
         manifest_name: "ibm-db2uoperator"
         manifest_version: "{{ db2u_version }}"
+        mirror_single_arch: amd64
 
     - name: ibm.mas_devops.mirror_extras_prepare
       when:

--- a/ibm/mas_devops/roles/mirror_images/defaults/main.yml
+++ b/ibm/mas_devops/roles/mirror_images/defaults/main.yml
@@ -31,3 +31,5 @@ mirror_working_dir: "{{ lookup('env', 'MIRROR_WORKING_DIR') }}"
 manifest_name: "{{ lookup('env', 'MANIFEST_NAME') }}"
 manifest_version: "{{ lookup('env', 'MANIFEST_VERSION') }}"
 auth_file: "{{ ansible_env.HOME }}/.ibm-mas/auth.json"
+
+mirror_single_arch: "{{ lookup('env', 'MIRROR_SINGLE_ARCH') }}"

--- a/ibm/mas_devops/roles/mirror_images/tasks/main.yml
+++ b/ibm/mas_devops/roles/mirror_images/tasks/main.yml
@@ -42,21 +42,21 @@
     that: mirror_single_arch in ["", "amd64", "ppc64le", "s390x"]
 
 - name: Set up exclusion rules for amd64
-  when: mirror_single_arch == amd64
+  when: mirror_single_arch == "amd64"
   set_fact:
     exclude_arch:
       - s390x
       - ppc64le
 
 - name: Set up exclusion rules for ppc64le
-  when: mirror_single_arch == ppc64le
+  when: mirror_single_arch == "ppc64le"
   set_fact:
     exclude_arch:
       - s390x
       - amd64
 
 - name: Set up exclusion rules for s390x
-  when: mirror_single_arch == s390x
+  when: mirror_single_arch == "s390x"
   set_fact:
     exclude_arch:
       - amd64
@@ -67,7 +67,7 @@
   ansible.builtin.lineinfile:
     path: "{{ mirror_working_dir }}/manifests/to-filesystem/{{ manifest_name }}_{{ manifest_version }}.txt"
     state: absent
-    regexp: '-{{ arch }}$'
+    regexp: '-{{ item }}$'
     backup: true
   with_items: "{{ exclude_arch }}"
 

--- a/ibm/mas_devops/roles/mirror_images/tasks/main.yml
+++ b/ibm/mas_devops/roles/mirror_images/tasks/main.yml
@@ -65,11 +65,21 @@
 - name: "Remove any container images with a tag ending in '-{arch}'"
   when: mirror_single_arch in ["amd64", "ppc64le", "s390x"]
   ansible.builtin.lineinfile:
-    path: "{{ mirror_working_dir }}/manifests/to-filesystem/{{ manifest_name }}_{{ manifest_version }}.txt"
+    path: "{{ mirror_working_dir }}/manifests/{{ mirror_mode }}/{{ manifest_name }}_{{ manifest_version }}.txt"
     state: absent
     regexp: '-{{ item }}$'
     backup: true
   with_items: "{{ exclude_arch }}"
+
+# Special case for Db2u
+# https://github.com/ibm-mas/ansible-devops/issues/1075
+- name: "Remove CP4D Db2u images (11.5.8.0)"
+  when: manifest_name == "ibm-db2uoperator"
+  ansible.builtin.lineinfile:
+    path: "{{ mirror_working_dir }}/manifests/{{ mirror_mode }}/{{ manifest_name }}_{{ manifest_version }}.txt"
+    state: absent
+    regexp: '11.5.8.0'
+    backup: true
 
 
 # 4A. Execute the mirror (to filesystem)

--- a/ibm/mas_devops/roles/mirror_images/tasks/main.yml
+++ b/ibm/mas_devops/roles/mirror_images/tasks/main.yml
@@ -10,6 +10,16 @@
       - mirror_working_dir is defined and mirror_working_dir != ""
     fail_msg: "One or more required properties are missing"
 
+- name: "{{ manifest_name }} : Debug"
+  debug:
+    msg:
+      - "Manifest Name .......................... {{ manifest_name }}"
+      - "Manifest Version ....................... {{ manifest_version }}"
+      - "Mirror Single Architecture ............. {{ mirror_single_arch | default('<not set>', True) }}"
+      - "Working Directory ...................... {{ mirror_working_dir }}"
+      - "Mode ................................... {{ mirror_mode }}"
+      - "Auth File .............................. {{ auth_file }}"
+
 
 # 2. Set up auth secret
 # -----------------------------------------------------------------------------
@@ -24,17 +34,45 @@
     dest: "{{ auth_file }}"
   no_log: true
 
-- name: "{{ manifest_name }} : Debug"
-  debug:
-    msg:
-      - "Manifest Name .......................... {{ manifest_name }}"
-      - "Manifest Version ....................... {{ manifest_version }}"
-      - "Working Directory ...................... {{ mirror_working_dir }}"
-      - "Mode ................................... {{ mirror_mode }}"
-      - "Auth File .............................. {{ auth_file }}"
+
+# 3. Modify the manifest
+# -----------------------------------------------------------------------------
+- name: Validate that mirror_single_arch is correctly set
+  assert:
+    that: mirror_single_arch in ["", "amd64", "ppc64le", "s390x"]
+
+- name: Set up exclusion rules for amd64
+  when: mirror_single_arch == amd64
+  set_fact:
+    exclude_arch:
+      - s390x
+      - ppc64le
+
+- name: Set up exclusion rules for ppc64le
+  when: mirror_single_arch == ppc64le
+  set_fact:
+    exclude_arch:
+      - s390x
+      - amd64
+
+- name: Set up exclusion rules for s390x
+  when: mirror_single_arch == s390x
+  set_fact:
+    exclude_arch:
+      - amd64
+      - ppc64le
+
+- name: "Remove any container images with a tag ending in '-{arch}'"
+  when: mirror_single_arch in ["amd64", "ppc64le", "s390x"]
+  ansible.builtin.lineinfile:
+    path: "{{ mirror_working_dir }}/manifests/to-filesystem/{{ manifest_name }}_{{ manifest_version }}.txt"
+    state: absent
+    regexp: '-{{ arch }}$'
+    backup: true
+  with_items: "{{ exclude_arch }}"
 
 
-# 3A. Execute the mirror (to filesystem)
+# 4A. Execute the mirror (to filesystem)
 # -----------------------------------------------------------------------------
 - name: "{{ manifest_name }} : Mirror Images to local filesystem"
   when: mirror_mode == "to-filesystem"
@@ -65,7 +103,7 @@
         fail_msg: "Image mirroring failed (see debug information above)."
 
 
-# 3B. Execute the mirror (from filesystem)
+# 4B. Execute the mirror (from filesystem)
 # -----------------------------------------------------------------------------
 - name: "{{ manifest_name }} : Mirror Images from local filesystem"
   when: mirror_mode == "from-filesystem"
@@ -96,7 +134,7 @@
         fail_msg: "Image mirroring failed (see debug information above)."
 
 
-# 3C. Execute the mirror (direct)
+# 4C. Execute the mirror (direct)
 # -----------------------------------------------------------------------------
 - name: "Mirror Images directly"
   when: mirror_mode == "direct"


### PR DESCRIPTION
This update reduces the size of the content mirrored for IBM Db2u from 78G to 40G by removing the non-amd64 images from the manifest generated by `ibm-pak`

```
mas mirror-images -m to-filesystem -d /pvc/mirror/db2-amd64only --no-confirm \
  -H $REGISTRY_PRIVATE_HOST -P $REGISTRY_PRIVATE_PORT -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD \
  --ibm-entitlement $IBM_ENTITLEMENT_KEY \
  -c v9-240730-amd64 -C 9.0.x \
  --mirror-db2
```
## Before
```
[ibmmas/cli:10.7.1]mascli$ du -hs /pvc/mirror/db2
78G     /pvc/mirror/db2
```

## After
```
[ibmmas/cli:10.7.1]mascli$ du -hs /pvc/mirror/db2-amd64only2
40G     /pvc/mirror/db2-amd64only2
```

## Removal of 11.5.8.0 Operand Images
Additionally, we have removed mirroring of the **11.5.8.0** operand images, to further reduce the size of the mirrored content to **24G**:

```
du -hs /pvc/mirror/db2-amd64only3
24G     /pvc/mirror/db2-amd64only3
```

The final processed manifest looks like this:
```
cat /pvc/mirror/db2-amd64only3/manifests/to-filesystem/ibm-db2uoperator_5.6.2.txt
icr.io/cpopen/db2u-day2-operator@sha256:44ef9e295426072db5a29caef0ace8722003c800d78ce77f1f3d29cdd9ad6b3a=file:///cpopen/db2u-day2-operator:5.6.1-8110-dev
icr.io/cpopen/db2u-day2-operator@sha256:fafd92d6f5c76b224d83e1292adb6290801d1d792c696955b489c973043912e1=file:///cpopen/db2u-day2-operator:5.6.2-8325-dev
icr.io/cpopen/db2u-operator@sha256:1c4d69c37e32192bf5c70d9525c32a89a1aaf6bd9b5fb256eb4be48281451a6d=file:///cpopen/db2u-operator:5.6.1-8110-dev
icr.io/cpopen/db2u-operator@sha256:d661782d263d22a8b7464dc4940620eaa4b5cb30a3cc6be16dbc1a3469011f52=file:///cpopen/db2u-operator:5.6.2-8325-dev
icr.io/cpopen/ibm-db2uoperator-bundle@sha256:0d946eccdfe935e9e774045c2277506faa1596bf6ab55202a6e31a8271eb1bfa=file:///cpopen/ibm-db2uoperator-bundle:5.6.2-8325-dev
icr.io/cpopen/ibm-db2uoperator-bundle@sha256:a33f934c483bdf904f896ddf0bbdf3cce99bc1170271fb9b696a01793b22c984=file:///cpopen/ibm-db2uoperator-bundle:5.6.1-8110-dev
icr.io/cpopen/ibm-db2uoperator-catalog@sha256:278fa6bbaa834faa4a0ec522cd85a301a088e610d8f5a74d7981f172d30cd5d4=file:///cpopen/ibm-db2uoperator-catalog:8110-dev
icr.io/cpopen/ibm-db2uoperator-catalog@sha256:fd7242e7a42f9b952af4d1db2b67878820352a5c1ce946637c9b954170c412f2=file:///cpopen/ibm-db2uoperator-catalog:8325-dev
icr.io/db2u/db2u.auxiliary.auth@sha256:90d80d10fa6573ea466512a3fc88c9f80ccb67f4d188206fa515b15993c56a96=file:///db2u/db2u.auxiliary.auth:s11.5.9.0-cn1-90-amd64
icr.io/db2u/db2u.db2wh@sha256:0886ee44e500e571ffcb47a82701b616da94feb9ff9eb2c0582a0852c30194fa=file:///db2u/db2u.db2wh:s11.5.9.0-cn1-90-amd64
icr.io/db2u/db2u.db2wh@sha256:f98bd7cdb4d2f22a412c9cf4aa8b1755f6b1866bc75448f0de87a4ce82c21eef=file:///db2u/db2u.db2wh:oaas-81-dev-amd64
icr.io/db2u/db2u.dv.api@sha256:621f1226c0041ec8961a219e804abb6b45a0b9332a9dc2dcdb216549035ee9b5=file:///db2u/db2u.dv.api:s11.5.9.0-cn1-90-amd64
icr.io/db2u/db2u.dv.caching@sha256:86be7fd023978bfaa922da408d457d864a0ad353d18cd07770f28a5b924fe41b=file:///db2u/db2u.dv.caching:s11.5.9.0-cn1-90-amd64
icr.io/db2u/db2u.dv.utils@sha256:79258a4b20e4063109e943c7f0aedb513bb837ddcd7dfb2ce72e9d1d598b2bb9=file:///db2u/db2u.dv.utils:s11.5.9.0-cn1-90-amd64
icr.io/db2u/db2u.hurricane@sha256:c28133ed6c25c163b5c63957773f7ff3375874f7a40bec9d3579bfc1349a78eb=file:///db2u/db2u.hurricane:s11.5.9.0-cn1-90-amd64
icr.io/db2u/db2u.instdb.restricted@sha256:a78c2c6f7b43e857554e1eed21a9d1fd41202559cb9e4231d975c48c0eb7075b=file:///db2u/db2u.instdb.restricted:s11.5.9.0-cn1-90-amd64
icr.io/db2u/db2u.instdb@sha256:cf2f99358fb6beac6ca2f9553855b8f33d4cfcd7748bd191c66b725180722cab=file:///db2u/db2u.instdb:s11.5.9.0-cn1-90-amd64
icr.io/db2u/db2u.instdb@sha256:de758e938d592256879d55449f07c7dabbc93d123d56ef99328bb41abdbcf34b=file:///db2u/db2u.instdb:oaas-81-dev-amd64
icr.io/db2u/db2u.logstreaming.fluentd@sha256:55fbd2c1938cb0f735e32a8385748b702c38c3e41c83cb44e8b3d5e41b685269=file:///db2u/db2u.logstreaming.fluentd:s11.5.9.0-cn1-90-amd64
icr.io/db2u/db2u.mustgather@sha256:a8a5f6ab563a7fbd93f22ee2eda3a2250c297c67011a1aadb46d6c68482535a3=file:///db2u/db2u.mustgather:s11.5.9.0-cn1-90-amd64
icr.io/db2u/db2u.qrep@sha256:c1121abab93abee6cf1d27019a2ba4ac2b8f7ade980207713054b184812d6d65=file:///db2u/db2u.qrep:s11.5.9.0-cn1-90-amd64
icr.io/db2u/db2u.rest@sha256:7cda76f07c2d6ced608befb3a4cf6f88c3318bb3a54d02e6b3c6c03f8abf92d2=file:///db2u/db2u.rest:s11.5.9.0-cn1-90-amd64
icr.io/db2u/db2u.restricted@sha256:afd250032aef39549f43d992a487a9d7b004f074e2cce3d8aadf6a8f327cecfb=file:///db2u/db2u.restricted:s11.5.9.0-cn1-90-amd64
icr.io/db2u/db2u.tools@sha256:290532cb23d45a246dad7bca1aa761407480a3423f645800f5aa6ca1dedd863d=file:///db2u/db2u.tools:s11.5.9.0-cn1-90-amd64
icr.io/db2u/db2u.update.image@sha256:68cac0eb685747dbad88cb160ea859298bd3a86c3d31a2ddd6b2da28180e56fc=file:///db2u/db2u.update.image:s11.5.9.0-cn1-90-amd64
icr.io/db2u/db2u.veleroplugin@sha256:01369d5f1da84f5ceb170c9bb9287e4fdac1dd39f30515b6a13ae37c1f38c559=file:///db2u/db2u.veleroplugin:s11.5.9.0-cn1-90-amd64
icr.io/db2u/db2u.watsonquery@sha256:e1c9542fd5a6ea90b7a265d823e348aaba669545f817f47ce7076dc5753963fe=file:///db2u/db2u.watsonquery:s11.5.9.0-cn1-90-amd64
icr.io/db2u/db2u@sha256:793e05f77076e8e1e055c738e90c9706d582c7da286e908955504842f844ce06=file:///db2u/db2u:s11.5.9.0-cn1-90-amd64
icr.io/db2u/etcd@sha256:bc137c50b206ca67994ece07ca41f65454e056835ebb7320bc01b14e5e5f16a2=file:///db2u/etcd:3.4.14-65-amd64
icr.io/db2u/etcd@sha256:d1dd2eae940427ff7bcd40506cc2181f3fc7826d48dbbb3a4bc3349a2d8c2f93=file:///db2u/etcd:3.4.14-90-amd64
```