### PR TITLE
[patch] Fix DB2 logs/backup/temps/storage optionally condition

### DIFF
--- a/ibm/mas_devops/roles/db2/README.md
+++ b/ibm/mas_devops/roles/db2/README.md
@@ -185,7 +185,7 @@ Storage class used for backup. This must support ReadWriteMany
 
 - Optional
 - Environment Variable: `DB2_BACKUP_STORAGE_CLASS`
-- Default: Defaults to `ibmc-file-gold` if the storage class is available in the cluster. Set to `""` will drop the backup storage on DB2ucluster CR.
+- Default: Defaults to `ibmc-file-gold` if the storage class is available in the cluster. Set to `None` will drop the backup storage on DB2ucluster CR.
 
 ### db2_backup_storage_size
 Size of backup persistent volume.
@@ -206,7 +206,7 @@ Storage class used for transaction logs. This must support ReadWriteOnce
 
 - Optional
 - Environment Variable: `DB2_LOGS_STORAGE_CLASS`
-- Default: Defaults to `ibmc-block-gold` if the storage class is available in the cluster. Set to `""` will drop the logs storage on DB2ucluster CR.
+- Default: Defaults to `ibmc-block-gold` if the storage class is available in the cluster. Set to `None` will drop the logs storage on DB2ucluster CR.
 
 ### db2_logs_storage_size
 Size of transaction logs persistent volume.
@@ -227,7 +227,7 @@ Storage class used for temporary data. This must support ReadWriteOnce
 
 - Optional
 - Environment Variable: `DB2_TEMP_STORAGE_CLASS`
-- Default: Defaults to `ibmc-block-gold` if the storage class is available in the cluster. Set to `""` will drop the tempts storage on DB2ucluster CR.
+- Default: Defaults to `ibmc-block-gold` if the storage class is available in the cluster. Set to `None` will drop the tempts storage on DB2ucluster CR.
 
 ### db2_temp_storage_size
 Size of temporary persistent volume.

--- a/ibm/mas_devops/roles/db2/README.md
+++ b/ibm/mas_devops/roles/db2/README.md
@@ -185,7 +185,7 @@ Storage class used for backup. This must support ReadWriteMany
 
 - Optional
 - Environment Variable: `DB2_BACKUP_STORAGE_CLASS`
-- Default: Defaults to `ibmc-file-gold` if the storage class is available in the cluster. Set to "" will drop the backup storage on DB2ucluster CR.
+- Default: Defaults to `ibmc-file-gold` if the storage class is available in the cluster. Set to `""` will drop the backup storage on DB2ucluster CR.
 
 ### db2_backup_storage_size
 Size of backup persistent volume.
@@ -206,7 +206,7 @@ Storage class used for transaction logs. This must support ReadWriteOnce
 
 - Optional
 - Environment Variable: `DB2_LOGS_STORAGE_CLASS`
-- Default: Defaults to `ibmc-block-gold` if the storage class is available in the cluster. Set to "" will drop the logs storage on DB2ucluster CR.
+- Default: Defaults to `ibmc-block-gold` if the storage class is available in the cluster. Set to `""` will drop the logs storage on DB2ucluster CR.
 
 ### db2_logs_storage_size
 Size of transaction logs persistent volume.
@@ -227,7 +227,7 @@ Storage class used for temporary data. This must support ReadWriteOnce
 
 - Optional
 - Environment Variable: `DB2_TEMP_STORAGE_CLASS`
-- Default: Defaults to `ibmc-block-gold` if the storage class is available in the cluster. Set to "" will drop the tempts storage on DB2ucluster CR.
+- Default: Defaults to `ibmc-block-gold` if the storage class is available in the cluster. Set to `""` will drop the tempts storage on DB2ucluster CR.
 
 ### db2_temp_storage_size
 Size of temporary persistent volume.

--- a/ibm/mas_devops/roles/db2/README.md
+++ b/ibm/mas_devops/roles/db2/README.md
@@ -185,7 +185,7 @@ Storage class used for backup. This must support ReadWriteMany
 
 - Optional
 - Environment Variable: `DB2_BACKUP_STORAGE_CLASS`
-- Default: Defaults to `ibmc-file-gold` if the storage class is available in the cluster.
+- Default: Defaults to `ibmc-file-gold` if the storage class is available in the cluster. Set to "" will drop the backup storage on DB2ucluster CR.
 
 ### db2_backup_storage_size
 Size of backup persistent volume.
