### PR TITLE
[patch] use apiVersion instead of api in grafana role

### DIFF
--- a/ibm/mas_devops/roles/grafana/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/grafana/tasks/install/main.yml
@@ -84,6 +84,7 @@
 # As per https://docs.openshift.com/container-platform/4.8/monitoring/enabling-monitoring-for-user-defined-projects.html#enabling-monitoring-for-user-defined-projects
 # use the external thanos url
 
+
 - name: Create the prometheus token
   shell: "oc create token prometheus-serviceaccount -n {{ grafana_namespace }}"
   register: prometheus_token_resp
@@ -97,7 +98,7 @@
 
 - name: "install : Get Thanos Querier route in openshift-monitoring namespace"
   kubernetes.core.k8s_info:
-    api: v1
+    api_version: route.openshift.io/v1
     kind: Route
     name: thanos-querier
     namespace: openshift-monitoring


### PR DESCRIPTION
@cuddlyporcupine  ran into an issue where short hand api version wasn't working, this works in both older and newer clusters 