### PR TITLE
[patch] wait for subscription to complete when creating

### DIFF
--- a/ibm/mas_devops/common_tasks/create_subscription.yml
+++ b/ibm/mas_devops/common_tasks/create_subscription.yml
@@ -135,7 +135,7 @@
   register: _subscription_info
   retries: 30
   delay: 30 # Retry for approx 15 minutes (30s * 30 attempts) before giving up
-  until: 
+  until:
     - _subscription_info.resources | length > 0
     - _subscription_info.resources[0].status.state is defined
     - _subscription_info.resources[0].status.state == "AtLatestKnown"

--- a/ibm/mas_devops/common_tasks/create_subscription.yml
+++ b/ibm/mas_devops/common_tasks/create_subscription.yml
@@ -123,3 +123,19 @@
   until:
     - _installplan_info.resources[0].status.phase is defined
     - _installplan_info.resources[0].status.phase == "Complete"
+
+# 5. Wait for Subscription to complete
+# -----------------------------------------------------------------------------
+- name: "create_subscription : Wait for Subscription state to become 'AtLatestKnown'"
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    namespace: "{{ subscription_namespace }}"
+    name: "{{ package_name }}"
+  register: _subscription_info
+  retries: 30
+  delay: 30 # Retry for approx 15 minutes (30s * 30 attempts) before giving up
+  until: 
+    - _subscription_info.resources | length > 0
+    - _subscription_info.resources[0].status.state is defined
+    - _subscription_info.resources[0].status.state == "AtLatestKnown"


### PR DESCRIPTION
**Description**
https://jsw.ibm.com/browse/MASCORE-3864 Is caused by an update to catalogs while the cert manager is being installed. To avoid this, the install pipeline has been changed to run the cert-manager role after the ibm-catalogs role (see https://github.com/ibm-mas/cli/pull/1249).

This change tests that the subscription successfully reaches "AtLatestKnown" state before continuing processing, giving an early failure if the subcription fails to resolve.

**Testing**
Tested by running in pfvtpds cluster:
<img width="543" alt="Project mas-pfvtpds-pipelines" src="https://github.com/user-attachments/assets/b51683c0-7fc5-46fd-9c22-a0df2ba36c27">

