### PR TITLE
[patch] restart cpd pods if they fail during installation

### DIFF
--- a/ibm/mas_devops/roles/cp4d/tasks/install-cp4d.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/install-cp4d.yml
@@ -151,6 +151,15 @@
       retries: 20 # Approximately 20 minutes before we give up
       delay: 60 # 1 minute
 
+# 3-pre. Wait for Zen Metastore Cluster  to be ready
+# -----------------------------------------------------------------------------
+# There have been issues with Zen Metastore Cluster not starting due to Persistent Storage,
+# This task restarts any failing pods
+- name: "install-cp4d : Wait for zen-metadata to be ready again (60s delay)"
+  include_tasks: "tasks/wait/wait-zenmetastore-edb.yml"
+  when:
+    - cpd_48_or_higher
+
 # 3. Wait for zenStatus
 # -----------------------------------------------------------------------------
 # oc get ZenService lite-cr -o jsonpath="{.status.zenStatus}{'\n'}"

--- a/ibm/mas_devops/roles/cp4d/tasks/wait/wait-zenmetastore-edb.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/wait/wait-zenmetastore-edb.yml
@@ -1,0 +1,105 @@
+---
+# 1. Wait for zen metastore cluster to start
+# -----------------------------------------------------------------------------
+- name: wait for Zen Metastore EDB Cluster to be created
+  k8s_info:
+    kind: Cluster
+    namespace: "{{ cpd_instance_namespace }}"
+    name: "zen-metastore-edb"
+  register: zenmetastoreCluster
+  retries: 120 # Give 60 minutes for the zenService to start Zen Metastore Pods (Logs show this taking ~20 minutes in a good run)
+  delay: 30
+  until: zenmetastoreCluster.resources[0].status is defined
+
+# 2. Wait for zen metastore replica pods to become ready
+# -----------------------------------------------------------------------------
+- name: wait for ZenMetastore pods to be become ready
+  k8s_info:
+    kind: Cluster
+    namespace: "{{ cpd_instance_namespace }}"
+    name: "zen-metastore-edb"
+  register: zenmetastoreCluster
+  retries: 40 # Give 20 minutes for the pods to become ready
+  delay: 30
+  until: >-
+    zenmetastoreCluster.resources[0].spec.instances is defined 
+    and zenmetastoreCluster.resources[0].status.readyInstances is defined 
+    and zenmetastoreCluster.resources[0].spec.instances == zenmetastoreCluster.resources[0].status.readyInstances
+  #ignore-errors: true # If this fails then we restart pending pods below
+  failed_when: false
+  
+# 2. Restart any ZenMetastore pods that are still Pending
+# -----------------------------------------------------------------------------
+- set_fact:
+    is_zenmetastore_ready: true
+  when:
+    zenmetastoreCluster.resources[0].spec.instances is defined 
+    and zenmetastoreCluster.resources[0].status.readyInstances is defined 
+    and zenmetastoreCluster.resources[0].spec.instances == zenmetastoreCluster.resources[0].status.readyInstances
+
+- name: Detecting and restarting pending ZenMetastore Pods
+  when: is_zenmetastore_ready is not defined
+  block:
+    - name: "install-cp4d : Get pending ZenMetastore Pods"
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Pod
+        label_selectors:
+          - "app.kubernetes.io/component=zen-metastore-edb"
+        field_selectors:
+          - "status.phase=Pending"
+        namespace: "{{ cpd_instance_namespace }}"
+      register: pending_pod_lookup
+
+    - name: "Get and set variables to store the lists"
+      set_fact:
+        pending_pod_names: "{{ pending_pod_lookup.resources | map(attribute='metadata.name') }}"
+
+    - debug:
+        msg: "Restarting pending ZenMetastore Pods: {{ pending_pod_names }}"
+
+    - name: Restarting pending ZenMetastore Pods
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Pod
+        namespace: "{{ cpd_instance_namespace }}" 
+        name: "{{ item }}"
+      loop: "{{ pending_pod_names }}"
+
+    # 3. Wait again zenmetastore replica pods to become ready
+    # -----------------------------------------------------------------------------
+    - name: wait for ZenMetastore pods to be become ready
+      k8s_info:
+        kind: Cluster
+        namespace: "{{ cpd_instance_namespace }}"
+        name: "zen-metastore-edb"
+      register: zenmetastoreCluster
+      retries: 40 # Give another 20 minutes for the pods to become ready
+      delay: 30
+      until: >-
+        zenmetastoreCluster.resources[0].spec.instances is defined 
+        and zenmetastoreCluster.resources[0].status.readyInstances is defined 
+        and zenmetastoreCluster.resources[0].spec.instances == zenmetastoreCluster.resources[0].status.readyInstances
+      failed_when: false # We handle and log the failure below.
+
+    - name: "Fail if ZenMetastore pods are not ready"
+      block: 
+        - name: "install-cp4d : Get Pending ZenMetastore Pods"
+          kubernetes.core.k8s_info:
+            api_version: v1
+            kind: Pod
+            label_selectors:
+              - "app.kubernetes.io/component=zen-metastore-edb"
+            field_selectors:
+              - "status.phase=Pending"
+            namespace: "{{ cpd_instance_namespace }}"
+          register: pending_pod_lookup
+
+        - fail:
+            msg:
+              - "ZenMetastore pods are not ready Instances required: {{ zenmetastoreCluster.resources[0].spec.instances }}, ready: {{ zenmetastoreCluster.resources[0].status.readyInstances }}"
+              - "Pending ZenMetastore Pods: {{ pending_pod_lookup.resources | map(attribute='metadata.name') }}"
+      when: 
+        zenmetastoreCluster.resources[0].spec.instances != zenmetastoreCluster.resources[0].status.readyInstances
+

