### PR TITLE
[major] Remove UDS image mirroring support

### DIFF
--- a/ibm/mas_devops/playbooks/mirror_dependencies.yml
+++ b/ibm/mas_devops/playbooks/mirror_dependencies.yml
@@ -21,45 +21,41 @@
     # -------------------------------------------------------------------------
     mirror_common_svcs: "{{ lookup('env', 'MIRROR_COMMONSERVICES') | default ('True', True) | bool }}"
 
-    # 4. UDS
-    # -------------------------------------------------------------------------
-    mirror_uds: "{{ lookup('env', 'MIRROR_UDS') | default ('True', True) | bool }}"
-
-    # 5. SLS
+    # 4. SLS
     # -------------------------------------------------------------------------
     mirror_sls: "{{ lookup('env', 'MIRROR_SLS') | default ('True', True) | bool }}"
 
-    # 6. TSM
+    # 5. TSM
     # -------------------------------------------------------------------------
     mirror_tsm: "{{ lookup('env', 'MIRROR_TRUSTSTOREMGR') | default ('True', True) | bool }}"
 
-    # 7. CP4D
+    # 6. CP4D
     # -------------------------------------------------------------------------
     cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') }}"
     mirror_cp4d: "{{ lookup('env', 'MIRROR_CP4D') | default ('False', True) | bool }}"
     cpd_48_or_higher: "{{ cpd_product_version is defined and cpd_product_version is version('4.8.0','>=') | bool }}"
 
-    # 8. Watson Studio Local
+    # 7. Watson Studio Local
     # -------------------------------------------------------------------------
     mirror_wsl: "{{ lookup('env', 'MIRROR_WSL') | default ('False', True) | bool }}"
 
-    # 9. Watson Machine Learning
+    # 8. Watson Machine Learning
     # -------------------------------------------------------------------------
     mirror_wml: "{{ lookup('env', 'MIRROR_WML') | default ('False', True) | bool }}"
 
-    # 10. Analytics Engine (Spark)
+    # 9. Analytics Engine (Spark)
     # -------------------------------------------------------------------------
     mirror_spark: "{{ lookup('env', 'MIRROR_SPARK') | default ('False', True) | bool }}"
 
-    # 11. Db2u
+    # 10. Db2u
     # -------------------------------------------------------------------------
     mirror_db2u: "{{ lookup('env', 'MIRROR_DB2U') | default ('False', True) | bool }}"
 
-    # 12. Cognos Analytics
+    # 11. Cognos Analytics
     # -------------------------------------------------------------------------
     mirror_cognos: "{{ lookup('env', 'MIRROR_COGNOS') | default ('False', True) | bool }}"
 
-    # 13. App Connect
+    # 12. App Connect
     # -------------------------------------------------------------------------
     mirror_appconnect: "{{ lookup('env', 'MIRROR_APPCONNECT') | default ('False', True) | bool }}"
 
@@ -208,44 +204,7 @@
         manifest_version: "{{ common_svcs_version_1 }}"
 
 
-    # 4. IBM User Data Services
-    # -------------------------------------------------------------------------
-    # 4.1 UDS
-    - name: ibm.mas_devops.mirror_case_prepare
-      when:
-        - mirror_uds
-        - mirror_mode != "from-filesystem"
-      vars:
-        case_name: ibm-uds
-        case_version: "{{ uds_version }}"
-        exclude_images: []
-        ibmpak_skip_dependencies: false
-
-    - name: ibm.mas_devops.mirror_images
-      when: mirror_uds
-      vars:
-        manifest_name: ibm-uds
-        manifest_version: "{{ uds_version }}"
-
-    # 4.2 IBM Events Operator (Used by UDS)
-    # The CASE bundle for this operator is broken, so we will manually mirror the images
-    # Based on UDS version - see catalog version for details
-    - name: ibm.mas_devops.mirror_extras_prepare
-      when:
-        - mirror_uds
-        - mirror_mode != "from-filesystem"
-      vars:
-        extras_name: uds
-        extras_version: "{{ uds_extras_version }}"
-
-    - name: ibm.mas_devops.mirror_images
-      when: mirror_uds
-      vars:
-        manifest_name: extras_uds
-        manifest_version: "{{ uds_extras_version }}"
-
-
-    # 5. IBM Suite License Service
+    # 4. IBM Suite License Service
     # -------------------------------------------------------------------------
     - name: ibm.mas_devops.mirror_case_prepare
       when:
@@ -264,7 +223,7 @@
         manifest_version: "{{ lookup('env', 'SLS_VERSION') | default (sls_version, True) }}"
 
 
-    # 6. IBM Truststore Manager
+    # 5. IBM Truststore Manager
     # -------------------------------------------------------------------------
     - name: ibm.mas_devops.mirror_case_prepare
       when:
@@ -283,7 +242,7 @@
         manifest_version: "{{ lookup('env', 'TSM_VERSION') | default (tsm_version, True) }}"
 
 
-    # 7. CP4D
+    # 6.1 CP4D Platform
     # -------------------------------------------------------------------------
     - name: ibm.mas_devops.mirror_case_prepare
       when:
@@ -301,7 +260,8 @@
         manifest_name: ibm-cp-datacore
         manifest_version: "{{ cp4d_platform_version }}"
 
-    # 7.1 CP4D - IBM Licensing dependency
+
+    # 6.2 CP4D Platform - IBM Licensing dependency
     # -------------------------------------------------------------------------
     - name: ibm.mas_devops.mirror_case_prepare
       when:
@@ -323,7 +283,9 @@
         manifest_name: ibm-licensing
         manifest_version: "{{ ibm_licensing_version }}"
 
