### PR TITLE
[patch] mirror ibm-elasticsearch-operator with wsl

### DIFF
--- a/ibm/mas_devops/common_vars/casebundles/v9-240625-amd64.yml
+++ b/ibm/mas_devops/common_vars/casebundles/v9-240625-amd64.yml
@@ -25,13 +25,7 @@ wml_version: 8.0.0                           # Operator version 5.0.0
 spark_version: 8.0.0                         # Operator version 5.0.0
 cognos_version: 25.0.0                       # Operator version 25.0.0
 couchdb_version: 1.0.13                      # Operator version 2.2.1 (This is required for Assist 9.0, https://github.com/IBM/cloud-pak/blob/master/repo/case/ibm-couchdb/index.yaml)
-
-# Watson discovery and its dependencies
-# Match corresponding case version for default versions in the catalog source
-# -----------------------------------------------------------------------------
-#wd_version: 5.5.0                            # Operator version 4.6.5
-#model_train_version: 1.2.13                  # Operator version 1.1.15
-#elasticsearch_version: 1.1.2071              # Operator version 1.1.2071
+elasticsearch_version: 1.1.2071              # Operator version 1.1.2071
 
 
 # Maximo Application Suite

--- a/ibm/mas_devops/common_vars/casebundles/v9-240730-amd64.yml
+++ b/ibm/mas_devops/common_vars/casebundles/v9-240730-amd64.yml
@@ -18,20 +18,14 @@ events_version: 5.0.1                        # Operator version 5.0.1 (https://g
 uds_version: 2.0.12                          # Operator version 2.0.12 # sticking to 2.0.12 version # Please do Not Change
 sls_version: 3.9.1                           # Operator version 3.9.1 (https://github.ibm.com/maximoappsuite/ibm-sls/releases)
 tsm_version: 1.5.4                           # Operator version 1.5.4 (https://github.ibm.com/maximoappsuite/ibm-truststore-mgr/releases)
-dd_version: 1.1.10 # updated                 # Operator version 1.1.9 (https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases)
+dd_version: 1.1.10 # updated                 # Operator version 1.1.10 (https://github.ibm.com/maximoappsuite/ibm-data-dictionary/releases)
 appconnect_version: 6.2.0                    # Operator version 6.2.0 # sticking to 6.2.0 version # Please do Not Change
 wsl_version: 8.0.0                           # Operator version 8.0.0
 wml_version: 8.0.0                           # Operator version 5.0.0
 spark_version: 8.0.0                         # Operator version 5.0.0
 cognos_version: 25.0.0                       # Operator version 25.0.0
 couchdb_version: 1.0.13                      # Operator version 2.2.1 (This is required for Assist 9.0, https://github.com/IBM/cloud-pak/blob/master/repo/case/ibm-couchdb/index.yaml)
-
-# Watson discovery and its dependencies
-# Match corresponding case version for default versions in the catalog source
-# -----------------------------------------------------------------------------
-#wd_version: 5.5.0                            # Operator version 4.6.5
-#model_train_version: 1.2.13                  # Operator version 1.1.15
-#elasticsearch_version: 1.1.2071              # Operator version 1.1.2071
+elasticsearch_version: 1.1.2071              # Operator version 1.1.2071
 
 
 # Maximo Application Suite

--- a/ibm/mas_devops/playbooks/mirror_dependencies.yml
+++ b/ibm/mas_devops/playbooks/mirror_dependencies.yml
@@ -155,6 +155,7 @@
         manifest_name: extras_mongoce
         manifest_version: "{{ mongo_extras_version_6 }}"
 
+
     # 3. IBM Cloud Pak Foundation Services
     # -------------------------------------------------------------------------
     # Just mirror IBM Cloud Pak Foundation Services images 'mirror_common_svcs' is set, or if CPD 4.8+ is being mirrored
@@ -205,6 +206,7 @@
       vars:
         manifest_name: ibm-cp-common-services
         manifest_version: "{{ common_svcs_version_1 }}"
+
 
     # 4. IBM User Data Services
     # -------------------------------------------------------------------------
@@ -279,6 +281,7 @@
       vars:
         manifest_name: ibm-truststore-mgr
         manifest_version: "{{ lookup('env', 'TSM_VERSION') | default (tsm_version, True) }}"
+
 
     # 7. CP4D
     # -------------------------------------------------------------------------
@@ -371,7 +374,7 @@
         manifest_name: ibm-wsl-runtimes
         manifest_version: "{{ wsl_version }}"
 
-    # 7.5 IBM Watson Discovery dependency - ibm-elasticsearch-operator
+    # 7.5 IBM Watson Studio dependency - ibm-elasticsearch-operator
     - name: ibm.mas_devops.mirror_case_prepare
       when:
         - mirror_wsl
@@ -388,7 +391,7 @@
         manifest_name: ibm-elasticsearch-operator
         manifest_version: "{{ elasticsearch_version }}"
 
-    # 9. IBM Watson Studio
+    # 8. IBM Watson Studio
     # -------------------------------------------------------------------------
     - name: ibm.mas_devops.mirror_case_prepare
       when:
@@ -477,6 +480,7 @@
         manifest_name: extras_db2u
         manifest_version: "{{ db2u_extras_version }}"
 
+
     # 12. Cognos Analytics
     # -------------------------------------------------------------------------
     - name: ibm.mas_devops.mirror_case_prepare
@@ -494,6 +498,7 @@
       vars:
         manifest_name: ibm-cognos-analytics-prod
         manifest_version: "{{ cognos_version }}"
+
 
     # 13. App Connect
     # -------------------------------------------------------------------------

--- a/ibm/mas_devops/playbooks/mirror_dependencies.yml
+++ b/ibm/mas_devops/playbooks/mirror_dependencies.yml
@@ -371,6 +371,23 @@
         manifest_name: ibm-wsl-runtimes
         manifest_version: "{{ wsl_version }}"
 
+    # 7.5 IBM Watson Discovery dependency - ibm-elasticsearch-operator
+    - name: ibm.mas_devops.mirror_case_prepare
+      when:
+        - mirror_wsl
+        - mirror_mode != "from-filesystem"
+      vars:
+        case_name: ibm-elasticsearch-operator
+        case_version: "{{ elasticsearch_version }}"
+        exclude_images: []
+        ibmpak_skip_dependencies: false
+
+    - name: ibm.mas_devops.mirror_images
+      when: mirror_wsl
+      vars:
+        manifest_name: ibm-elasticsearch-operator
+        manifest_version: "{{ elasticsearch_version }}"
+
     # 9. IBM Watson Studio
     # -------------------------------------------------------------------------
     - name: ibm.mas_devops.mirror_case_prepare


### PR DESCRIPTION
Failing when creating wml and wsl service in airgap with error message of missing of ibm-elasticsearch-operator operator image,

Adding back task to mirror ibm-elasticsearch-operator 