### PR TITLE
[patch] Add Red Hat catalog prefix

### DIFF
--- a/ibm/mas_devops/roles/ocp_contentsourcepolicy/README.md
+++ b/ibm/mas_devops/roles/ocp_contentsourcepolicy/README.md
@@ -117,6 +117,13 @@ The password for the target registry.
 - Environment Variable: `REGISTRY_PASSWORD`
 - Default: None
 
+### redhat_catalogs_prefix
+The prefix amended to the catalog sources names. E.g: With a `redhat_catalogs_prefix` of "ibm-mas" then `redhat/certified-operator-index` would instead be created as `redhat/ibm-mas-certified-operator-index`
+
+- Optional
+- Environment Variable: `REDHAT_CATALOGS_PREFIX`
+- Default: None
+
 
 Example Playbook
 -------------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/ocp_contentsourcepolicy/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_contentsourcepolicy/defaults/main.yml
@@ -20,3 +20,7 @@ fvt_image_registry: "{{ lookup('env', 'FVT_IMAGE_REGISTRY') }}"
 artifactory_username: "{{ lookup('env', 'ARTIFACTORY_USERNAME') }}"
 artifactory_token: "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"
 artifactory_auth: "{{ artifactory_username }}:{{ artifactory_token }}"
+
+#Optional redhat catalog prefix settings
+env_redhat_catalogs_prefix: "{{ lookup('env', 'REDHAT_CATALOGS_PREFIX') | default('', true) }}"
+redhat_catalogs_prefix: "{% if env_redhat_catalogs_prefix|length > 0 %}{{ env_redhat_catalogs_prefix }}-{% endif %}" # If the prefix is not empty then add a dash

--- a/ibm/mas_devops/roles/ocp_contentsourcepolicy/templates/redhat-catalogs.yml.j2
+++ b/ibm/mas_devops/roles/ocp_contentsourcepolicy/templates/redhat-catalogs.yml.j2
@@ -7,7 +7,7 @@ metadata:
 spec:
   displayName: Certified Operators
   publisher: Red Hat
-  image: {{ registry_private_url }}/redhat/certified-operator-index:v{{ ocp_release }}
+  image: {{ registry_private_url }}/redhat/{{ redhat_catalogs_prefix }}certified-operator-index:v{{ ocp_release }}
   sourceType: grpc
 ---
 apiVersion: operators.coreos.com/v1alpha1
@@ -18,7 +18,7 @@ metadata:
 spec:
   displayName: Community Operators
   publisher: Red Hat
-  image: {{ registry_private_url }}/redhat/community-operator-index:v{{ ocp_release }}
+  image: {{ registry_private_url }}/redhat/{{ redhat_catalogs_prefix }}community-operator-index:v{{ ocp_release }}
   sourceType: grpc
 ---
 apiVersion: operators.coreos.com/v1alpha1
@@ -29,7 +29,7 @@ metadata:
 spec:
   displayName: Red Hat Operators
   publisher: Red Hat
-  image: {{ registry_private_url }}/redhat/redhat-operator-index:v{{ ocp_release }}
+  image: {{ registry_private_url }}/redhat/{{ redhat_catalogs_prefix }}redhat-operator-index:v{{ ocp_release }}
   sourceType: grpc
 ---
 apiVersion: operator.openshift.io/v1alpha1


### PR DESCRIPTION
For https://github.com/ibm-mas/ansible-devops/issues/1257

Adds a prefix variable (`redhat_catalogs_prefix` & `REDHAT_CATALOGS_PREFIX` naturally) to allow the user to add a prefix to the redhat catalogs created by the [ocp_contentsourcepolicy](https://github.com/ibm-mas/ansible-devops/tree/master/ibm/mas_devops/roles/ocp_contentsourcepolicy) role.

Prefix defaults to nothing, resulting in no change of behaviour therefore making sure this isn't a breaking change. If the prefix is not nothing when the role is run it will also add a dash to the end of the prefix. 

When running without a prefix set the catalog sources point to an address the same way they always have:

```yaml
spec:
  displayName: Certified Operators
  publisher: Red Hat
  image: SAMPLE_URL/redhat/certified-operator-index:vSAMPLE_OCP_VERS
  sourceType: grpc
```

However now when running with a prefix (in this case set to "PrefixTest" then the same role will result in:

```yaml
spec:
  displayName: Certified Operators
  publisher: Red Hat
  image: SAMPLE_URL/redhat/PrefixTest-certified-operator-index:vSAMPLE_OCP_VERS
  sourceType: grpc
```


