### PR TITLE
[patch] replaces awk cmd with k8s_info in detect_cert_manager

### DIFF
--- a/ibm/mas_devops/common_tasks/detect_cert_manager.yml
+++ b/ibm/mas_devops/common_tasks/detect_cert_manager.yml
@@ -8,15 +8,18 @@
 # -----------------------------------------------------------------------------
 # oc get pods -A | grep cert-manager-cainjector| awk '{print $1}' should return the namespace where the cert-manager instance is running i.e cert-manager-operator
 - name: Lookup Certificate Manager installations
-  shell: oc get pods -A | grep cert-manager-cainjector | awk '{print $1}'
+  kubernetes.core.k8s_info:
+    kind: Pod
+    label_selectors:
+      - app=cainjector
   register: cert_manager_webhook_lookup
 
 - debug:
-    var: cert_manager_webhook_lookup.stdout_lines
+    var: cert_manager_webhook_lookup | json_query('resources[*].metadata.namespace')
 
 - name: Set list of namespaces where Certificate Manager is running."
   set_fact:
-    cert_manager_namespace_list: "{{ cert_manager_webhook_lookup.stdout_lines | unique }}" # only interested in distinct namespaces where cert-manager might be installed
+    cert_manager_namespace_list: "{{ cert_manager_webhook_lookup | json_query('resources[*].metadata.namespace') | unique }}" # only interested in distinct namespaces where cert-manager might be installed
 
 - name: Assert Certificate Manager is installed
   assert:


### PR DESCRIPTION
### Description:
Sometimes, awk cmd used here seem to not work in some systems. 
```
- name: Lookup Certificate Manager installations
  shell: oc get pods -A | grep cert-manager-cainjector | awk '{print $1}'
  register: cert_manager_webhook_lookup
```

Hence, awk is replaced with k8s_info to fetch the pod using label_selectors: **app=cainjector**

### Related Links:
https://github.com/ibm-mas/ansible-devops/issues/1323
https://jsw.ibm.com/browse/MASCORE-3809

### Testing:
Tested in a quickburn cluster by installing core. As seen below, k8s_info fetches the pods by label selector successfully and then json_query finds the namespaces from the fetched pods.

[Masdev Install Log.log](https://github.com/user-attachments/files/16905857/Masdev.Install.Log.log)

<img width="1329" alt="Screenshot 2024-09-06 at 14 59 05" src="https://github.com/user-attachments/assets/cd00f7a3-1199-4ecf-92dc-2f5c2f52aaa9">
