### PR TITLE
[patch] apply kubernetes changes server side to avoid version conflicts

### DIFF
--- a/.github/workflows/ansible-publish.yml
+++ b/.github/workflows/ansible-publish.yml
@@ -63,7 +63,7 @@ jobs:
             --enableRetired
 
       - name: Upload dependency check results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
            name: OWASP dependency check report
            path: ${{github.workspace}}/reports

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -33,7 +33,7 @@ jobs:
           $GITHUB_WORKSPACE/build/bin/build-collection.sh
 
       - name: Upload Ansible Collection to Github Actions
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ibm-mas_devops-${{ env.VERSION }}.tar.gz
           path: ${{ github.workspace }}/ibm/mas_devops/ibm-mas_devops-${{ env.VERSION }}.tar.gz
@@ -69,7 +69,7 @@ jobs:
             --enableRetired
 
       - name: Upload dependency check results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
            name: OWASP dependency check report
            path: ${{github.workspace}}/reports

--- a/ibm/mas_devops/roles/cp4d/tasks/create-cpd-core-service-accounts.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/create-cpd-core-service-accounts.yml
@@ -7,6 +7,9 @@
     name: "{{ cpd_sa_item }}"
     namespace: "{{ cpd_instance_namespace }}"
     apply: true
+    server_side_apply:
+      field_manager: ansible
+      force_conflicts: true
     definition:
       imagePullSecrets:
         - name: ibm-entitlement-key

--- a/ibm/mas_devops/roles/cp4d/tasks/install-cp4d.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/install-cp4d.yml
@@ -108,6 +108,9 @@
                   cpu: 200m
                   memory: 1024Mi
         apply: true
+        server_side_apply:
+          field_manager: ansible
+          force_conflicts: true
 
     # 2.4 Delete zen-operator pod to force the reconcile from the beginning after lite-cr is patched.
     # This is just a bit of a hacky way to force zen operator to read the zen version we specify.
@@ -127,6 +130,9 @@
           spec:
             replicas: 0
         apply: true
+        server_side_apply:
+          field_manager: ansible
+          force_conflicts: true
 
     - name: "install-cp4d : Scale up ibm-zen-operator to force reconcile"
       kubernetes.core.k8s:
@@ -138,6 +144,9 @@
           spec:
             replicas: 1
         apply: true
+        server_side_apply:
+          field_manager: ansible
+          force_conflicts: true
 
     # 2.5 Wait for Zen operator ...
     - name: "install-cp4d : Wait for ibm-zen-operator to be ready again (60s delay)"

--- a/ibm/mas_devops/roles/cp4d_service/tasks/create-cpd-service-accounts.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/create-cpd-service-accounts.yml
@@ -7,6 +7,10 @@
     name: "{{ cpd_sa_item }}"
     namespace: "{{ cpd_instance_namespace }}"
     apply: true
+    server_side_apply:
+      field_manager: ansible
+      force_conflicts: true
+
     definition:
       imagePullSecrets:
         - name: ibm-entitlement-key

--- a/ibm/mas_devops/roles/cp4d_service/tasks/install.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/install.yml
@@ -129,6 +129,9 @@
   kubernetes.core.k8s:
     apply: yes
     template: "templates/subscription.yml.j2"
+    server_side_apply:
+      field_manager: ansible
+      force_conflicts: true
 
 # 5. Wait until the Service CRD is available
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-ccs.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-ccs.yml
@@ -55,6 +55,9 @@
                 cpu: 250m
                 memory: 256Mi
         apply: true
+        server_side_apply:
+          field_manager: ansible
+          force_conflicts: true
 
     # 3. Delete ccs-operator pod to force the reconcile from the beginning after ccs-cr is patched.
     # -----------------------------------------------------------------------------
@@ -68,6 +71,9 @@
           spec:
             replicas: 0
         apply: true
+        server_side_apply:
+          field_manager: ansible
+          force_conflicts: true
 
     - name: "wait-ccs : Scale up ccs-operator"
       kubernetes.core.k8s:
@@ -79,6 +85,9 @@
           spec:
             replicas: 1
         apply: true
+        server_side_apply:
+          field_manager: ansible
+          force_conflicts: true
 
     # 4. Wait for ccs operator ...
     # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-elasticsearch.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-elasticsearch.yml
@@ -36,6 +36,9 @@
           spec:
             replicas: 0
         apply: true
+        server_side_apply:
+          field_manager: ansible
+          force_conflicts: true
 
     - name: "wait/ccs : Delete elasticsearch-master-create-snapshot-repo-job so next time it recreates with right imagePullPolicy"
       kubernetes.core.k8s:
@@ -76,6 +79,9 @@
           spec:
             replicas: 1
         apply: true
+        server_side_apply:
+          field_manager: ansible
+          force_conflicts: true
 
     # 2.5 Wait for Elastic Search operator to be ready
     - name: "wait/ccs : Wait for ibm-elasticsearch-operator to be ready again (60s delay)"

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wml-etcd.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-wml-etcd.yml
@@ -42,6 +42,9 @@
           spec:
             replicas: 0
         apply: true
+        server_side_apply:
+          field_manager: ansible
+          force_conflicts: true
 
     # Delete wml-cpd-etcd statefulset so next time it recreates with proper upgrade specs
     - name: "wait/wml : Delete wml-cpd-etcd statefulset so next time it recreates with proper upgrade specs"
@@ -63,6 +66,9 @@
           spec:
             replicas: 1
         apply: true
+        server_side_apply:
+          field_manager: ansible
+          force_conflicts: true
 
     # Wait for ibm-cpd-wml-operator to be ready
     - name: "wait/ccs : Wait for ibm-cpd-wml-operator to be ready again (60s delay)"


### PR DESCRIPTION
**Description**
Fixing Issue https://jsw.ibm.com/browse/MASCORE-3802

409 conflicts occur when applying changes client side as the resource changed has been modifed server side by the time the api call has succeeded. To fix this we use kubernetes server-side apply.

**Testing** 
I tested the new code against pfvtcpd48 cluster, the roles succeeded which doesn't necessarily mean that this intermittent failure is fixed but shows that the server side apply works and doesn't break things further