--- a/ibm/mas_devops/roles/cp4d/tasks/wait/wait-zenmetastore-edb.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/wait/wait-zenmetastore-edb.yml
@@ -22,19 +22,19 @@
   retries: 40 # Give 20 minutes for the pods to become ready
   delay: 30
   until: >-
-    zenmetastoreCluster.resources[0].spec.instances is defined 
-    and zenmetastoreCluster.resources[0].status.readyInstances is defined 
+    zenmetastoreCluster.resources[0].spec.instances is defined
+    and zenmetastoreCluster.resources[0].status.readyInstances is defined
     and zenmetastoreCluster.resources[0].spec.instances == zenmetastoreCluster.resources[0].status.readyInstances
   #ignore-errors: true # If this fails then we restart pending pods below
   failed_when: false
-  
+
 # 2. Restart any ZenMetastore pods that are still Pending
 # -----------------------------------------------------------------------------
 - set_fact:
     is_zenmetastore_ready: true
   when:
-    zenmetastoreCluster.resources[0].spec.instances is defined 
-    and zenmetastoreCluster.resources[0].status.readyInstances is defined 
+    zenmetastoreCluster.resources[0].spec.instances is defined
+    and zenmetastoreCluster.resources[0].status.readyInstances is defined
     and zenmetastoreCluster.resources[0].spec.instances == zenmetastoreCluster.resources[0].status.readyInstances
 
 - name: "wait-zenmetastore-edb : Detecting and restarting pending ZenMetastore Pods"
@@ -62,7 +62,7 @@
         state: absent
         api_version: v1
         kind: Pod
-        namespace: "{{ cpd_instance_namespace }}" 
+        namespace: "{{ cpd_instance_namespace }}"
         name: "{{ item }}"
       loop: "{{ pending_pod_names }}"
 
@@ -77,13 +77,13 @@
       retries: 40 # Give another 20 minutes for the pods to become ready
       delay: 30
       until: >-
-        zenmetastoreCluster.resources[0].spec.instances is defined 
-        and zenmetastoreCluster.resources[0].status.readyInstances is defined 
+        zenmetastoreCluster.resources[0].spec.instances is defined
+        and zenmetastoreCluster.resources[0].status.readyInstances is defined
         and zenmetastoreCluster.resources[0].spec.instances == zenmetastoreCluster.resources[0].status.readyInstances
       failed_when: false # We handle and log the failure below.
 
     - name: "wait-zenmetastore-edb : Fail if ZenMetastore pods are not ready"
