### PR TITLE
[patch] allow setting of PLAIN authentication for MongoDB

### DIFF
--- a/ibm/mas_devops/roles/gencfg_mongo/README.md
+++ b/ibm/mas_devops/roles/gencfg_mongo/README.md
@@ -25,6 +25,18 @@ Required. MongoDB admin password
 - Environment Variable: `MONGODB_ADMIN_PASSWORD`
 - Default: None
 
+### mongodb_authentication_mechanism
+Required. MongoDB authentication mechanism. Specify DEFAULT for SCRAM-SHA-256 or SCRAM-SHA-1. For LDAP authentication use PLAIN
+
+- Environment Variable: `MONGODB_AUTHENTICATION_MECHANISM`
+- Default: DEFAULT
+
+### mongodb_authentication_database
+Required. MongoDB authentication database. This value must be $external if PLAIN has been specified for mongodb_authentication_mechanism
+
+- Environment Variable: `MONGODB_AUTHENTICATION_DATABASE`
+- Default: admin
+
 ### mongodb_hosts
 Required. In case if there are multiple instances, the host address should be seperated by a ,. Example: docdb-1.abc.ca-central-1.docdb.amazonaws.com:27017,docdb-2.def.ca-central-1.docdb.amazonaws.com:27017
 

--- a/ibm/mas_devops/roles/gencfg_mongo/defaults/main.yml
+++ b/ibm/mas_devops/roles/gencfg_mongo/defaults/main.yml
@@ -4,6 +4,8 @@
 mongodb_namespace: "{{ lookup('env', 'MONGODB_NAMESPACE') | default('mongoce', true) }}"
 mongodb_admin_username: "{{ lookup('env', 'MONGODB_ADMIN_USERNAME') }}"
 mongodb_admin_password: "{{ lookup('env', 'MONGODB_ADMIN_PASSWORD') }}"
+mongodb_authentication_mechanism: "{{ lookup('env', 'MONGODB_AUTHENTICATION_MECHANISM') | default('DEFAULT', true) }}"
+mongodb_authentication_database: "{{ lookup('env', 'MONGODB_AUTHENTICATION_DATABASE') | default('admin', true) }}"
 mongodb_hosts: "{{ lookup('env', 'MONGODB_HOSTS') }}"
 mongodb_ca_pem_local_file: "{{ lookup('env', 'MONGODB_CA_PEM_LOCAL_FILE') }}"
 # MAS instance configuration

--- a/ibm/mas_devops/roles/gencfg_mongo/tasks/main.yml
+++ b/ibm/mas_devops/roles/gencfg_mongo/tasks/main.yml
@@ -47,6 +47,24 @@
     that: mongo_hosts_dict is defined and mongo_hosts_dict|length>0
     fail_msg: "mongo_hosts_dict is empty"
 
+- name: "Fail if mongodb_authentication_mechanism is not DEFAULT or PLAIN"
+  assert:
+    that: 
+      - mongodb_authentication_mechanism is defined
+      - mongodb_authentication_mechanism == "DEFAULT" or mongodb_authentication_mechanism == "PLAIN"
+    fail_msg: "mongodb_authentication_mechanism may only be defined as DEFAULT or PLAIN"
+
+- name: "Fail if mongodb_authentication_database is not provided"
+  assert:
+    that: mongodb_authentication_database is defined and mongodb_authentication_database != ""
+    fail_msg: "mongodb_authentication_database property is required"
+
+- name: "Fail if mongodb_authentication_mechanism is PLAIN and mongodb_authentication_database is not $external"
+  assert:
+    that: mongodb_authentication_database == "$external"
+    fail_msg: "mongodb_authentication_database must be set to $external when mongodb_authentication_mechanism is set to PLAIN"
+  when: mongodb_authentication_mechanism == "PLAIN"
+
 - name: "Debug information"
   debug:
     msg:
@@ -54,6 +72,8 @@
       - "MAS Config Dir.......................... {{ mas_config_dir }}"
       - "Mongo Admin username.................... {{ mongodb_admin_username }}"
       - "Mongo Admin password.................... {{ mongodb_admin_password }}"
+      - "Mongo Authentication Mechanism.......... {{ mongodb_authentication_mechanism }}"
+      - "Mongo Authentication Database........... {{ mongodb_authentication_database }}"
       - "Mongo hosts ID.......................... {{ mongodb_hosts }}"
       - "Mongo CA PEM............................ {{ mongodb_ca_pem_local_file }}"
       - "Mongo Namespace......................... {{ mongodb_namespace }}"

--- a/ibm/mas_devops/roles/gencfg_mongo/tasks/main.yml
+++ b/ibm/mas_devops/roles/gencfg_mongo/tasks/main.yml
@@ -49,7 +49,7 @@
 
 - name: "Fail if mongodb_authentication_mechanism is not DEFAULT or PLAIN"
   assert:
-    that: 
+    that:
       - mongodb_authentication_mechanism is defined
       - mongodb_authentication_mechanism == "DEFAULT" or mongodb_authentication_mechanism == "PLAIN"
     fail_msg: "mongodb_authentication_mechanism may only be defined as DEFAULT or PLAIN"

--- a/ibm/mas_devops/roles/gencfg_mongo/templates/suite_mongocfg.yml.j2
+++ b/ibm/mas_devops/roles/gencfg_mongo/templates/suite_mongocfg.yml.j2
@@ -34,9 +34,9 @@ spec:
   displayName: "External MongoDB in 'mas-{{mas_instance_id}}-core' namespace"
   type: external
   config:
-    configDb: admin
+    configDb: {{mongodb_authentication_database}}
     retryWrites: {{mongodb_retry_writes}}
-    authMechanism: DEFAULT
+    authMechanism: {{mongodb_authentication_mechanism}}
     credentials:
       secretName: mongodb-{{mas_instance_id|lower}}-admin
     hosts:

--- a/ibm/mas_devops/roles/mongodb/README.md
+++ b/ibm/mas_devops/roles/mongodb/README.md
@@ -722,6 +722,10 @@ cat /proc/cpuinfo | grep flags | grep avx
 
 If `avx` is not found in the available `flags` then either the physical processor hosting the OpenShift cluster does not provide the AVX instruction set or the virtual host configuration is not exposing the AVX instruction set. If the latter is suspected the virtual hosting documentation should be referenced for details on how to expose the AVX instruction set.
 
+### LDAP Authentication
+
+If authenticating via LDAP with PLAIN specified for `authMechanism` then `configDb` must be set to `$external` in the MongoCfg. The field `configDb` in the MongoCfg refers to the authentication database. 
+
 ### CA Certificate Renewal
 
 !!! warning


### PR DESCRIPTION
## Document and and logic for PLAIN authMechanism and MongoDB

Previously for the convenience role `gencfg_mongo` there was no mention of how to configure LDAP authentication. LDAP authentication is available when the MongoDB instance is MongoDB EE. When using LDAP authentication the `authMechanism` in the MongoCfg must be set to `PLAIN` and the `configDb` field should be set to `$external`

This PR will introduce documentation related to LDAP authentication and update the `gencfg_mongo` role to allow setting of the `authMechanism` and `configDb`.

**note**

In the MongoCfg the filed `configDb` refers to the MongoDB authentication database. 

## Testing

All scenarios of the `gencfg_mongo` role have been testing with respect to `authMechanism` and `configDb`. This includes default settings as well as setting `authMechanism` to DEFAULT and PLAIN.