### PR TITLE
[patch] Add cos prefix in use_hmac parameter

### DIFF
--- a/ibm/mas_devops/roles/cos/README.md
+++ b/ibm/mas_devops/roles/cos/README.md
@@ -80,10 +80,10 @@ Local directory to save the generated ObjectStorageCfg resource definition.  Thi
 - Environment Variable: `MAS_CONFIG_DIR`
 - Default Value: None
 
-### use_hmac
+### cos_use_hmac
 Supported values are true and false, this is used when ibm cloud-cos to be setup with hmac encrypted credentials.
 
-- Environment Variable: USE_HMAC
+- Environment Variable: COS_USE_HMAC
 - Default: false
 
 ### cluster ingres tls secret name

--- a/ibm/mas_devops/roles/cos/defaults/main.yml
+++ b/ibm/mas_devops/roles/cos/defaults/main.yml
@@ -8,7 +8,7 @@ cos_service: "cloud-object-storage"
 # ---------------------------------------------------------------------------------------------------------------------
 mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
 mas_config_dir: "{{ lookup('env', 'MAS_CONFIG_DIR') }}"
-use_hmac: "{{ lookup('env', 'USE_HMAC') | default(false, true) }}" # Supported value is "system"
+cos_use_hmac: "{{ lookup('env', 'COS_USE_HMAC') | default(false, true) }}"
 
 # OpenShift Container Storage Object Storage (ocs)
 # ---------------------------------------------------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/cos/tasks/providers/ibm/provision.yml
+++ b/ibm/mas_devops/roles/cos/tasks/providers/ibm/provision.yml
@@ -98,7 +98,7 @@
     resource_instance_id: "{{ cos_resource_id }}"
     ibmcloud_api_key: "{{ ibmcloud_apikey }}"
     parameters:
-      HMAC: "{{ use_hmac }}"
+      HMAC: "{{ cos_use_hmac }}"
 
 - name: "ibm : Retrieve cos service credential for this MAS instance"
   ibm.cloudcollection.ibm_resource_key_info:
@@ -122,8 +122,8 @@
     - cos_key_info.resource.credentials is defined
     - cos_key_info.resource.credentials['cos_hmac_keys.access_key_id'] is defined
     - cos_key_info.resource.credentials['cos_hmac_keys.secret_access_key'] is defined
-    - use_hmac is defined
-    - use_hmac
+    - cos_use_hmac is defined
+    - cos_use_hmac
   set_fact:
     cos_hmac_access_key: "{{ cos_key_info.resource.credentials['cos_hmac_keys.access_key_id'] }}"
     cos_hmac_secret_key: "{{ cos_key_info.resource.credentials['cos_hmac_keys.secret_access_key'] }}"


### PR DESCRIPTION
As `use_hmac` parameter refers to cos, we must use `cos_` prefix to follow the standard for cos parameters.

We have three PRs that must be merged together:
- https://github.com/ibm-mas/cli/pull/1241
- https://github.com/ibm-mas/ansible-devops/pull/1467
- https://github.ibm.com/maximoappsuite/ansible-fvt/pull/478

-----

Tested in fvt-personal (pfvtaleq):

<img width="757" alt="image" src="https://github.com/user-attachments/assets/a59f76db-7f2b-4109-b2d7-3a33a7f13c20">

And `cos` role/task has passed:

<img width="291" alt="image" src="https://github.com/user-attachments/assets/2a55e4f4-2941-48bb-85df-1a816497d65d">
 