### PR TITLE
[patch] grant dbAdminAnyDatabase role to the admin user

### DIFF
--- a/ibm/mas_devops/roles/mongodb/templates/community/0.7.9/cr.yml.j2
+++ b/ibm/mas_devops/roles/mongodb/templates/community/0.7.9/cr.yml.j2
@@ -42,6 +42,8 @@ spec:
           db: admin
         - name: readWriteAnyDatabase
           db: admin
+        - name: dbAdminAnyDatabase
+          db: admin
       scramCredentialsSecretName: mas-mongo-ce-scram
   additionalMongodConfig:
     storage.wiredTiger.engineConfig.journalCompressor: snappy

--- a/ibm/mas_devops/roles/mongodb/templates/community/0.8.3/cr.yml.j2
+++ b/ibm/mas_devops/roles/mongodb/templates/community/0.8.3/cr.yml.j2
@@ -43,6 +43,8 @@ spec:
           db: admin
         - name: readWriteAnyDatabase
           db: admin
+        - name: dbAdminAnyDatabase
+          db: admin
       scramCredentialsSecretName: mas-mongo-ce-scram
   additionalMongodConfig:
     storage.wiredTiger.engineConfig.journalCompressor: snappy


### PR DESCRIPTION
Grant the admin user the dbAdminAnyDatabase role.  Among other things, this role allows the admin user to enable profiling on any mongodb database in the cluster.