-      block: 
+      block:
         - name: "install-cp4d : Get Pending ZenMetastore Pods"
           kubernetes.core.k8s_info:
             api_version: v1
@@ -99,6 +99,5 @@
             msg:
               - "ZenMetastore pods are not ready Instances required: {{ zenmetastoreCluster.resources[0].spec.instances }}, ready: {{ zenmetastoreCluster.resources[0].status.readyInstances }}"
               - "Pending ZenMetastore Pods: {{ pending_pod_lookup.resources | map(attribute='metadata.name') }}"
-      when: 
+      when:
         zenmetastoreCluster.resources[0].spec.instances != zenmetastoreCluster.resources[0].status.readyInstances
-

--- a/ibm/mas_devops/roles/cp4d/tasks/wait/wait-zenmetastore-edb.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/wait/wait-zenmetastore-edb.yml
@@ -1,7 +1,7 @@
 ---
 # 1. Wait for zen metastore cluster to start
 # -----------------------------------------------------------------------------
-- name: wait for Zen Metastore EDB Cluster to be created
+- name: "wait-zenmetastore-edb : Wait for Zen Metastore EDB Cluster to be created"
   k8s_info:
     kind: Cluster
     namespace: "{{ cpd_instance_namespace }}"
@@ -13,7 +13,7 @@
 
 # 2. Wait for zen metastore replica pods to become ready
 # -----------------------------------------------------------------------------
-- name: wait for ZenMetastore pods to be become ready
+- name: "wait-zenmetastore-edb : Wait for ZenMetastore pods to be become ready"
   k8s_info:
     kind: Cluster
     namespace: "{{ cpd_instance_namespace }}"
@@ -37,7 +37,7 @@
     and zenmetastoreCluster.resources[0].status.readyInstances is defined 
     and zenmetastoreCluster.resources[0].spec.instances == zenmetastoreCluster.resources[0].status.readyInstances
 
-- name: Detecting and restarting pending ZenMetastore Pods
+- name: "wait-zenmetastore-edb : Detecting and restarting pending ZenMetastore Pods"
   when: is_zenmetastore_ready is not defined
   block:
     - name: "install-cp4d : Get pending ZenMetastore Pods"
@@ -51,14 +51,13 @@
         namespace: "{{ cpd_instance_namespace }}"
       register: pending_pod_lookup
 
-    - name: "Get and set variables to store the lists"
-      set_fact:
+    - set_fact:
         pending_pod_names: "{{ pending_pod_lookup.resources | map(attribute='metadata.name') }}"
 
     - debug:
         msg: "Restarting pending ZenMetastore Pods: {{ pending_pod_names }}"
 
-    - name: Restarting pending ZenMetastore Pods
+    - name: "wait-zenmetastore-edb : Restarting pending ZenMetastore Pods"
       kubernetes.core.k8s:
         state: absent
         api_version: v1
@@ -69,7 +68,7 @@
 
     # 3. Wait again zenmetastore replica pods to become ready
     # -----------------------------------------------------------------------------
-    - name: wait for ZenMetastore pods to be become ready
+    - name: "wait-zenmetastore-edb : Wait for ZenMetastore pods to be become ready"
       k8s_info:
         kind: Cluster
         namespace: "{{ cpd_instance_namespace }}"
@@ -83,7 +82,7 @@
         and zenmetastoreCluster.resources[0].spec.instances == zenmetastoreCluster.resources[0].status.readyInstances
       failed_when: false # We handle and log the failure below.
 
-    - name: "Fail if ZenMetastore pods are not ready"
+    - name: "wait-zenmetastore-edb : Fail if ZenMetastore pods are not ready"
       block: 
         - name: "install-cp4d : Get Pending ZenMetastore Pods"
           kubernetes.core.k8s_info:

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-ccs.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-ccs.yml
@@ -100,7 +100,7 @@
     - cpd_48_or_higher # elastic search operator was just introduced with cpd 4.8
     - not skip_ibm_entitlement_injection # eventually we hope to be able to skip patching the elastic search cr with image pull secret, but not for now
 
