### PR TITLE
[patch] Align base language variable names

### DIFF
--- a/ibm/mas_devops/roles/suite_app_config/README.md
+++ b/ibm/mas_devops/roles/suite_app_config/README.md
@@ -323,7 +323,7 @@ Typically you would either choose between `ReadWriteOnce` (if using a block stor
 
 ### Manage - Supported languages variables
 ---
-### mas_app_settings_base_language
+### mas_app_settings_base_lang
 Optional. Provide the base language for Manage application.
 For a full list of supported languages for Manage application and its corresponding language codes, please refer to [Language Support](https://www.ibm.com/docs/en/maximo-manage/continuous-delivery?topic=deploy-language-support) documentation.
 

--- a/ibm/mas_devops/roles/suite_app_config/README.md
+++ b/ibm/mas_devops/roles/suite_app_config/README.md
@@ -355,7 +355,7 @@ For a full list of supported languages for Manage application and its correspond
 - Environment Variable: `MAS_APP_SETTINGS_BASE_LANG`
 - Default: `EN` (English)
 
-### mas_app_settings_secondary_languages
+### mas_app_settings_secondary_langs
 Provide a list of additional secondary languages for Manage application.
 
 Note: The more languages you add, the longer Manage will take to install and activate.

--- a/ibm/mas_devops/roles/suite_app_config/README.md
+++ b/ibm/mas_devops/roles/suite_app_config/README.md
@@ -147,20 +147,23 @@ Role Variables - Manage Workspace
 ---
 
 ### mas_appws_bindings_health_wsl_flag
-Optional. Boolean value indicating if Watson Studio must be bound to Manage. It is expected a system level WatsonStudioCfg applied in the cluster.
+Boolean value indicating if Watson Studio must be bound to Manage. It is expected a system level WatsonStudioCfg applied in the cluster.
 
+- Optional
 - Environment Variable: `MAS_APPWS_BINDINGS_HEALTH_WSL_FLAG`
 - Default: `false`
 
 ### mas_appws_bindings_health_wsl
-Optional. Set as `system` to indicate Watson Studio must be installed and bound to Health
+Set as `system` to indicate Watson Studio must be installed and bound to Health
 
+- Optional
 - Environment Variable: `MAS_APPWS_BINDINGS_HEALTH_WSL`
 - Default: None
 
 ### mas_app_settings_aio_flag
-Optional. Flag indicating if Asset Investment Optimization (AIO) resource must be loaded or not. It can be loaded only when Optimizer application is installed.
+Flag indicating if Asset Investment Optimization (AIO) resource must be loaded or not. It can be loaded only when Optimizer application is installed.
 
+- Optional
 - Only supported when Optimizer application is installed.
 - Environment Variable: `MAS_APP_SETTINGS_AIO_FLAG`
 - Default: `true`
@@ -169,26 +172,30 @@ Optional. Flag indicating if Asset Investment Optimization (AIO) resource must b
 ---
 
 ### mas_app_settings_db_schema
-Optional. Name of the schema where Manage database lives in. Code also supports deprecated `mas_app_settings_db2_schema` variable name.
+Name of the schema where Manage database lives in. Code also supports deprecated `mas_app_settings_db2_schema` variable name.
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_DB_SCHEMA`
 - Default: `maximo`
 
 ### mas_app_settings_demodata
-Optional. Flag indicating if manage demodata should be loaded or not.
+Flag indicating if manage demodata should be loaded or not.
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_DEMODATA`
 - Default: `false` (do not load demodata)
 
 ### mas_app_settings_tablespace
-Optional. Name of the Manage database tablespace
+Name of the Manage database tablespace
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_TABLESPACE`
 - Default: `MAXDATA`
 
 ### mas_app_settings_indexspace
-Optional. Name of the Manage database indexspace
+Name of the Manage database indexspace
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_INDEXSPACE`
 - Default: `MAXINDEX`
 
@@ -196,12 +203,13 @@ Optional. Name of the Manage database indexspace
 ---
 
 ### mas_app_settings_persistent_volumes_flag
-Optional. Flag indicating if persistent volumes should be configured by default during Manage Workspace activation.
+Flag indicating if persistent volumes should be configured by default during Manage Workspace activation.
 There are two defaulted File Storage Persistent Volumes Claim resources that will be created out of the box for Manage if this flag is set to `true`:
 
 - `/DOCLINKS`: Persistent volume used to store doclinks/attachments.
 - `/bim`: Persistent volume used to store Building Information Models related artifacts (models, docs and import).
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_PERSISTENT_VOLUMES_FLAG`
 - Default: `false`
 
@@ -210,43 +218,49 @@ There are two defaulted File Storage Persistent Volumes Claim resources that wil
 The following properties can be defined to customize the persistent volumes for the JMS queues setup for Manage.
 
 ### mas_app_settings_jms_queue_pvc_storage_class
-Optional. Provide the persistent volume storage class to be used for JMS queue configuration.
+Provide the persistent volume storage class to be used for JMS queue configuration.
 **Note:** JMS configuration will only be done if `mas_app_settings_server_bundles_size` property is set to `jms`.
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_JMS_QUEUE_PVC_STORAGE_CLASS`
 - Default: None - If not set, a default storage class will be auto defined accordingly to your cluster's available storage classes.
 
 ### mas_app_settings_jms_queue_pvc_name
-Optional. Provide the persistent volume claim name to be used for JMS queue configuration.
+Provide the persistent volume claim name to be used for JMS queue configuration.
 **Note:** JMS configuration will only be done if `mas_app_settings_server_bundles_size` property is set to `jms`.
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_JMS_QUEUE_PVC_NAME`
 - Default: `manage-jms`
 
 ### mas_app_settings_jms_queue_pvc_size
-Optional. Provide the persistent volume claim size to be used for JMS queue configuration.
+Provide the persistent volume claim size to be used for JMS queue configuration.
 **Note:** JMS configuration will only be done if `mas_app_settings_server_bundles_size` property is set to `jms`.
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_JMS_QUEUE_PVC_SIZE`
 - Default: `20Gi`
 
 ### mas_app_settings_jms_queue_mount_path
-Optional. Provide the persistent volume storage mount path to be used for JMS queue configuration.
+Provide the persistent volume storage mount path to be used for JMS queue configuration.
 **Note:** JMS configuration will only be done if `mas_app_settings_server_bundles_size` property is set to `jms`.
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_JMS_QUEUE_MOUNT_PATH`
 - Default: `/jms`
 
 ### mas_app_settings_jms_queue_pvc_accessmode
-Optional. Provide the persistent volume storage access-mode to be used for JMS queue configuration.
+Provide the persistent volume storage access-mode to be used for JMS queue configuration.
 Typically you would either choose between `ReadWriteOnce` (if using a block storage class) or `ReadWriteMany` (if using file storage class).
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_JMS_QUEUE_PVC_ACCESSMODE`
 - Default: `ReadWriteMany`
 
 ### mas_app_settings_default_jms
-Optional. Set this to `true` if you want to have JMS continuous queues configured
+Set this to `true` if you want to have JMS continuous queues configured
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_DEFAULT_JMS`
 - Default: `false`
 
@@ -256,33 +270,38 @@ Optional. Set this to `true` if you want to have JMS continuous queues configure
 The following properties can be defined to customize the persistent volumes for the Doclinks/Attachments setup for Manage.
 
 ### mas_app_settings_doclinks_pvc_storage_class
-Optional. Provide the persistent volume storage class to be used for doclinks/attachments configuration.
+Provide the persistent volume storage class to be used for doclinks/attachments configuration.
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_DOCLINKS_PVC_STORAGE_CLASS`
 - Default: None - If not set, a default storage class will be auto defined accordingly to your cluster's available storage classes.
 
 ### mas_app_settings_doclinks_pvc_name
-Optional. Provide the persistent volume claim name to be used for doclinks/attachments configuration.
+Provide the persistent volume claim name to be used for doclinks/attachments configuration.
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_DOCLINKS_PVC_NAME`
 - Default: `manage-doclinks`
 
 ### mas_app_settings_doclinks_pvc_size
-Optional. Provide the persistent volume claim size to be used for doclinks/attachments configuration.
+Provide the persistent volume claim size to be used for doclinks/attachments configuration.
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_DOCLINKS_PVC_SIZE`
 - Default: `20Gi`
 
 ### mas_app_settings_doclinks_mount_path
-Optional. Provide the persistent volume storage mount path to be used for doclinks/attachments configuration.
+Provide the persistent volume storage mount path to be used for doclinks/attachments configuration.
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_DOCLINKS_MOUNT_PATH`
 - Default: `/DOCLINKS`
 
 ### mas_app_settings_doclinks_pvc_accessmode
-Optional. Provide the persistent volume storage access-mode to be used for doclinks/attachments configuration.
+Provide the persistent volume storage access-mode to be used for doclinks/attachments configuration.
 Typically you would either choose between `ReadWriteOnce` (if using a block storage class) or `ReadWriteMany` (if using file storage class).
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_DOCLINKS_PVC_ACCESSMODE`
 - Default: `ReadWriteMany`
 
@@ -291,53 +310,60 @@ Typically you would either choose between `ReadWriteOnce` (if using a block stor
 The following properties can be defined to customize the persistent volumes for the Building Information Models setup for Manage.
 
 ### mas_app_settings_bim_pvc_storage_class
-Optional. Provide the persistent volume storage class to be used for Building Information Models configuration.
+Provide the persistent volume storage class to be used for Building Information Models configuration.
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_BIM_PVC_STORAGE_CLASS`
 - Default: None - If not set, a default storage class will be auto defined accordingly to your cluster's available storage classes.
 
 ### mas_app_settings_bim_pvc_name
-Optional. Provide the persistent volume claim name to be used for Building Information Models configuration.
+Provide the persistent volume claim name to be used for Building Information Models configuration.
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_BIM_PVC_NAME`
 - Default: `manage-bim`
 
 ### mas_app_settings_bim_pvc_size
-Optional. Provide the persistent volume claim size to be used for Building Information Models configuration.
+Provide the persistent volume claim size to be used for Building Information Models configuration.
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_BIM_PVC_SIZE`
 - Default: `20Gi`
 
 ### mas_app_settings_bim_mount_path
-Optional. Provide the persistent volume storage mount path to be used for Building Information Models configuration.
+Provide the persistent volume storage mount path to be used for Building Information Models configuration.
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_BIM_MOUNT_PATH`
 - Default: `/bim`
 
 ### mas_app_settings_bim_pvc_accessmode
-Optional. Provide the persistent volume storage access-mode to be used for Building Information Models configuration.
+Provide the persistent volume storage access-mode to be used for Building Information Models configuration.
 Typically you would either choose between `ReadWriteOnce` (if using a block storage class) or `ReadWriteMany` (if using file storage class).
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_BIM_PVC_ACCESSMODE`
 - Default: `ReadWriteMany`
 
 ### Manage - Supported languages variables
 ---
 ### mas_app_settings_base_lang
-Optional. Provide the base language for Manage application.
+Provide the base language for Manage application.
 For a full list of supported languages for Manage application and its corresponding language codes, please refer to [Language Support](https://www.ibm.com/docs/en/maximo-manage/continuous-delivery?topic=deploy-language-support) documentation.
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_BASE_LANG`
 - Default: `EN` (English)
 
 ### mas_app_settings_secondary_languages
-Optional. Provide a list of additional secondary languages for Manage application.
+Provide a list of additional secondary languages for Manage application.
 
 Note: The more languages you add, the longer Manage will take to install and activate.
 
 Export the `MAS_APP_SETTINGS_SECONDARY_LANGS` variable with the language codes as comma-separated values.
 For a full list of supported languages for Manage application and its corresponding language codes, please refer to [Language Support](https://www.ibm.com/docs/en/maximo-manage/continuous-delivery?topic=deploy-language-support) documentation.
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_SECONDARY_LANGS`
 - Default: None
 
@@ -367,14 +393,16 @@ Currently supported server bundle sizes are:
 ### Manage - Customization Archive settings variables
 ---
 ### mas_app_settings_customization_archive_url
-Optional. Provide a custom archive/file path to be included as part of Manage deployment.
+Provide a custom archive/file path to be included as part of Manage deployment.
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_URL`
 - Default: None
 
 ### mas_app_settings_customization_archive_name
-Optional. Provide a custom archive file name to be associated with the archive/file path provided. Only used when `mas_app_settings_customization_archive_url` is defined.
+Provide a custom archive file name to be associated with the archive/file path provided. Only used when `mas_app_settings_customization_archive_url` is defined.
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_CUSTOMIZATION_ARCHIVE_NAME`
 - Default: `manage-custom-archive`
 
@@ -382,36 +410,41 @@ Optional. Provide a custom archive file name to be associated with the archive/f
 ---
 
 ### mas_app_settings_crypto_key
-Optional. This defines the `MXE_SECURITY_CRYPTO_KEY` value if you want to customize your Manage database encryption keys.
+This defines the `MXE_SECURITY_CRYPTO_KEY` value if you want to customize your Manage database encryption keys.
 For more details, refer to [Manage database encryption](https://www.ibm.com/docs/en/mas-cd/continuous-delivery?topic=encryption-database-scenarios) documentation.
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_CRYPTO_KEY`
 - Default: Auto-generated
 
 ### mas_app_settings_cryptox_key
-Required if `mas_app_settings_crypto_key` is set. This defines the `MXE_SECURITY_CRYPTOX_KEY` value if you want to customize your Manage database encryption keys.
+This defines the `MXE_SECURITY_CRYPTOX_KEY` value if you want to customize your Manage database encryption keys.
 For more details, refer to [Manage database encryption](https://www.ibm.com/docs/en/mas-cd/continuous-delivery?topic=encryption-database-scenarios) documentation.
 
+- **Required** if `mas_app_settings_crypto_key`is set.
 - Environment Variable: `MAS_APP_SETTINGS_CRYPTOX_KEY`
 - Default: Auto-generated
 
 ### mas_app_settings_old_crypto_key
-Optional. This defines the `MXE_SECURITY_OLD_CRYPTO_KEY` value if you want to customize your Manage database encryption keys.
+This defines the `MXE_SECURITY_OLD_CRYPTO_KEY` value if you want to customize your Manage database encryption keys.
 For more details, refer to [Manage database encryption](https://www.ibm.com/docs/en/mas-cd/continuous-delivery?topic=encryption-database-scenarios) documentation.
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_OLD_CRYPTO_KEY`
 - Default: None
 
 ### mas_app_settings_cryptox_key
-Required if `mas_app_settings_old_crypto_key` is set. This defines the `MXE_SECURITY_OLD_CRYPTOX_KEY` value if you want to customize your Manage database encryption keys.
+This defines the `MXE_SECURITY_OLD_CRYPTOX_KEY` value if you want to customize your Manage database encryption keys.
 For more details, refer to [Manage database encryption](https://www.ibm.com/docs/en/mas-cd/continuous-delivery?topic=encryption-database-scenarios) documentation.
 
+- **Required** if `mas_app_settings_old_crypto_key`is set.
 - Environment Variable: `MAS_APP_SETTINGS_OLD_CRYPTOX_KEY`
 - Default: None
 
 ### mas_app_settings_override_encryption_secrets_flag
-Optional. Set this to `true` if you want to override existing Manage database encryption keys i.e Manage database reencryption scenario. A backup of the secret holding the original encryption keys will be taken prior overriding it with the new defined keys. If set to `false`, then the database encryption keys will only be created with the defined keys if no existing database encryption keys are found under the target Manage instance i.e new Manage installations.
+Set this to `true` if you want to override existing Manage database encryption keys i.e Manage database reencryption scenario. A backup of the secret holding the original encryption keys will be taken prior overriding it with the new defined keys. If set to `false`, then the database encryption keys will only be created with the defined keys if no existing database encryption keys are found under the target Manage instance i.e new Manage installations.
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_OVERRIDE_ENCRYPTION_SECRETS_FLAG`
 - Default: `False`
 
@@ -419,8 +452,9 @@ Optional. Set this to `true` if you want to override existing Manage database en
 ---
 
 ### mas_app_settings_server_timezone
-Optional. Sets the Manage server timezone. If you also want to have the Manage's DB2 database aligned with the same timezone, you must set `DB2_TIMEZONE` while provisioning the corresponding DB2 instance using `db2` role.
+Sets the Manage server timezone. If you also want to have the Manage's DB2 database aligned with the same timezone, you must set `DB2_TIMEZONE` while provisioning the corresponding DB2 instance using `db2` role.
 
+- Optional
 - Environment Variable: `MAS_APP_SETTINGS_SERVER_TIMEZONE`
 - Default: `GMT`
 

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/health.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/health.yml
@@ -8,7 +8,7 @@ mas_appws_spec:
       persistentVolumes: "{{ mas_app_settings_persistent_volumes if (mas_app_settings_persistent_volumes_flag) else [] }}"
       serverBundles: "{{ mas_app_settings_server_bundles[mas_app_settings_server_bundles_size]['serverBundles']}}"
     languages:
-      baseLang: "{{ mas_app_settings_base_language | default( 'EN' , true) }}"
+      baseLang: "{{ mas_app_settings_base_lang | default( 'EN' , true) }}"
       secondaryLangs: "{{ mas_app_settings_secondary_languages.split(',') if (mas_app_settings_secondary_languages is defined and mas_app_settings_secondary_languages | length > 0) else [] }}"
     aio:
       install: "{{ mas_app_settings_aio_flag | bool  }}"

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/health.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/health.yml
@@ -9,7 +9,7 @@ mas_appws_spec:
       serverBundles: "{{ mas_app_settings_server_bundles[mas_app_settings_server_bundles_size]['serverBundles']}}"
     languages:
       baseLang: "{{ mas_app_settings_base_lang | default( 'EN' , true) }}"
-      secondaryLangs: "{{ mas_app_settings_secondary_languages.split(',') if (mas_app_settings_secondary_languages is defined and mas_app_settings_secondary_languages | length > 0) else [] }}"
+      secondaryLangs: "{{ mas_app_settings_secondary_langs.split(',') if (mas_app_settings_secondary_langs is defined and mas_app_settings_secondary_langs | length > 0) else [] }}"
     aio:
       install: "{{ mas_app_settings_aio_flag | bool  }}"
     db:

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/manage.yml
@@ -11,7 +11,7 @@ mas_appws_spec:
       defaultJMS: "{{ mas_app_settings_default_jms }}"
       serverTimezone: "{{ mas_app_settings_server_timezone }}"
     languages:
-      baseLang: "{{ mas_app_settings_base_language | default('EN' , true) }}"
+      baseLang: "{{ mas_app_settings_base_lang | default('EN' , true) }}"
       secondaryLangs: "{{ mas_app_settings_secondary_languages.split(',') if (mas_app_settings_secondary_languages is defined and mas_app_settings_secondary_languages | length > 0) else [] }}"
     aio:
       install: "{{ mas_app_settings_aio_flag | bool  }}"

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/manage.yml
@@ -12,7 +12,7 @@ mas_appws_spec:
       serverTimezone: "{{ mas_app_settings_server_timezone }}"
     languages:
       baseLang: "{{ mas_app_settings_base_lang | default('EN' , true) }}"
-      secondaryLangs: "{{ mas_app_settings_secondary_languages.split(',') if (mas_app_settings_secondary_languages is defined and mas_app_settings_secondary_languages | length > 0) else [] }}"
+      secondaryLangs: "{{ mas_app_settings_secondary_langs.split(',') if (mas_app_settings_secondary_langs is defined and mas_app_settings_secondary_langs | length > 0) else [] }}"
     aio:
       install: "{{ mas_app_settings_aio_flag | bool  }}"
     db:

--- a/ibm/mas_devops/roles/suite_app_config/vars/health.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/health.yml
@@ -66,7 +66,7 @@ mas_app_settings_persistent_volumes_default:
 mas_app_settings_persistent_volumes: "{{ mas_app_settings_persistent_volumes_default if (mas_app_settings_persistent_volumes_flag) else [] }}"
 
 # properties to configure supported languages
-mas_app_settings_base_language: "{{ lookup('env', 'MAS_APP_SETTINGS_BASE_LANG') | default( 'EN', true) }}"
+mas_app_settings_base_lang: "{{ lookup('env', 'MAS_APP_SETTINGS_BASE_LANG') | default( 'EN', true) }}"
 mas_app_settings_secondary_languages: "{{ lookup('env', 'MAS_APP_SETTINGS_SECONDARY_LANGS') | default([], true) }}"
 
 # these settings will defined the bundle servers spec - health standalone just has dev size (all bundle pod)

--- a/ibm/mas_devops/roles/suite_app_config/vars/health.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/health.yml
@@ -67,7 +67,7 @@ mas_app_settings_persistent_volumes: "{{ mas_app_settings_persistent_volumes_def
 
 # properties to configure supported languages
 mas_app_settings_base_lang: "{{ lookup('env', 'MAS_APP_SETTINGS_BASE_LANG') | default( 'EN', true) }}"
-mas_app_settings_secondary_languages: "{{ lookup('env', 'MAS_APP_SETTINGS_SECONDARY_LANGS') | default([], true) }}"
+mas_app_settings_secondary_langs: "{{ lookup('env', 'MAS_APP_SETTINGS_SECONDARY_LANGS') | default([], true) }}"
 
 # these settings will defined the bundle servers spec - health standalone just has dev size (all bundle pod)
 mas_app_settings_server_bundles_size: "dev"

--- a/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
@@ -71,7 +71,7 @@ mas_app_settings_server_timezone: "{{ lookup('env', 'MAS_APP_SETTINGS_SERVER_TIM
 
 # properties to configure supported languages
 mas_app_settings_base_lang: "{{ lookup('env', 'MAS_APP_SETTINGS_BASE_LANG') | default('EN', true) }}"
-mas_app_settings_secondary_languages: "{{ lookup('env', 'MAS_APP_SETTINGS_SECONDARY_LANGS') | default([], true) }}"
+mas_app_settings_secondary_langs: "{{ lookup('env', 'MAS_APP_SETTINGS_SECONDARY_LANGS') | default([], true) }}"
 
 # property to confifure jms queues
 mas_app_settings_default_jms: "{{ lookup('env', 'MAS_APP_SETTINGS_DEFAULT_JMS') | default('false', true) | bool }}"

--- a/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
@@ -70,7 +70,7 @@ mas_app_settings_persistent_volumes: "{{ mas_app_settings_persistent_volumes_def
 mas_app_settings_server_timezone: "{{ lookup('env', 'MAS_APP_SETTINGS_SERVER_TIMEZONE') | default('GMT', true) }}"
 
 # properties to configure supported languages
-mas_app_settings_base_language: "{{ lookup('env', 'MAS_APP_SETTINGS_BASE_LANG') | default('EN', true) }}"
+mas_app_settings_base_lang: "{{ lookup('env', 'MAS_APP_SETTINGS_BASE_LANG') | default('EN', true) }}"
 mas_app_settings_secondary_languages: "{{ lookup('env', 'MAS_APP_SETTINGS_SECONDARY_LANGS') | default([], true) }}"
 
 # property to confifure jms queues


### PR DESCRIPTION
For ibm-mas/cli#1216

Corresponding issues:
- https://github.com/ibm-mas/python-devops/pull/22
- https://github.com/ibm-mas/cli/pull/1217

Aligning variable name usage across our devops tools:
- Any instance of `mas_app_settings_base_language` has been changed to `mas_app_settings_base_lang`
- Any instance of `mas_app_settings_secondary_languages` has been changed to `mas_app_settings_secondary_langs`

Also aligning the impacted readMe in `suit_app_config` to have a consistent method of declaring optional variables. This is in a separate commit to make it easier to review changes