### PR TITLE
[patch] debug statement for cos hmac

### DIFF
--- a/ibm/mas_devops/roles/cos/tasks/providers/ibm/provision.yml
+++ b/ibm/mas_devops/roles/cos/tasks/providers/ibm/provision.yml
@@ -117,6 +117,12 @@
   set_fact:
     cos_password: "{{ cos_key_info.resource.credentials.apikey }};{{ cos_key_info.resource.credentials.resource_instance_id }}"
 
+- name: debug access_key_id
+  debug:
+    msg:
+     - "access_key_id ..... {{ cos_key_info.resource.credentials['cos_hmac_keys.access_key_id'] }}"
+
+
 - name: "ibm : Set cos_hmac_access_key and cos_hmac_secret_key variable"
   when:
     - cos_key_info.resource.credentials is defined


### PR DESCRIPTION
Simple debug statement for cos hmac. 
Test results:
```
TASK [ibm.mas_devops.cos : debug access_key_id] ********************************
ok: [localhost] => 
  msg:
  - access_key_id ..... <redacted>
```
