### PR TITLE
[minor] Include LVM Storage Operator in MAS ISC and ICSP

### DIFF
--- a/ibm/mas_devops/roles/mirror_ocp/README.md
+++ b/ibm/mas_devops/roles/mirror_ocp/README.md
@@ -30,6 +30,7 @@ Three **Catalogs** are mirrored, containing the following content:
 5. local-storage-operator (required by ibm.mas_devops.ocs role)
 6. odf-operator (required by ibm.mas_devops.ocs role)
 7. openshift-cert-manager-operator (required by ibm.mas_devops.cert_manager role)
+8. lvms-operator (not directly used, but often used in SNO environments)
 
 Requirements
 -------------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -80,4 +80,7 @@ mirror:
         - name: openshift-cert-manager-operator  # Required by ibm.mas_devops.cert_manager role
           channels:
             - name: stable-v1
+        - name: lvms-operator  # Not used by any of our roles, but used in SNO installations
+          channels:
+            - name: stable-{{ ocp_release }}
 {% endif %}

--- a/ibm/mas_devops/roles/ocp_contentsourcepolicy/README.md
+++ b/ibm/mas_devops/roles/ocp_contentsourcepolicy/README.md
@@ -48,6 +48,7 @@ All content from the subset of the Red Hat operator catalogs supported by [mirro
 - **registry.redhat.io/ubi8**
 - **registry.redhat.io/openshift-pipelines**
 - **registry.redhat.io/openshift-serverless-1**
+- **registry.redhat.io/lvms4**
 
 !!! note
     A content source policy for this content is only configured when **setup_redhat_catalogs** is set to `True`.

--- a/ibm/mas_devops/roles/ocp_contentsourcepolicy/templates/redhat-catalogs.yml.j2
+++ b/ibm/mas_devops/roles/ocp_contentsourcepolicy/templates/redhat-catalogs.yml.j2
@@ -116,3 +116,6 @@ spec:
   - mirrors:
     - {{ registry_private_url }}/cert-manager
     source: registry.redhat.io/cert-manager
+  - mirrors:
+    - {{ registry_private_url }}/lvms4
+    source: registry.redhat.io/lvms4

--- a/ibm/mas_devops/roles/registry/templates/certs/certificate.yml.j2
+++ b/ibm/mas_devops/roles/registry/templates/certs/certificate.yml.j2
@@ -22,6 +22,7 @@ spec:
     - "{{ cluster_subdomain.resources[0].spec.domain }}"
     - "*.{{ cluster_subdomain.resources[0].spec.domain }}"
     - "airgap-registry.{{ registry_namespace }}.svc"
+    - "airgap-registry-lb.{{ registry_namespace }}.svc"
   organization:
     - "IBM Maximo Application Suite"
   subject:

--- a/ibm/mas_devops/roles/registry/templates/deployment.yml.j2
+++ b/ibm/mas_devops/roles/registry/templates/deployment.yml.j2
@@ -8,6 +8,8 @@ metadata:
     app: airgap-registry
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: airgap-registry


### PR DESCRIPTION
Adds the **LVM Storage Operator** the the MAS subset of Red Hat Operator Catalog Content.  This operator is not directly used in any of our automation, but is the standard storage classes used in Single Node OpenShift environments.