-    # 7.2 IBM Watson Studio and Watson Machine Learning dependency - ibm-ccs
+
+    # 6.3 IBM Watson Studio and Watson Machine Learning dependency - ibm-ccs
+    # -------------------------------------------------------------------------
     - name: ibm.mas_devops.mirror_case_prepare
       when:
         - mirror_wsl or mirror_wml
@@ -340,7 +302,9 @@
         manifest_name: ibm-ccs
         manifest_version: "{{ wsl_version }}"
 
-    # 7.3 IBM Watson Studio dependency - ibm-datarefinery
+
+    # 7.1 IBM Watson Studio dependency - ibm-datarefinery
+    # -------------------------------------------------------------------------
     - name: ibm.mas_devops.mirror_case_prepare
       when:
         - mirror_wsl
@@ -357,7 +321,8 @@
         manifest_name: ibm-datarefinery
         manifest_version: "{{ wsl_version }}"
 
-    # 7.4 IBM Watson Studio dependency - ibm-wsl-runtimes
+    # 7.2 IBM Watson Studio dependency - ibm-wsl-runtimes
+    # -------------------------------------------------------------------------
     - name: ibm.mas_devops.mirror_case_prepare
       when:
         - mirror_wsl
@@ -374,7 +339,8 @@
         manifest_name: ibm-wsl-runtimes
         manifest_version: "{{ wsl_version }}"
 
-    # 7.5 IBM Watson Studio dependency - ibm-elasticsearch-operator
+    # 7.3 IBM Watson Studio dependency - ibm-elasticsearch-operator
+    # -------------------------------------------------------------------------
     - name: ibm.mas_devops.mirror_case_prepare
       when:
         - mirror_wsl
@@ -391,7 +357,7 @@
         manifest_name: ibm-elasticsearch-operator
         manifest_version: "{{ elasticsearch_version }}"
 
-    # 8. IBM Watson Studio
+    # 7.4 IBM Watson Studio
     # -------------------------------------------------------------------------
     - name: ibm.mas_devops.mirror_case_prepare
       when:
@@ -410,7 +376,7 @@
         manifest_version: "{{ wsl_version }}"
 
 
-    # 9. IBM Watson Machine Learning
+    # 8. IBM Watson Machine Learning
     # -------------------------------------------------------------------------
     - name: ibm.mas_devops.mirror_case_prepare
       when:
@@ -429,7 +395,7 @@
         manifest_version: "{{ wml_version }}"
 
 
-    # 10. Analytics Engine (Spark)
+    # 9. Analytics Engine (Spark)
     # -------------------------------------------------------------------------
     - name: ibm.mas_devops.mirror_case_prepare
       when:
@@ -448,7 +414,7 @@
         manifest_version: "{{ spark_version }}"
 
 
-    # 11. IBM Db2u
+    # 10. IBM Db2u
     # -------------------------------------------------------------------------
     - name: ibm.mas_devops.mirror_case_prepare
       when:
@@ -481,7 +447,7 @@
         manifest_version: "{{ db2u_extras_version }}"
 
 
-    # 12. Cognos Analytics
+    # 11. Cognos Analytics
     # -------------------------------------------------------------------------
     - name: ibm.mas_devops.mirror_case_prepare
       when:
@@ -500,7 +466,7 @@
         manifest_version: "{{ cognos_version }}"
 
 
-    # 13. App Connect
+    # 12. App Connect
     # -------------------------------------------------------------------------
     - name: ibm.mas_devops.mirror_case_prepare
       when:

--- a/ibm/mas_devops/roles/mirror_images/defaults/main.yml
+++ b/ibm/mas_devops/roles/mirror_images/defaults/main.yml
@@ -16,12 +16,6 @@ artifactory_auth: "{{ artifactory_username }}:{{ artifactory_token }}"
 ibm_entitlement_key: "{{ lookup('env', 'IBM_ENTITLEMENT_KEY') }}"
 ibm_auth: "cp:{{ ibm_entitlement_key }}"
 
-# Authentication - RedHat
-# -----------------------------------------------------------------------------
-redhat_connect_username: "{{ lookup('env', 'REDHAT_CONNECT_USERNAME') }}"
-redhat_connect_password: "{{ lookup('env', 'REDHAT_CONNECT_PASSWORD') }}"
-redhat_connect_auth: "{{ redhat_connect_username }}:{{ redhat_connect_password }}"
-
 # Authentication - Target Registry
 # -----------------------------------------------------------------------------
 registry_username: "{{ lookup('env', 'REGISTRY_USERNAME') }}"

--- a/ibm/mas_devops/roles/mirror_images/templates/auth-secret.json.j2
+++ b/ibm/mas_devops/roles/mirror_images/templates/auth-secret.json.j2
@@ -20,16 +20,6 @@
       "auth": "{{ registry_auth | b64encode }}"
     },
 {% endif %}
-{% if redhat_connect_auth is defined and redhat_connect_auth != ":" %}
-    "registry.connect.redhat.com": {
-      "email": "{{ redhat_connect_username }}",
-      "auth": "{{ redhat_connect_auth | b64encode }}"
-    },
-    "registry.redhat.io": {
-      "email": "{{ redhat_connect_username }}",
-      "auth": "{{ redhat_connect_auth | b64encode }}"
-    },
-{% endif %}
 {% if ibm_auth is defined and ibm_auth != ":" %}
     "cp.icr.io": {
       "email": "unused",


### PR DESCRIPTION
We needed the `redhat_connect_username` and `redhat_connect_password` for mirroring UDS images because some images were in the RedHat container registry instead of the IBM container registry.  Now that we have completed the migration to DRO there is no need for this anymore/mirroring UDS is no longer supported as UDS has been shut down.