-# 5. Wait for CouchDB SS to be ready
+# 5. Wait for CouchDB Stateful Set to be ready
 # -----------------------------------------------------------------------------
 # There have been issues with CouchDB not starting due to Persistent Storage,
 # This task restarts any failing pods

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-ccs.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-ccs.yml
@@ -100,7 +100,16 @@
     - cpd_48_or_higher # elastic search operator was just introduced with cpd 4.8
     - not skip_ibm_entitlement_injection # eventually we hope to be able to skip patching the elastic search cr with image pull secret, but not for now
 
-# 5. Wait for CCS CR to be ready
+# 5. Wait for CouchDB SS to be ready
+# -----------------------------------------------------------------------------
+# There have been issues with CouchDB not starting due to Persistent Storage,
+# This task restarts any failing pods
+- include_tasks: "tasks/wait/wait-couchdb.yml"
+  when:
+    - cpd_48_or_higher
+
+
+# 6. Wait for CCS CR to be ready
 # -----------------------------------------------------------------------------
 # Note: We can't fail early when we see Failed status, as the operator will
 # report failed multiple times during initial reconcile.

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-couchdb.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-couchdb.yml
@@ -14,7 +14,7 @@
     and couchdbStatefulSet.resources[0].status.replicas is defined
     and couchdbStatefulSet.resources[0].status.replicas == 0 )
     or ( couchdbStatefulSet.resources[0].status is defined
-    and couchdbStatefulSet.resources[0].status.updatedReplicas is defined 
+    and couchdbStatefulSet.resources[0].status.updatedReplicas is defined
     and couchdbStatefulSet.resources[0].status.replicas == couchdbStatefulSet.resources[0].status.updatedReplicas ))
 
 
@@ -29,17 +29,17 @@
   retries: 10 # Give 5 minutes for the pods to become ready
   delay: 30
   until: >-
-    couchdbStatefulSet.resources[0].status.readyReplicas is defined 
+    couchdbStatefulSet.resources[0].status.readyReplicas is defined
     and couchdbStatefulSet.resources[0].status.replicas == couchdbStatefulSet.resources[0].status.readyReplicas
   #ignore-errors: true # If this fails then we restart pending pods below
   failed_when: false
-  
+
 # 2. Restart any couchDB pods that are still Pending
 # -----------------------------------------------------------------------------
 - set_fact:
     is_couchdb_ready: true
   when:
-    couchdbStatefulSet.resources[0].status.readyReplicas is defined 
+    couchdbStatefulSet.resources[0].status.readyReplicas is defined
     and couchdbStatefulSet.resources[0].status.replicas == couchdbStatefulSet.resources[0].status.readyReplicas
 
 - name: "wait-couchdb: Detecting and restarting pending CouchDB Pods"
@@ -66,7 +66,7 @@
         state: absent
         api_version: v1
         kind: Pod
-        namespace: "{{ cpd_instance_namespace }}" 
+        namespace: "{{ cpd_instance_namespace }}"
         name: "{{ item }}"
       loop: "{{ pending_pod_names }}"
 
@@ -81,12 +81,12 @@
       retries: 10 # Give another 5 minutes for the pods to become ready
       delay: 30
       until: >-
-        couchdbStatefulSet.resources[0].status.readyReplicas is defined 
+        couchdbStatefulSet.resources[0].status.readyReplicas is defined
         and couchdbStatefulSet.resources[0].status.replicas == couchdbStatefulSet.resources[0].status.readyReplicas
       failed_when: false # We handle and log the failure below.
 
     - name: "wait-couchdb: Fail if CouchDB pods are not ready"
-      block: 
+      block:
         - name: "install-cp4d : Get Pending CouchDB Pods"
           kubernetes.core.k8s_info:
             api_version: v1
@@ -102,7 +102,7 @@
             msg:
               - "CouchDB pods are not ready {{ couchdbStatefulSet.resources[0].status }}"
               - "Pending CouchDB Pods: {{ pending_pod_lookup.resources | map(attribute='metadata.name') }}"
