### PR TITLE
[patch] fix nfs for manage and health

### DIFF
--- a/ibm/mas_devops/roles/suite_app_config/vars/health.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/health.yml
@@ -23,6 +23,7 @@ mas_app_settings_default_manage_supported_storage_classes:
   - ocs-storagecluster-cephfs
   - azurefiles-premium
   - efs
+  - nfs-client
 
 # properties to configure persistent volumes for doclinks i.e attachments
 mas_app_settings_doclinks_pvc_storage_class: "{{ lookup('env', 'MAS_APP_SETTINGS_DOCLINKS_PVC_STORAGE_CLASS') }}" # if not defined by user, it will be automatically defined while setting persistent storage

--- a/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
@@ -24,6 +24,7 @@ mas_app_settings_default_manage_supported_storage_classes:
   - ocs-storagecluster-cephfs
   - azurefiles-premium
   - efs
+  - nfs-client
 
 # properties to configure persistent volumes for doclinks i.e attachments
 mas_app_settings_doclinks_pvc_storage_class: "{{ lookup('env', 'MAS_APP_SETTINGS_DOCLINKS_PVC_STORAGE_CLASS') }}" # if not defined by user, it will be automatically defined while setting persistent storage

--- a/ibm/mas_devops/roles/suite_manage_pvc_config/tasks/determine-storage-classes.yml
+++ b/ibm/mas_devops/roles/suite_manage_pvc_config/tasks/determine-storage-classes.yml
@@ -21,7 +21,7 @@
     - mas_app_settings_custom_persistent_volume_sc_name is not defined or mas_app_settings_custom_persistent_volume_sc_name == ""
   vars:
     # ROKS, OCS, Azure
-    supported_storage_classes: [ibmc-file-gold-gid, ocs-storagecluster-cephfs, azurefiles-premium]
+    supported_storage_classes: [ibmc-file-gold-gid, ocs-storagecluster-cephfs, nfs-client, azurefiles-premium]
   set_fact:
     mas_app_settings_custom_persistent_volume_sc_name: "{{ lookup_storageclasses | ibm.mas_devops.defaultStorageClass(supported_storage_classes) }}"
 


### PR DESCRIPTION
No related issue to this but found a bug around the storage class `nfs-client` setup not being defaulted for manage and health as well as not setting it as the cluster primary storage when installing quick burn Fyre clusters. 