### PR TITLE
[patch] fix gpu-operator-certified mirror error by using default v24.6 channel

### DIFF
--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -27,10 +27,10 @@ mirror:
         - name: gpu-operator-certified  # Required by ibm.mas_devops.nvidia_gpu role
           channels:
             - name: v23.3
-            # We don't use the v24.3 channel, but oc-mirror fails when the default channel is not included
+            # We don't use the v24.6 channel, but oc-mirror fails when the default channel is not included
             # - https://access.redhat.com/solutions/7013461
             # - https://issues.redhat.com/browse/OCPBUGS-385
-            - name: v24.3
+            - name: v24.6
         - name: kubeturbo-certified  # Required by ibm.mas_devops.kubeturbo role
           channels:
             - name: stable


### PR DESCRIPTION
Ref: https://github.com/ibm-mas/ansible-devops/pull/1297/files

https://ibm-watson-iot.slack.com/archives/C031Q7W21FZ/p1724134258818859