### PR TITLE
[patch] Add variable for vargraphic setting for Manage and Health

### DIFF
--- a/ibm/mas_devops/roles/suite_app_config/README.md
+++ b/ibm/mas_devops/roles/suite_app_config/README.md
@@ -180,6 +180,11 @@ Optional. Flag indicating if manage demodata should be loaded or not.
 - Environment Variable: `MAS_APP_SETTINGS_DEMODATA`
 - Default: `false` (do not load demodata)
 
+### "{{ mas_app_settings_db2vargraphic | bool }}"
+Optional. Flag indicating if VARGRAPHIC (if true) or VARCHAR (if false) is used.
+
+- Default: `true` (use VARGRAPHIC)
+
 ### mas_app_settings_tablespace
 Optional. Name of the Manage database tablespace
 

--- a/ibm/mas_devops/roles/suite_app_config/README.md
+++ b/ibm/mas_devops/roles/suite_app_config/README.md
@@ -180,10 +180,10 @@ Optional. Flag indicating if manage demodata should be loaded or not.
 - Environment Variable: `MAS_APP_SETTINGS_DEMODATA`
 - Default: `false` (do not load demodata)
 
-### "{{ mas_app_settings_db2vargraphic | bool }}"
-Optional. Flag indicating if VARGRAPHIC (if true) or VARCHAR (if false) is used.
+### mas_app_settings_db2vargraphic
+Optional. Flag indicating if VARGRAPHIC (if true) or VARCHAR (if false) is used. Details: https://www.ibm.com/docs/en/mas-cd/continuous-delivery?topic=deploy-language-support
 
-- Default: `true` (use VARGRAPHIC)
+- Default: `true`
 
 ### mas_app_settings_tablespace
 Optional. Name of the Manage database tablespace

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/health.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/health.yml
@@ -16,7 +16,7 @@ mas_appws_spec:
       dbSchema: "{{ mas_app_settings_db2_schema }}"
       maxinst:
         demodata: "{{ mas_app_settings_demodata | bool }}"
-        db2Vargraphic: "{{ mas_app_settings_db2vargraphic | default('true', true) | bool }}"
+        db2Vargraphic: "{{ mas_app_settings_db2vargraphic | bool }}"
         indexSpace: "{{ mas_app_settings_indexspace }}"
         tableSpace: "{{ mas_app_settings_tablespace }}"
         bypassUpgradeVersionCheck: false

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/health.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/health.yml
@@ -16,7 +16,7 @@ mas_appws_spec:
       dbSchema: "{{ mas_app_settings_db2_schema }}"
       maxinst:
         demodata: "{{ mas_app_settings_demodata | bool }}"
-        db2Vargraphic: true
+        db2Vargraphic: "{{ mas_app_settings_db2vargraphic | default('true', true) | bool }}"
         indexSpace: "{{ mas_app_settings_indexspace }}"
         tableSpace: "{{ mas_app_settings_tablespace }}"
         bypassUpgradeVersionCheck: false

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/manage.yml
@@ -19,7 +19,7 @@ mas_appws_spec:
       dbSchema: "{{ mas_app_settings_db2_schema }}"
       maxinst:
         demodata: "{{ mas_app_settings_demodata | bool }}"
-        db2Vargraphic: "{{ mas_app_settings_db2vargraphic | default('true', true) | bool }}"
+        db2Vargraphic: "{{ mas_app_settings_db2vargraphic | bool }}"
         tableSpace: "{{ mas_app_settings_tablespace }}"
         indexSpace: "{{ mas_app_settings_indexspace }}"
         bypassUpgradeVersionCheck: false

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/manage.yml
@@ -19,7 +19,7 @@ mas_appws_spec:
       dbSchema: "{{ mas_app_settings_db2_schema }}"
       maxinst:
         demodata: "{{ mas_app_settings_demodata | bool }}"
-        db2Vargraphic: true
+        db2Vargraphic: "{{ mas_app_settings_db2vargraphic | default('true', true) | bool }}"
         tableSpace: "{{ mas_app_settings_tablespace }}"
         indexSpace: "{{ mas_app_settings_indexspace }}"
         bypassUpgradeVersionCheck: false

--- a/ibm/mas_devops/roles/suite_app_config/vars/health.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/health.yml
@@ -9,6 +9,7 @@ mas_app_cfg_retries: "{{ lookup('env', 'MAS_APP_CFG_RETRIES') | default(50, true
 mas_app_settings_aio_flag: "{{ lookup('env', 'MAS_APP_SETTINGS_AIO_FLAG') | default('true', true)}}"
 mas_app_settings_db2_schema: "{{ lookup('env', 'MAS_APP_SETTINGS_DB2_SCHEMA') | default('maximo', true)}}"
 mas_app_settings_demodata: "{{ lookup('env', 'MAS_APP_SETTINGS_DEMODATA') | default('false', true) }}"
+mas_app_settings_db2vargraphic : "{{ lookup('env', 'MAS_APP_SETTINGS_DB2VARGRAPHIC') | default('true', true) | bool }}"
 
 mas_app_settings_tablespace: "{{ lookup('env', 'MAS_APP_SETTINGS_TABLESPACE') | default('MAXDATA', true)}}"
 mas_app_settings_indexspace: "{{ lookup('env', 'MAS_APP_SETTINGS_INDEXSPACE') | default('MAXINDEX', true)}}"

--- a/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
@@ -10,6 +10,7 @@ mas_app_cfg_retries: "{{ lookup('env', 'MAS_APP_CFG_RETRIES') | default(60, true
 mas_app_settings_aio_flag: "{{ lookup('env', 'MAS_APP_SETTINGS_AIO_FLAG') | default('true', true) | bool }}"
 mas_app_settings_db2_schema: "{{ lookup('env', 'MAS_APP_SETTINGS_DB2_SCHEMA') | default('maximo', true)}}"
 mas_app_settings_demodata: "{{ lookup('env', 'MAS_APP_SETTINGS_DEMODATA') | default('false', true) | bool }}"
+mas_app_settings_db2vargraphic : "{{ lookup('env', 'MAS_APP_SETTINGS_DB2VARGRAPHIC') | default('true', true) | bool }}"
 
 mas_app_settings_tablespace: "{{ lookup('env', 'MAS_APP_SETTINGS_TABLESPACE') | default('MAXDATA', true)}}"
 mas_app_settings_indexspace: "{{ lookup('env', 'MAS_APP_SETTINGS_INDEXSPACE') | default('MAXINDEX', true)}}"


### PR DESCRIPTION
Added variable for setting Vargraphic option in Manage and Health database configuration. By default sets to True to avoid breaking changes.