### PR TITLE
[patch] Add MAS_APP_SETTINGS_DB_SCHEMA as alt for MAS_APP_SETTINGS_DB2_SCHEMA

### DIFF
--- a/docs/playbooks/oneclick-manage.md
+++ b/docs/playbooks/oneclick-manage.md
@@ -84,7 +84,7 @@ export MAS_JDBC_USER=maximo
 export MAS_JDBC_PASSWORD=xxx
 export MAS_JDBC_URL=xxx
 
-export MAS_APP_SETTINGS_DB2_SCHEMA=maximo
+export MAS_APP_SETTINGS_DB_SCHEMA=maximo
 export MAS_APP_SETTINGS_TABLESPACE=maxdata
 export MAS_APP_SETTINGS_INDEXSPACE=maxindex
 

--- a/ibm/mas_devops/playbooks/oneclick_add_manage.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_manage.yml
@@ -66,7 +66,7 @@
           - lookup('env', 'MAS_JDBC_USER') != ""
           - lookup('env', 'MAS_JDBC_PASSWORD') != ""
           - lookup('env', 'MAS_JDBC_URL') != ""
-          - lookup('env', 'MAS_APP_SETTINGS_DB2_SCHEMA') != ""
+          - lookup('env', 'MAS_APP_SETTINGS_DB_SCHEMA') != "" or lookup('env', 'MAS_APP_SETTINGS_DB2_SCHEMA') != ""
           - lookup('env', 'MAS_APP_SETTINGS_TABLESPACE') != ""
           - lookup('env', 'MAS_APP_SETTINGS_INDEXSPACE') != ""
         fail_msg: "One or more JDBC configuration environment variables are not defined for external database"

--- a/ibm/mas_devops/roles/suite_app_config/README.md
+++ b/ibm/mas_devops/roles/suite_app_config/README.md
@@ -169,9 +169,9 @@ Optional. Flag indicating if Asset Investment Optimization (AIO) resource must b
 ---
 
 ### mas_app_settings_db_schema
-Optional. Name of the schema where Manage database lives in. Code also supports legacy mas_app_settings_db2_schema variable name.
+Optional. Name of the schema where Manage database lives in. Code also supports deprecated `mas_app_settings_db2_schema` variable name.
 
-- Environment Variable: MAS_APP_SETTINGS_DB_SCHEMA') |
+- Environment Variable: `MAS_APP_SETTINGS_DB_SCHEMA`
 - Default: `maximo`
 
 ### mas_app_settings_demodata

--- a/ibm/mas_devops/roles/suite_app_config/README.md
+++ b/ibm/mas_devops/roles/suite_app_config/README.md
@@ -168,10 +168,10 @@ Optional. Flag indicating if Asset Investment Optimization (AIO) resource must b
 ### Manage - DB2 settings variables
 ---
 
-### mas_app_settings_db2_schema
-Optional. Name of the schema where Manage database lives in.
+### mas_app_settings_db_schema
+Optional. Name of the schema where Manage database lives in. Code also supports legacy mas_app_settings_db2_schema variable name.
 
-- Environment Variable: MAS_APP_SETTINGS_DB2_SCHEMA') |
+- Environment Variable: MAS_APP_SETTINGS_DB_SCHEMA') |
 - Default: `maximo`
 
 ### mas_app_settings_demodata

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/health.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/health.yml
@@ -13,7 +13,7 @@ mas_appws_spec:
     aio:
       install: "{{ mas_app_settings_aio_flag | bool  }}"
     db:
-      dbSchema: "{{ mas_app_settings_db2_schema }}"
+      dbSchema: "{{ mas_app_settings_db_schema }}"
       maxinst:
         demodata: "{{ mas_app_settings_demodata | bool }}"
         db2Vargraphic: true

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/manage.yml
@@ -16,7 +16,7 @@ mas_appws_spec:
     aio:
       install: "{{ mas_app_settings_aio_flag | bool  }}"
     db:
-      dbSchema: "{{ mas_app_settings_db2_schema }}"
+      dbSchema: "{{ mas_app_settings_db_schema }}"
       maxinst:
         demodata: "{{ mas_app_settings_demodata | bool }}"
         db2Vargraphic: true

