### PR TITLE
[patch] move mongo image to ubi8

### DIFF
--- a/ibm/mas_devops/roles/mirror_extras_prepare/vars/mongoce_7.0.12.yml
+++ b/ibm/mas_devops/roles/mirror_extras_prepare/vars/mongoce_7.0.12.yml
@@ -22,5 +22,5 @@ extra_images:
 
   - name: ibmmas/mongo
     registry: quay.io
-    tag: 7.0.12
-    digest: sha256:33aab919ee0106de3569cac6c99530c5ab66e3ef532a40fcdabe8c9f42a52395 # quay.io/mongodb/mongodb-community-server:7.0.12-ubi9-20240705T083914Z
+    tag: 7.0.12-ubi8-20240909T102937Z
+    digest: sha256:34341de709b1a70f5e0339ecb1ad2aa2152ecf88e5ca825e2a764da69bbd0269 # quay.io/mongodb/mongodb-community-server:7.0.12-ubi8-20240909T102937Z


### PR DESCRIPTION
A bug in ubi9 is causing a fips enabled cluster to not work with Mongo 7. So we need to pick up the ubi 8 version.

I have tested this version out in a fips compliant fyre cluster. 

SLS Mongo Configuration:
<img width="1522" alt="image" src="https://github.com/user-attachments/assets/ac39db0a-1756-48a1-9dcf-356574b46d28">

Mongo Namespace and Mongo 7:
<img width="1544" alt="image" src="https://github.com/user-attachments/assets/9096315b-1a90-4c63-b72f-6b9579bf20dd">

<img width="1546" alt="image" src="https://github.com/user-attachments/assets/9448d2bc-a556-43fb-a15d-60b023271323">