-      when: 
+      when:
         couchdbStatefulSet.resources[0].status.replicas != couchdbStatefulSet.resources[0].status.readyReplicas
 
   when: is_couchdb_ready is not defined

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-couchdb.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-couchdb.yml
@@ -1,0 +1,109 @@
+---
+# 1. Wait for couch-db stateful set to start all the replica pods
+# -----------------------------------------------------------------------------
+- name: wait for CouchDB pods to be created
+  k8s_info:
+    kind: StatefulSet
+    namespace: "{{ cpd_instance_namespace }}"
+    name: "wdp-couchdb"
+  register: couchdbStatefulSet
+  retries: 40 # Give 20 minutes for the ccs Operator to start CouchDB Pods (Logs show this taking ~7 minutes in a good run)
+  delay: 30
+  until: >-
+    (( couchdbStatefulSet.resources[0].status is defined
+    and couchdbStatefulSet.resources[0].status.replicas is defined
+    and couchdbStatefulSet.resources[0].status.replicas == 0 )
+    or ( couchdbStatefulSet.resources[0].status is defined
+    and couchdbStatefulSet.resources[0].status.updatedReplicas is defined 
+    and couchdbStatefulSet.resources[0].status.replicas == couchdbStatefulSet.resources[0].status.updatedReplicas ))
+
+
+# 2. Wait for couchdb replica pods to become ready
+# -----------------------------------------------------------------------------
+- name: wait for CouchDB pods to be become ready
+  k8s_info:
+    kind: StatefulSet
+    namespace: "{{ cpd_instance_namespace }}"
+    name: "wdp-couchdb"
+  register: couchdbStatefulSet
+  retries: 10 # Give 5 minutes for the pods to become ready
+  delay: 30
+  until: >-
+    couchdbStatefulSet.resources[0].status.readyReplicas is defined 
+    and couchdbStatefulSet.resources[0].status.replicas == couchdbStatefulSet.resources[0].status.readyReplicas
+  #ignore-errors: true # If this fails then we restart pending pods below
+  failed_when: false
+  
+# 2. Restart any couchDB pods that are still Pending
+# -----------------------------------------------------------------------------
+- set_fact:
+    is_couchdb_ready: true
+  when:
+    couchdbStatefulSet.resources[0].status.readyReplicas is defined 
+    and couchdbStatefulSet.resources[0].status.replicas == couchdbStatefulSet.resources[0].status.readyReplicas
+
+- name: Detecting and restarting pending CouchDB Pods
+  block:
+    - name: "install-cp4d : Get pending CouchDB Pods"
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Pod
+        label_selectors:
+          - "app=couchdb"
+        field_selectors:
+          - "status.phase=Pending"
+        namespace: "{{ cpd_instance_namespace }}"
+      register: pending_pod_lookup
+
+    - name: "Get and set variables to store the lists"
+      set_fact:
+        pending_pod_names: "{{ pending_pod_lookup.resources | map(attribute='metadata.name') }}"
+
+    - debug:
+        msg: "Restarting pending CouchDB Pods: {{ pending_pod_names }}"
+
+    - name: Restarting pending CouchDB Pods
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Pod
+        namespace: "{{ cpd_instance_namespace }}" 
+        name: "{{ item }}"
+      loop: "{{ pending_pod_names }}"
+
+    # 3. Wait again couchdb replica pods to become ready
+    # -----------------------------------------------------------------------------
+    - name: wait for CouchDB pods to be become ready
+      k8s_info:
+        kind: StatefulSet
+        namespace: "{{ cpd_instance_namespace }}"
+        name: "wdp-couchdb"
+      register: couchdbStatefulSet
+      retries: 10 # Give another 5 minutes for the pods to become ready
+      delay: 30
+      until: >-
+        couchdbStatefulSet.resources[0].status.readyReplicas is defined 
+        and couchdbStatefulSet.resources[0].status.replicas == couchdbStatefulSet.resources[0].status.readyReplicas
+      failed_when: false # We handle and log the failure below.
+
+    - name: "Fail if CouchDB pods are not ready"
+      block: 
+        - name: "install-cp4d : Get Pending CouchDB Pods"
+          kubernetes.core.k8s_info:
+            api_version: v1
+            kind: Pod
+            label_selectors:
+              - "app=couchdb"
+            field_selectors:
+              - "status.phase=Pending"
+            namespace: "{{ cpd_instance_namespace }}"
+          register: pending_pod_lookup
+
+        - fail:
+            msg:
+              - "CouchDB pods are not ready {{ couchdbStatefulSet.resources[0].status }}"
+              - "Pending CouchDB Pods: {{ pending_pod_lookup.resources | map(attribute='metadata.name') }}"
+      when: 
+        couchdbStatefulSet.resources[0].status.replicas != couchdbStatefulSet.resources[0].status.readyReplicas
+
+  when: is_couchdb_ready is not defined

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-couchdb.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-couchdb.yml
@@ -1,7 +1,7 @@
 ---
 # 1. Wait for couch-db stateful set to start all the replica pods
 # -----------------------------------------------------------------------------
