### PR TITLE
[patch] add support for default storage classes in techzone clusters

### DIFF
--- a/ibm/mas_devops/common_vars/default_storage_classes.yml
+++ b/ibm/mas_devops/common_vars/default_storage_classes.yml
@@ -2,6 +2,7 @@
 default_storage_classes_rwx:
   - ibmc-file-gold-gid
   - ocs-storagecluster-cephfs
+  - ocs-external-storagecluster-cephfs
   - efs
   - azurefiles-premium
   - nfs-client
@@ -16,6 +17,7 @@ default_storage_classes_rwx_nogid:
 default_storage_classes_rwo:
   - ibmc-block-gold
   - ocs-storagecluster-ceph-rbd
+  - ocs-external-storagecluster-ceph-rbd
   - gp3-csi
   - managed-premium
   - nfs-client


### PR DESCRIPTION
This PR is for support storage classes for cluster provisioned in techzone

![image](https://github.com/user-attachments/assets/335ac32a-e9aa-474a-bc57-17e38955b6e2)

This was tested by me on Mas Core + AI Broker deployment
