### PR TITLE
[patch] Add retries to fyre provisioning API

### DIFF
--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/fyre.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/fyre.yml
@@ -17,6 +17,7 @@
   assert:
     that: fyre_cluster_size is defined and fyre_cluster_size != ""
 
+
 # 2. Debug Info
 # -----------------------------------------------------------------------------
 - name: "fyre : Debug information"
@@ -41,6 +42,7 @@
       - "Worker CPU ................... {{ fyre_worker_cpu | default('<undefined>', true) }}"
       - "Worker memory ................ {{ fyre_worker_memory | default('<undefined>', true) }}"
 
+
 # 3. Determine whether there is already an environment running
 # -----------------------------------------------------------------------------
 - name: "fyre : Check if cluster already exists"
@@ -58,6 +60,7 @@
   debug:
     var: _cluster_exist
 
+
 # 4. Deploy the OCP+ cluster
 # -----------------------------------------------------------------------------
 - name: "fyre : Debug cluster provision json body"
@@ -69,10 +72,17 @@
   debug:
     msg: "{{ lookup('template', fyre_template_name) }}"
 
+# Note: FYRE rate limits this API globally - we are competing with all other FYRE users for limited "slots" to
+# provision new OCP+ clusters, when this happens we will see an error like this with a RC of 429:
+#
+# > overall (across all product groups and users) rate limit (3 in 5 minutes) exceeded
+#
+# To mitigate this we have a retry in place, but it will also trigger retries due to any other failure condition
+# We will retry for approximately half an hour before giving up.
 - name: "fyre : Create new OCP+ cluster"
   when:
     - _cluster_exist.json is defined
-    - _cluster_exist.json.owning_user is not defined # when there's no cluster owner, it means there's no cluster thus we create it
+    - _cluster_exist.json.owning_user is not defined  # When there's no cluster owner, it means there's no cluster thus we create it
   vars:
     fyre_template_name: "templates/fyre/{{ fyre_quota_type }}.json.j2"
   uri:
@@ -85,10 +95,13 @@
     body_format: json
     validate_certs: false
   register: _cluster_create
+  delay: 60  # Every 1 minute
+  retries: 30
 
 - name: "fyre : Debug cluster provision"
   debug:
     var: _cluster_create
+
 
 # 5. Track the progress of the deployment
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
FYRE rate limits the provisioning API globally - we are competing with all other FYRE users for limited "slots" to provision new OCP+ clusters, when this happens we will see an error like this with a RC of 429:

> overall (across all product groups and users) rate limit (3 in 5 minutes) exceeded

To mitigate this we have a retry in place, but it will also trigger retries due to any other failure condition.  We will retry for approximately half an hour before giving up.