-- name: wait for CouchDB pods to be created
+- name: "wait-couchdb: Wait for CouchDB pods to be created"
   k8s_info:
     kind: StatefulSet
     namespace: "{{ cpd_instance_namespace }}"
@@ -20,7 +20,7 @@
 
 # 2. Wait for couchdb replica pods to become ready
 # -----------------------------------------------------------------------------
-- name: wait for CouchDB pods to be become ready
+- name: "wait-couchdb: Wait for CouchDB pods to be become ready"
   k8s_info:
     kind: StatefulSet
     namespace: "{{ cpd_instance_namespace }}"
@@ -42,7 +42,7 @@
     couchdbStatefulSet.resources[0].status.readyReplicas is defined 
     and couchdbStatefulSet.resources[0].status.replicas == couchdbStatefulSet.resources[0].status.readyReplicas
 
-- name: Detecting and restarting pending CouchDB Pods
+- name: "wait-couchdb: Detecting and restarting pending CouchDB Pods"
   block:
     - name: "install-cp4d : Get pending CouchDB Pods"
       kubernetes.core.k8s_info:
@@ -55,14 +55,13 @@
         namespace: "{{ cpd_instance_namespace }}"
       register: pending_pod_lookup
 
-    - name: "Get and set variables to store the lists"
-      set_fact:
+    - set_fact:
         pending_pod_names: "{{ pending_pod_lookup.resources | map(attribute='metadata.name') }}"
 
     - debug:
         msg: "Restarting pending CouchDB Pods: {{ pending_pod_names }}"
 
-    - name: Restarting pending CouchDB Pods
+    - name: "wait-couchdb: Restarting pending CouchDB Pods"
       kubernetes.core.k8s:
         state: absent
         api_version: v1
@@ -73,7 +72,7 @@
 
     # 3. Wait again couchdb replica pods to become ready
     # -----------------------------------------------------------------------------
-    - name: wait for CouchDB pods to be become ready
+    - name: "wait-couchdb: Wait for CouchDB pods to be become ready"
       k8s_info:
         kind: StatefulSet
         namespace: "{{ cpd_instance_namespace }}"
@@ -86,7 +85,7 @@
         and couchdbStatefulSet.resources[0].status.replicas == couchdbStatefulSet.resources[0].status.readyReplicas
       failed_when: false # We handle and log the failure below.
 
-    - name: "Fail if CouchDB pods are not ready"
+    - name: "wait-couchdb: Fail if CouchDB pods are not ready"
       block: 
         - name: "install-cp4d : Get Pending CouchDB Pods"
           kubernetes.core.k8s_info:


### PR DESCRIPTION
### Overview

Fixing issue https://jsw.ibm.com/browse/MASCORE-3583

CP4D installation can fail due to Pods failing to mount Persistent Volumes:
- CPD core - zen-metastore-edb pods fail
- CPD services - couchdb pods fail

This fix puts in tasks to wait for these pods to successfully deploy and restarts them if they fail

### Testing

Manually tested against FVT Stable (which showed the failure), then tested in personalfvt pfvtcpd5