### PR TITLE
[minor] Added HMAC support for cos

### DIFF
--- a/ibm/mas_devops/roles/cos/README.md
+++ b/ibm/mas_devops/roles/cos/README.md
@@ -80,6 +80,12 @@ Local directory to save the generated ObjectStorageCfg resource definition.  Thi
 - Environment Variable: `MAS_CONFIG_DIR`
 - Default Value: None
 
+### use_hmac
+Supported values are true and false, this is used when ibm cloud-cos to be setup with hmac encrypted credentials.
+
+- Environment Variable: USE_HMAC
+- Default: false
+
 ### cluster ingres tls secret name
 Specify the name of the cluster's ingres tls secret which contains the default router certificate.
 

--- a/ibm/mas_devops/roles/cos/defaults/main.yml
+++ b/ibm/mas_devops/roles/cos/defaults/main.yml
@@ -8,6 +8,7 @@ cos_service: "cloud-object-storage"
 # ---------------------------------------------------------------------------------------------------------------------
 mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
 mas_config_dir: "{{ lookup('env', 'MAS_CONFIG_DIR') }}"
+use_hmac: "{{ lookup('env', 'USE_HMAC') | default(false, true) }}" # Supported value is "system"
 
 # OpenShift Container Storage Object Storage (ocs)
 # ---------------------------------------------------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/cos/tasks/providers/ibm/provision.yml
+++ b/ibm/mas_devops/roles/cos/tasks/providers/ibm/provision.yml
@@ -96,13 +96,15 @@
     name: "{{ mas_instance_id }}-key"
     role: "{{ cos_resource_key_iam_role }}"
     resource_instance_id: "{{ cos_resource_id }}"
-    ibmcloud_api_key: "{{ ibmcloud_apikey  }}"
+    ibmcloud_api_key: "{{ ibmcloud_apikey }}"
+    parameters:
+      HMAC: "{{ use_hmac }}"
 
 - name: "ibm : Retrieve cos service credential for this MAS instance"
   ibm.cloudcollection.ibm_resource_key_info:
     name: "{{ mas_instance_id }}-key"
     resource_instance_id: "{{ cos_resource_id }}"
-    ibmcloud_api_key: "{{ ibmcloud_apikey  }}"
+    ibmcloud_api_key: "{{ ibmcloud_apikey }}"
   register: cos_key_info
 
 - name: "ibm : Debug COS Key Resource"
@@ -115,10 +117,20 @@
   set_fact:
     cos_password: "{{ cos_key_info.resource.credentials.apikey }};{{ cos_key_info.resource.credentials.resource_instance_id }}"
 
+- name: "ibm : Set cos_hmac_access_key and cos_hmac_secret_key variable"
+  when:
+    - cos_key_info.resource.credentials is defined
+    - cos_key_info.resource.credentials['cos_hmac_keys.access_key_id'] is defined
+    - cos_key_info.resource.credentials['cos_hmac_keys.secret_access_key'] is defined
+    - use_hmac is defined
+    - use_hmac
+  set_fact:
+    cos_hmac_access_key: "{{ cos_key_info.resource.credentials['cos_hmac_keys.access_key_id'] }}"
+    cos_hmac_secret_key: "{{ cos_key_info.resource.credentials['cos_hmac_keys.secret_access_key'] }}"
 
 # 5. Save the ObjectStorageCfg to local disk
 # ---------------------------------------------------------------------------------------------------------------------
-- name: Copy objectstorageCfg to filesytem
+- name: Copy objectstorageCfg to filesystem
   when:
     - mas_instance_id is defined
     - mas_instance_id != ""

--- a/ibm/mas_devops/roles/cos/templates/ibm/objectstoragecfg.yml.j2
+++ b/ibm/mas_devops/roles/cos/templates/ibm/objectstoragecfg.yml.j2
@@ -14,6 +14,10 @@ metadata:
 data:
   username: "{{ 'ibmcloud-iam-apikey' | b64encode }}"
   password: "{{ cos_password | b64encode }}"
+{% if cos_hmac_access_key is defined and cos_hmac_secret_key is defined %}
+  accesskey: "{{ cos_hmac_access_key | b64encode }}"
+  secretkey: "{{ cos_hmac_secret_key | b64encode }}"
+{% endif %}
 ---
 apiVersion: config.mas.ibm.com/v1
 kind: ObjectStorageCfg


### PR DESCRIPTION
Manage App requires COS instance with HMAC encrypted accesskey and secretkey.

We have tested 2 scenarios:

1). Set HMAC as True. Created build and manage app -instance fvt27929

it sets accesskey, and secret key along with username and password:

<img width="1612" alt="image" src="https://github.com/user-attachments/assets/b77f917a-a9fd-446c-b1f0-8a3fb86bbf7b">

objectstorage config is in Ready State:
<img width="1612" alt="image" src="https://github.com/user-attachments/assets/ea07fdc9-e59c-4128-a5a2-6559888c9d9f">


I have further tested consuming this accesskey and secret key for manage tests and those are working.

2). Set HMAC as False. Created build and manage app -instance fvt28915
it does not set accesskey, and secret key. However it sets username and password as per existing code.

<img width="1623" alt="image" src="https://github.com/user-attachments/assets/aaf68af3-1648-46a0-8a49-5e5b3a4ef418">

objectstorage config is in Ready State:

<img width="1710" alt="image" src="https://github.com/user-attachments/assets/511647ca-b085-4efa-9b3c-c67f54a983d9">



