### PR TITLE
[patch] Fix the field value type to string instead of integer for idp timeouts

### DIFF
--- a/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
+++ b/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
@@ -41,15 +41,15 @@ spec:
     {% endif %}
 
     {% if idle_timeout != '' %}
-      idleTimeout: {{ idle_timeout | int }}
+      idleTimeout: {{ idle_timeout }}
     {% endif %}
 
     {% if idp_session_timeout != '' %}
-      idpSessionTimeout: {{ idp_session_timeout | int }}
+      idpSessionTimeout: {{ idp_session_timeout }}
     {% endif %}
 
     {% if refresh_token_timeout != '' %}
-      refreshTokenTimeout: {{ refresh_token_timeout | int }}
+      refreshTokenTimeout: {{ refresh_token_timeout }}
     {% endif %}
 
     {% if seamless_login != '' %}


### PR DESCRIPTION
problem:

1. mas install 
In step 12) Single Sign-On (SSO) ,  enter values like below. 
Many aspects of Maximo Application Suite's Single Sign-On (SSO) can be customized:
 - Idle session automatic logout timer
 - Session, access token, and refresh token timeouts
 - Default identity provider (IDP), and seamless login
 - Brower cookie properties
Configure SSO properties? [y/n] y
Idle session logout timer (seconds) 60
Session timeout (e.g. '12h' for 12 hours) 12h
Access token timeout (e.g. '30m' for 30 minutes) 30m
Refresh token timeout (e.g. '12h' for 12 hours) 12h
Default Identity Provider


fixes

```
RESULT:   TASK [ibm.mas_devops.suite_install : Create suite.ibm.com/v1 CR] ***************
fatal: [localhost]: FAILED! => changed=false 
  error: 422
  msg: 'Suite masdemo: Failed to create object: b''{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Suite.core.mas.ibm.com \\"masdemo\\" is invalid: [spec.settings.sso.idpSessionTimeout: Invalid value: \\"integer\\": spec.settings.sso.idpSessionTimeout in body must be of type string: \\"integer\\", spec.settings.sso.refreshTokenTimeout: Invalid value: \\"integer\\": spec.settings.sso.refreshTokenTimeout in body must be of type string: \\"integer\\"]","reason":"Invalid","details":{"name":"masdemo","group":"core.mas.ibm.com","kind":"Suite","causes":[{"reason":"FieldValueTypeInvalid","message":"Invalid value: \\"integer\\": spec.settings.sso.idpSessionTimeout in body must be of type string: \\"integer\\"","field":"spec.settings.sso.idpSessionTimeout"},{"reason":"FieldValueTypeInvalid","message":"Invalid value: \\"integer\\": spec.settings.sso.refreshTokenTimeout in body must be of type string: \\"integer\\"","field":"spec.settings.sso.refreshTokenTimeout"}]},"code":422}\n'''
  reason: Unprocessable Entity
  status: 422
```