### PR TITLE
[patch] [MASCORE-3733] grafana dashboard not working after upgrade openshift to v4.15

### DIFF
--- a/ibm/mas_devops/roles/grafana/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/grafana/tasks/install/main.yml
@@ -71,13 +71,21 @@
     wait: yes
     wait_timeout: 300
 
+# 7. Install service account and role to use promethesus
+# -------------------------------------------------------------------------------------
+- name: "install : Create Prometheus Service Account and Role"
+  kubernetes.core.k8s:
+    template: "templates/grafana/v{{grafana_major_version}}/grafana-prometheus-serviceaccount.yml.j2"
+    wait: yes
+    wait_timeout: 300
+    
 # 7. Configure Grafana Datasource
 # -------------------------------------------------------------------------------------
 # As per https://docs.openshift.com/container-platform/4.8/monitoring/enabling-monitoring-for-user-defined-projects.html#enabling-monitoring-for-user-defined-projects
 # use the external thanos url
 
-- name: Create the prometheus-user-workload token
-  shell: "oc create token prometheus-user-workload -n openshift-user-workload-monitoring"
+- name: Create the prometheus token
+  shell: "oc create token prometheus-serviceaccount -n {{ grafana_namespace }}"
   register: prometheus_token_resp
   retries: 10
   delay: 30 # seconds

--- a/ibm/mas_devops/roles/grafana/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/grafana/tasks/install/main.yml
@@ -79,7 +79,7 @@
     wait: yes
     wait_timeout: 300
 
-# 7. Configure Grafana Datasource
+# 8. Configure Grafana Datasource
 # -------------------------------------------------------------------------------------
 # As per https://docs.openshift.com/container-platform/4.8/monitoring/enabling-monitoring-for-user-defined-projects.html#enabling-monitoring-for-user-defined-projects
 # use the external thanos url
@@ -121,7 +121,7 @@
     wait: yes
     wait_timeout: 120
 
-# 8. Wait for Grafana to be ready
+# 9. Wait for Grafana to be ready
 # -------------------------------------------------------------------------------------
 - name: "install : Wait for grafana v5 to be ready (60s delay)"
   kubernetes.core.k8s_info:

--- a/ibm/mas_devops/roles/grafana/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/grafana/tasks/install/main.yml
@@ -78,7 +78,7 @@
     template: "templates/grafana/v{{grafana_major_version}}/grafana-prometheus-serviceaccount.yml.j2"
     wait: yes
     wait_timeout: 300
-    
+
 # 7. Configure Grafana Datasource
 # -------------------------------------------------------------------------------------
 # As per https://docs.openshift.com/container-platform/4.8/monitoring/enabling-monitoring-for-user-defined-projects.html#enabling-monitoring-for-user-defined-projects

--- a/ibm/mas_devops/roles/grafana/templates/grafana/v4/grafana-prometheus-serviceaccount.yml.j2
+++ b/ibm/mas_devops/roles/grafana/templates/grafana/v4/grafana-prometheus-serviceaccount.yml.j2
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-serviceaccount
+  namespace: "{{ grafana_v4_namespace }}"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-role
+rules:
+  - verbs:
+      - get
+      - create
+    apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheuses/api
+      - prometheus/api
+      - prometheuses
+      - prometheus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-rolebinding
+roleRef:
+  name: prometheus-role
+  kind: ClusterRole
+  apiGroup: ""
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-serviceaccount
+    namespace: "{{ grafana_v4_namespace }}"

--- a/ibm/mas_devops/roles/grafana/templates/grafana/v4/grafana-prometheus-serviceaccount.yml.j2
+++ b/ibm/mas_devops/roles/grafana/templates/grafana/v4/grafana-prometheus-serviceaccount.yml.j2
@@ -20,6 +20,62 @@ rules:
       - prometheus/api
       - prometheuses
       - prometheus
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resources:
+      - nodes/metrics
+  - verbs:
+      - get
+    nonResourceURLs:
+      - /metrics
+  - verbs:
+      - create
+    apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+  - verbs:
+      - create
+    apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resources:
+      - namespaces
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - services
+      - endpoints
+      - pods
+  - verbs:
+      - get
+    apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - alertmanagers
+  - verbs:
+      - use
+    apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - nonroot-v2
+  - verbs:
+      - create
+    nonResourceURLs:
+      - /api/v2/alerts
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/ibm/mas_devops/roles/grafana/templates/grafana/v5/grafana-prometheus-serviceaccount.yml.j2
+++ b/ibm/mas_devops/roles/grafana/templates/grafana/v5/grafana-prometheus-serviceaccount.yml.j2
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-serviceaccount
+  namespace: "{{ grafana_v5_namespace }}"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-role
+rules:
+  - verbs:
+      - get
+      - create
+    apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheuses/api
+      - prometheus/api
+      - prometheuses
+      - prometheus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-rolebinding
+roleRef:
+  name: prometheus-role
+  kind: ClusterRole
+  apiGroup: ""
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-serviceaccount
+    namespace: "{{ grafana_v5_namespace }}"

--- a/ibm/mas_devops/roles/suite_install/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_install/defaults/main.yml
@@ -11,7 +11,7 @@ mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
 
 # Enable Support for Special Characters in Usernames
 # -----------------------------------------------------------------------------
-mas_special_characters : "{{ lookup('env', 'MAS_SPECIAL_CHARACTERS') }}"
+mas_special_characters: "{{ lookup('env', 'MAS_SPECIAL_CHARACTERS') }}"
 
 # SSO Configuration
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
I fixed this by copying the rbac rules from the prometheus user workload serviceaccount and allowing us to create our own and modify the rules. The missing rules were:
```
- verbs:
      - get
      - create
    apiGroups:
      - monitoring.coreos.com
    resources:
      - prometheuses/api
      - prometheus/api
      - prometheuses
      - prometheus
```
I am not sure if this is a a new feature that was added to 4.15 OpenShift, but we didn't have the ability to manipulate the rules in the existing service account. This should guarantee we have control over the roles and permissions of Grafana going forward so we do not hit 401 and 403 errors and if we do we can easily update the file and redeploy.