--- a/ibm/mas_devops/roles/suite_app_config/vars/health.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/health.yml
@@ -8,7 +8,8 @@ mas_app_cfg_retries: "{{ lookup('env', 'MAS_APP_CFG_RETRIES') | default(50, true
 
 mas_app_settings_aio_flag: "{{ lookup('env', 'MAS_APP_SETTINGS_AIO_FLAG') | default('true', true)}}"
 mas_app_settings_db2_schema: "{{ lookup('env', 'MAS_APP_SETTINGS_DB2_SCHEMA') | default('maximo', true)}}"
-mas_app_settings_demodata: "{{ lookup('env', 'MAS_APP_SETTINGS_DEMODATA') | default('false', true) }}"
+mas_app_settings_db_schema: "{{ lookup('env', 'MAS_APP_SETTINGS_DB_SCHEMA') | default(mas_app_settings_db2_schema, true)}}"
+mas_app_settings_demodata: "{{ lookup('env', 'MAS_APP_SETTINGS_DEMODATA') | default('falseMAS_APP_SETTINGS_DB2_SCHEMA', true) }}"
 
 mas_app_settings_tablespace: "{{ lookup('env', 'MAS_APP_SETTINGS_TABLESPACE') | default('MAXDATA', true)}}"
 mas_app_settings_indexspace: "{{ lookup('env', 'MAS_APP_SETTINGS_INDEXSPACE') | default('MAXINDEX', true)}}"

--- a/ibm/mas_devops/roles/suite_app_config/vars/health.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/health.yml
@@ -9,7 +9,7 @@ mas_app_cfg_retries: "{{ lookup('env', 'MAS_APP_CFG_RETRIES') | default(50, true
 mas_app_settings_aio_flag: "{{ lookup('env', 'MAS_APP_SETTINGS_AIO_FLAG') | default('true', true)}}"
 mas_app_settings_db2_schema: "{{ lookup('env', 'MAS_APP_SETTINGS_DB2_SCHEMA') | default('maximo', true)}}"
 mas_app_settings_db_schema: "{{ lookup('env', 'MAS_APP_SETTINGS_DB_SCHEMA') | default(mas_app_settings_db2_schema, true)}}"
-mas_app_settings_demodata: "{{ lookup('env', 'MAS_APP_SETTINGS_DEMODATA') | default('falseMAS_APP_SETTINGS_DB2_SCHEMA', true) }}"
+mas_app_settings_demodata: "{{ lookup('env', 'MAS_APP_SETTINGS_DEMODATA') | default('false', true) }}"
 
 mas_app_settings_tablespace: "{{ lookup('env', 'MAS_APP_SETTINGS_TABLESPACE') | default('MAXDATA', true)}}"
 mas_app_settings_indexspace: "{{ lookup('env', 'MAS_APP_SETTINGS_INDEXSPACE') | default('MAXINDEX', true)}}"

--- a/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
@@ -9,6 +9,7 @@ mas_app_cfg_retries: "{{ lookup('env', 'MAS_APP_CFG_RETRIES') | default(60, true
 
 mas_app_settings_aio_flag: "{{ lookup('env', 'MAS_APP_SETTINGS_AIO_FLAG') | default('true', true) | bool }}"
 mas_app_settings_db2_schema: "{{ lookup('env', 'MAS_APP_SETTINGS_DB2_SCHEMA') | default('maximo', true)}}"
+mas_app_settings_db_schema: "{{ lookup('env', 'MAS_APP_SETTINGS_DB_SCHEMA') | default(mas_app_settings_db2_schema, true)}}"
 mas_app_settings_demodata: "{{ lookup('env', 'MAS_APP_SETTINGS_DEMODATA') | default('false', true) | bool }}"
 
 mas_app_settings_tablespace: "{{ lookup('env', 'MAS_APP_SETTINGS_TABLESPACE') | default('MAXDATA', true)}}"


### PR DESCRIPTION
`MAS_APP_SETTINGS_DB2_SCHEMA` (& `mas_app_settings_db2_schema`) are now referred to as `MAS_APP_SETTINGS_DB_SCHEMA` (& `mas_app_settings_db_schema`) in the docs and code - although the db2_schema variables are still compatible and viable options. This is not a breaking change.

Testing done to confirm new logic won't cause a breaking change:
<img width="692" alt="Screenshot 2024-08-23 at 11 11 23" src="https://github.com/user-attachments/assets/e4585c32-7bc9-4269-a0a1-e223aeb3d983">

For: https://github.com/ibm-mas/ansible-devops/issues/1343