@@ -206,7 +206,7 @@ Storage class used for transaction logs. This must support ReadWriteOnce
 
 - Optional
 - Environment Variable: `DB2_LOGS_STORAGE_CLASS`
-- Default: Defaults to `ibmc-block-gold` if the storage class is available in the cluster.
+- Default: Defaults to `ibmc-block-gold` if the storage class is available in the cluster. Set to "" will drop the logs storage on DB2ucluster CR.
 
 ### db2_logs_storage_size
 Size of transaction logs persistent volume.
@@ -227,7 +227,7 @@ Storage class used for temporary data. This must support ReadWriteOnce
 
 - Optional
 - Environment Variable: `DB2_TEMP_STORAGE_CLASS`
-- Default: Defaults to `ibmc-block-gold` if the storage class is available in the cluster.
+- Default: Defaults to `ibmc-block-gold` if the storage class is available in the cluster. Set to "" will drop the tempts storage on DB2ucluster CR.
 
 ### db2_temp_storage_size
 Size of temporary persistent volume.

--- a/ibm/mas_devops/roles/db2/tasks/install/determine-storage-classes.yml
+++ b/ibm/mas_devops/roles/db2/tasks/install/determine-storage-classes.yml
@@ -48,7 +48,7 @@
 # 4. Logs Storage (Optional)
 # -----------------------------------------------------------------------------
 - name: Default Logs Storage for ROKS if not set by user (ReadWriteOnce)
-  when: db2_logs_storage_class is not defined
+  when: db2_logs_storage_class is not defined or db2_logs_storage_class == ""
   set_fact:
     db2_logs_storage_class: "{{ lookup_storageclasses | ibm.mas_devops.defaultStorageClass(default_storage_classes_rwo) }}"
 
@@ -56,7 +56,7 @@
 # 5. Backup Storage (Optional)
 # -----------------------------------------------------------------------------
 - name: Default Backup Storage for ROKS if not set by user (ReadWriteMany)
-  when: db2_backup_storage_class is not defined
+  when: db2_backup_storage_class is not defined or db2_backup_storage_class == ""
   set_fact:
     db2_backup_storage_class: "{{ lookup_storageclasses | ibm.mas_devops.defaultStorageClass(default_storage_classes_rwx) }}"
 
@@ -64,7 +64,7 @@
 # 6. Temp Storage (Optional)
 # -----------------------------------------------------------------------------
 - name: Default Temp Storage for ROKS if not set by user (ReadWriteOnce)
-  when: db2_temp_storage_class is not defined
+  when: db2_temp_storage_class is not defined or db2_temp_storage_class == ""
   set_fact:
     db2_temp_storage_class: "{{ lookup_storageclasses | ibm.mas_devops.defaultStorageClass(default_storage_classes_rwo) }}"
 

--- a/ibm/mas_devops/roles/db2/tasks/install/determine-storage-classes.yml
+++ b/ibm/mas_devops/roles/db2/tasks/install/determine-storage-classes.yml
@@ -48,7 +48,7 @@
 # 4. Logs Storage (Optional)
 # -----------------------------------------------------------------------------
 - name: Default Logs Storage for ROKS if not set by user (ReadWriteOnce)
-  when: db2_logs_storage_class is not defined or db2_logs_storage_class == ""
+  when: db2_logs_storage_class is not defined
   set_fact:
     db2_logs_storage_class: "{{ lookup_storageclasses | ibm.mas_devops.defaultStorageClass(default_storage_classes_rwo) }}"
 
@@ -56,7 +56,7 @@
 # 5. Backup Storage (Optional)
 # -----------------------------------------------------------------------------
 - name: Default Backup Storage for ROKS if not set by user (ReadWriteMany)
-  when: db2_backup_storage_class is not defined or db2_backup_storage_class == ""
+  when: db2_backup_storage_class is not defined
   set_fact:
     db2_backup_storage_class: "{{ lookup_storageclasses | ibm.mas_devops.defaultStorageClass(default_storage_classes_rwx) }}"
 
@@ -64,7 +64,7 @@
 # 6. Temp Storage (Optional)
 # -----------------------------------------------------------------------------
 - name: Default Temp Storage for ROKS if not set by user (ReadWriteOnce)
