### PR TITLE
[patch] Fix namespace lookup when cert provider is ibm

### DIFF
--- a/ibm/mas_devops/common_tasks/detect_cert_manager.yml
+++ b/ibm/mas_devops/common_tasks/detect_cert_manager.yml
@@ -11,7 +11,7 @@
   kubernetes.core.k8s_info:
     kind: Pod
     label_selectors:
-      - app=cainjector
+      - app in (cainjector, ibm-cert-manager-cainjector)
   register: cert_manager_webhook_lookup
 
 - debug:


### PR DESCRIPTION
## Description:
Currently, the task for namespace lookup in detect_cert_manager fails if the certificate_manager_provider is used as ibm since, it has a different app label compared to redhat provider. This change adds the label for ibm provider as well.

## Related Links:
https://jsw.ibm.com/browse/MASCORE-3918

## Testing:
Tested in a quickburn with 2 scenarios having certificate manager as ibm and redhat.

**Certificate manager provider is ibm:**
<img width="1027" alt="Screenshot 2024-09-19 at 17 32 41" src="https://github.com/user-attachments/assets/e57dfccb-2a50-4541-9d6e-faed3e238034">
<img width="1719" alt="Screenshot 2024-09-19 at 18 16 32" src="https://github.com/user-attachments/assets/b213ba1e-ae17-4d6d-ae00-23bfb1e03efb">


**Certificate manager provider is redhat:**
<img width="1023" alt="Screenshot 2024-09-19 at 18 14 43" src="https://github.com/user-attachments/assets/c556927d-e108-4e74-b98b-3613f21b4102">
<img width="1719" alt="Screenshot 2024-09-19 at 18 17 42" src="https://github.com/user-attachments/assets/e0972a09-fe3a-4fec-a09f-bb7e0597cafc">