-  when: db2_temp_storage_class is not defined or db2_temp_storage_class == ""
+  when: db2_temp_storage_class is not defined
   set_fact:
     db2_temp_storage_class: "{{ lookup_storageclasses | ibm.mas_devops.defaultStorageClass(default_storage_classes_rwo) }}"
 

--- a/ibm/mas_devops/roles/db2/templates/db2ucluster.yml.j2
+++ b/ibm/mas_devops/roles/db2/templates/db2ucluster.yml.j2
@@ -105,7 +105,7 @@ spec:
         resources:
           requests:
             storage: "{{ db2_data_storage_size }}"
-{% if db2_backup_storage_class is defined and db2_backup_storage_class != "" %}
+{% if db2_backup_storage_class is defined and db2_backup_storage_class != "None" %}
     - name: backup
       type: create
       spec:
@@ -117,7 +117,7 @@ spec:
         storageClassName: "{{ db2_backup_storage_class }}"
       type: create
 {% endif %}
-{% if db2_logs_storage_class is defined and db2_logs_storage_class != "" %}
+{% if db2_logs_storage_class is defined and db2_logs_storage_class != "None" %}
     - name: activelogs
       spec:
         accessModes:
@@ -128,7 +128,7 @@ spec:
         storageClassName: "{{ db2_logs_storage_class }}"
       type: template
 {% endif %}
-{% if db2_temp_storage_class is defined and db2_temp_storage_class != "" %}
+{% if db2_temp_storage_class is defined and db2_temp_storage_class != "None" %}
     - name: tempts
       spec:
         accessModes:


### PR DESCRIPTION
To fix the bug reported on https://github.com/ibm-mas/ansible-devops/issues/1424

The changes on public Ansible role ibm.mas_devops.db2 tested successfully on AWS stg cluster `sa-s05n-euce1`, the playbook as follow:

```
Using below playbook to execute the ibm.mas_devops.db2 role,
Target cluster is on AWS SaaS.

=================================================================================================

- hosts: localhost
  any_errors_fatal: true
  vars:
    mas_instance_id: test01
    ibm_entitlement_key: xxxxxxxxxxxxxxxxxxxxxxxxx
    db2_namespace: "mas-{{ mas_instance_id }}-db2u-manage"
    db2_instance_name: "{{ mas_instance_id }}db2umanage"
    db2_ldap_username: "{{ mas_instance_id | replace('-', '') | replace('_', '') }}managedb"
    db2_ldap_password: "{{ lookup('password', '/dev/null length=8 chars=ascii_lowercase seed=mas_instance_id') }}"
    db2_fsId: xxxxxxxxxxxxxxxxxxxxxx
  pre_tasks:

    - name: Query db2 Storage Class
      set_fact:
        db2_sc: "{{ query('k8s', kind='StorageClass', api_version='v1', resource_name='efs-csi-'+ mas_instance_id )}}"

    - name: Create db2 Storage Class
      kubernetes.core.k8s:
        state: present
        definition:
          kind: StorageClass
          apiVersion: storage.k8s.io/v1
          metadata:
            name: efs-csi-{{mas_instance_id}}
          provisioner: efs.csi.aws.com
          parameters:
            provisioningMode: efs-ap
            fileSystemId: "{{ db2_fsId }}"
            directoryPerms: "777"
            uid: "0"
            gid: "0"
            basePath: "/dynamic_provision"
      when:
        - db2_sc | length == 0

    - name: Set Facts For Manage Db2
      set_fact:
        db2_meta_storage_class: efs-csi-{{mas_instance_id}}
        db2_data_storage_class: efs-csi-{{mas_instance_id}}
        db2_backup_storage_class: efs-csi-{{mas_instance_id}}
        db2_temp_storage_class: None
        inventory_config_name: inventory.yml
        db2_sub_name: ibm-db2u-operator
        jdbccfg:
          cpd_namespace: "{{ db2_namespace }}"
          db2wh_instance_id: "{{ db2_instance_name }}"
          credentials: "{{ lookup('env', 'JDBC_CREDENTIALS') }}"
          jdbc_db2_ldap_username: "{{ db2_ldap_username }}"
          jdbc_db2_ldap_password: "{{ db2_ldap_password }}"
        enforce_db2_config: "{{ lookup('env', 'ENFORCE_DB2_CONFIG') }}"
        db2_config_version: "{{ lookup('env', 'DB2_CONFIG_VERSION') }}"


  roles:

    - name: ibm.mas_devops.db2
   ```

The db2ucluster CR dropped the tempts storage when db2_temp_storage_class set to `None`.

Below are the db2ucluster yaml contents:

```
apiVersion: db2u.databases.ibm.com/v1
kind: Db2uCluster
metadata:
  annotations:
    db2u/certs-api-cert: '[secure]'
    db2u/certs-api-key: '[secure]'
    db2u/certs-wv-rest: '[secure]'
    db2u/license: '[secure]'
    db2u/sshkeys-db2instusr: '[secure]'
    db2u/sshkeys-db2uadm: '[secure]'
    db2u/sshkeys-db2uhausr: '[secure]'
    kubectl.kubernetes.io/last-applied-configuration: >-
      {"apiVersion":"db2u.databases.ibm.com/v1","kind":"Db2uCluster","metadata":{"name":"test01db2umanage","namespace":"mas-test01-db2u-manage"},"spec":{"account":{"imagePullSecrets":["ibm-registry"],"privileged":true},"addOns":{"graph":{"enabled":false},"rest":{"enabled":false}},"environment":{"database":{"dbConfig":{"APPLHEAPSZ":"8192
      AUTOMATIC"},"name":"BLUDB","settings":{"dftTableOrg":"ROW"},"ssl":{"certLabel":"CN=db2u","secretName":"db2u-certificate"}},"dbType":"db2wh","instance":{"registry":{"DB2AUTH":"OSAUTHDB,ALLOW_LOCAL_FALLBACK,PLUGIN_AUTO_RELOAD","DB2_4K_DEVICE_SUPPORT":"ON","DB2_FMP_RUN_AS_CONNECTED_USER":"NO","DB2_WORKLOAD":"ANALYTICS"}},"mln":{"total":1}},"license":{"accept":true},"podConfig":{"db2u":{"resource":{"db2u":{"limits":{"cpu":"6000m","memory":"16Gi"},"requests":{"cpu":"4000m","memory":"8Gi"}}}}},"size":1,"storage":[{"name":"meta","spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"20Gi"}},"storageClassName":"efs-csi-test01"},"type":"create"},{"name":"data","spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"100Gi"}},"storageClassName":"efs-csi-test01"},"type":"template"},{"name":"backup","spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"100Gi"}},"storageClassName":"efs-csi-test01"},"type":"create"},{"name":"activelogs","spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"100Gi"}},"storageClassName":"gp3-csi"},"type":"template"}],"version":"s11.5.8.0-cn3"}}
  resourceVersion: '2514093746'
  name: test01db2umanage
  uid: a2e18081-55ee-4c18-ac4f-d19395af3bf7
  creationTimestamp: '2024-08-23T07:49:41Z'
  generation: 3
  managedFields:
    - apiVersion: db2u.databases.ibm.com/v1
      fieldsType: FieldsV1
      fieldsV1:
        'f:metadata':
          'f:annotations':
            .: {}
            'f:kubectl.kubernetes.io/last-applied-configuration': {}
        'f:spec':
          'f:version': {}
          'f:storage': {}
          'f:addOns':
            .: {}
            'f:graph': {}
            'f:rest': {}
          'f:license':
            .: {}
            'f:accept': {}
          .: {}
          'f:podConfig':
            .: {}
            'f:db2u':
              .: {}
              'f:resource':
                .: {}
                'f:db2u':
                  .: {}
                  'f:limits':
                    .: {}
                    'f:memory': {}
                  'f:requests':
                    .: {}
                    'f:memory': {}
          'f:size': {}
          'f:account':
            .: {}
            'f:imagePullSecrets': {}
            'f:privileged': {}
          'f:environment':
            .: {}
            'f:database':
              .: {}
              'f:dbConfig':
                .: {}
                'f:APPLHEAPSZ': {}
              'f:name': {}
              'f:settings':
                .: {}
                'f:dftTableOrg': {}
              'f:ssl':
                .: {}
                'f:certLabel': {}
            'f:dbType': {}
            'f:instance':
              .: {}
              'f:registry':
                .: {}
                'f:DB2AUTH': {}
                'f:DB2_4K_DEVICE_SUPPORT': {}
                'f:DB2_FMP_RUN_AS_CONNECTED_USER': {}
                'f:DB2_WORKLOAD': {}
            'f:mln':
              .: {}
              'f:total': {}
      manager: OpenAPI-Generator
      operation: Update
      time: '2024-08-23T07:49:41Z'
    - apiVersion: db2u.databases.ibm.com/v1
      fieldsType: FieldsV1
      fieldsV1:
        'f:metadata':
          'f:annotations':
            'f:db2u/certs-api-cert': {}
            'f:db2u/certs-api-key': {}
            'f:db2u/certs-wv-rest': {}
            'f:db2u/license': {}
            'f:db2u/sshkeys-db2instusr': {}
            'f:db2u/sshkeys-db2uadm': {}
            'f:db2u/sshkeys-db2uhausr': {}
          'f:labels':
            .: {}
            'f:formation_id': {}
        'f:spec':
          'f:addOns':
            'f:qrep':
              .: {}
              'f:infraHost': {}
              'f:infraIP': {}
              'f:license': {}
          'f:environment':
            'f:database':
              'f:ssl':
                'f:secretName': {}
            'f:instance':
              'f:password': {}
            'f:ldap':
              .: {}
              'f:blueAdminPassword': {}
              'f:enabled': {}
              'f:password': {}
          'f:podConfig':
            'f:db2u':
              'f:resource':
                'f:db2u':
                  'f:limits':
                    'f:cpu': {}
                  'f:requests':
                    'f:cpu': {}
      manager: manager
      operation: Update
      time: '2024-08-23T07:50:02Z'
    - apiVersion: db2u.databases.ibm.com/v1
      fieldsType: FieldsV1
      fieldsV1:
        'f:status':
          .: {}
          'f:conditions': {}
          'f:maintenanceState': {}
          'f:state': {}
          'f:version': {}
      manager: manager
      operation: Update
      subresource: status
      time: '2024-08-23T08:00:22Z'
  namespace: mas-test01-db2u-manage
  labels:
    formation_id: test01db2umanage
spec:
  account:
    imagePullSecrets:
      - ibm-registry
    privileged: true
  addOns:
    graph: {}
    qrep:
      infraHost: xxx.ibm.com
      infraIP: x.x.x.x
      license: {}
    rest: {}
  environment:
    database:
      dbConfig:
        APPLHEAPSZ: 8192 AUTOMATIC
      name: BLUDB
      settings:
        dftTableOrg: ROW
      ssl:
        certLabel: CN=db2u
        secretName: '[secure]'
    dbType: db2wh
    instance:
      password: '[secure]'
      registry:
        DB2AUTH: 'OSAUTHDB,ALLOW_LOCAL_FALLBACK,PLUGIN_AUTO_RELOAD'
        DB2_4K_DEVICE_SUPPORT: 'ON'
        DB2_FMP_RUN_AS_CONNECTED_USER: 'NO'
        DB2_WORKLOAD: ANALYTICS
    ldap:
      blueAdminPassword: '[secure]'
      enabled: true
      password: '[secure]'
    mln:
      total: 1
  license:
    accept: true
  podConfig:
    db2u:
      resource:
        db2u:
          limits:
            cpu: '6'
            memory: 16Gi
          requests:
            cpu: '4'
            memory: 8Gi
  size: 1
  storage:
    - name: meta
      spec:
        accessModes:
          - ReadWriteMany
        resources:
          requests:
            storage: 20Gi
        storageClassName: efs-csi-test01
      type: create
    - name: data
      spec:
        accessModes:
          - ReadWriteOnce
        resources:
          requests:
            storage: 100Gi
        storageClassName: efs-csi-test01
      type: template
    - name: backup
      spec:
        accessModes:
          - ReadWriteMany
        resources:
          requests:
            storage: 100Gi
        storageClassName: efs-csi-test01
      type: create
    - name: activelogs
      spec:
        accessModes:
          - ReadWriteOnce
        resources:
          requests:
            storage: 100Gi
        storageClassName: gp3-csi
      type: template
  version: s11.5.8.0-cn3
status:
  conditions:
    - lastTransitionTime: '2024-08-23T08:00:22Z'
      status: OK
      type: FormationStatus
  maintenanceState: None
  state: Ready
  version: s11.5.8.0-cn3
```

[db2-install-test.log](https://github.com/user-attachments/files/16725785/db2-install-test.log)
