### PR TITLE
[patch] [MASCORE-3990] Mongo v7 upgrade wipes existing stateful set cpu/memory requests/limits

### DIFF
--- a/ibm/mas_devops/roles/mongodb/README.md
+++ b/ibm/mas_devops/roles/mongodb/README.md
@@ -94,8 +94,7 @@ List of preserved settings
 - mongodb_storage_class
 - mongodb_storage_capacity_data
 - mongodb_storage_capacity_logs
-
-
+- mongodb_replicas
 
 ### mongodb_storage_class
 Required.  The name of the storage class to configure the MongoDb operator to use for persistent storage in the MongoDb cluster.

--- a/ibm/mas_devops/roles/mongodb/README.md
+++ b/ibm/mas_devops/roles/mongodb/README.md
@@ -75,6 +75,28 @@ Defines the specific mongo version to be used. Best practice would be to use the
 - Environment Variable: `MONGODB_VERSION`
 - Default Value: Automatically defined by the mongo version specified in the [latest MAS case bundle available](https://github.com/ibm-mas/ansible-devops/tree/master/ibm/mas_devops/common_vars/casebundles).
 
+### mongodb_override_spec
+This forces the deploy to use the environment variables instead of maintaining spec settings for the existing installed MongoDB. By default this is False and if you upgrade or reinstall Mongo your existing settings will be preserved.
+
+!!! important
+    It is advised you check your existing Mongo installation before using this. If you do not set the environment variables to match what you have in the spec or you use defaults you may find your members, memory, and cpu reset to the default values specified in this README. Unknown settings are not preserved in the spec.
+
+- Optional
+- Environment Variable: `MONGODB_OVERRIDE_SPEC`
+- Default Value: `false`
+
+List of preserved settings
+
+- mongodb_cpu_limits
+- mongodb_mem_limits
+- mongodb_cpu_requests
+- mongodb_mem_requests
+- mongodb_storage_class
+- mongodb_storage_capacity_data
+- mongodb_storage_capacity_logs
+
+
+
 ### mongodb_storage_class
 Required.  The name of the storage class to configure the MongoDb operator to use for persistent storage in the MongoDb cluster.
 

--- a/ibm/mas_devops/roles/mongodb/defaults/main.yml
+++ b/ibm/mas_devops/roles/mongodb/defaults/main.yml
@@ -17,6 +17,9 @@ mas_app_id: "{{ lookup('env', 'MAS_APP_ID') }}"
 # Where to install the operator and create the mongo instance
 mongodb_namespace: "{{ lookup('env', 'MONGODB_NAMESPACE') | default('mongoce', True) }}"
 
+# Decide if you want to keep your current spec for Mongo or overwrite it
+mongodb_override_spec: "{{ lookup('env','MONGODB_OVERRIDE_SPEC') | default (false, true) | bool }}"
+
 # Storage configuration
 mongodb_storage_class: "{{ lookup('env', 'MONGODB_STORAGE_CLASS') }}"
 mongodb_storage_capacity_data: "{{ lookup('env', 'MONGODB_STORAGE_CAPACITY_DATA') | default('20Gi', True) }}"

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/install-mongo.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/install-mongo.yml
@@ -99,6 +99,7 @@
       - "MAS instance ID ........................... {{ mas_instance_id | default('<undefined>', True) }}"
       - "MAS config directory ...................... {{ mas_config_dir | default('<undefined>', True)  }}"
       - "Controlled Upgrade ........................ {{ controlled_upgrade }}"
+      - "Override Spec over existing MongoDB ....... {{ mongodb_override_spec }}"
 
 # Validate if upgrade has been issued by user
 # Only needed when there is an existing mongo instance and its version does not match with the target version to be installed
@@ -275,7 +276,7 @@
     apply: yes
     definition: "{{ lookup('template', 'templates/community/{{ mongodb_ce_version }}/cr.yml.j2') }}"
   when:
-    - existing_mongodb.resources[0].status.version is not defined
+    - mongodb_override_spec or existing_mongodb.resources[0].status.version is not defined
 
 - name: "community : install : Preserving existing settings if Mongo already installed"
   vars:
@@ -292,6 +293,7 @@
     definition: "{{ lookup('template', 'templates/community/{{ mongodb_ce_version }}/cr.yml.j2') }}"
   when:
     - existing_mongodb.resources[0].status.version is defined
+    - not mongodb_override_spec
 
 - name: "community : install : Set expected MongoDb version to {{ current_mongodb_version }}"
   set_fact:

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/install-mongo.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/install-mongo.yml
@@ -270,10 +270,28 @@
 
 # 11. Deploy the cluster
 # -----------------------------------------------------------------------------
-- name: "community : install : Create MongoDb cluster"
+- name: "community : install : Install new MongoDB cluster CR"
   kubernetes.core.k8s:
     apply: yes
     definition: "{{ lookup('template', 'templates/community/{{ mongodb_ce_version }}/cr.yml.j2') }}"
+  when:
+    - existing_mongodb.resources[0].status.version is not defined
+
+- name: "community : install : Preserving existing settings if Mongo already installed"
+  vars:
+    mongodb_cpu_limits: "{{ existing_mongodb.resources[0].spec.statefulSet.spec.template.spec.containers[0].resources.limits.cpu }}"
+    mongodb_mem_limits: "{{ existing_mongodb.resources[0].spec.statefulSet.spec.template.spec.containers[0].resources.limits.memory }}"
+    mongodb_cpu_requests: "{{ existing_mongodb.resources[0].spec.statefulSet.spec.template.spec.containers[0].resources.requests.cpu }}"
+    mongodb_mem_requests: "{{ existing_mongodb.resources[0].spec.statefulSet.spec.template.spec.containers[0].resources.requests.memory }}"
+    mongodb_storage_class: "{{ existing_mongodb.resources[0].spec.statefulSet.spec.volumeClaimTemplates[0].spec.storageClassName }}"
+    mongodb_storage_capacity_data: "{{ existing_mongodb.resources[0].spec.statefulSet.spec.volumeClaimTemplates[0].spec.resources.requests.storage }}"
+    mongodb_storage_capacity_logs: "{{ existing_mongodb.resources[0].spec.statefulSet.spec.volumeClaimTemplates[1].spec.resources.requests.storage }}"
+    mongodb_replicas: "{{ existing_mongodb.resources[0].spec.members }}"
+  kubernetes.core.k8s:
+    apply: yes
+    definition: "{{ lookup('template', 'templates/community/{{ mongodb_ce_version }}/cr.yml.j2') }}"
+  when:
+    - existing_mongodb.resources[0].status.version is defined
 
 - name: "community : install : Set expected MongoDb version to {{ current_mongodb_version }}"
   set_fact:
@@ -344,6 +362,8 @@
     kind: StatefulSet
     name: mas-mongo-ce
     namespace: "{{ mongodb_namespace }}"
+  vars:
+    mongodb_replicas_check: "{{ existing_mongodb.resources[0].spec.members | default(mongodb_replicas|int) }}"
   register: mongodb_statefulset
   retries: 45 # Approx 90 minutes
   delay: 120 # 2 minutes
@@ -351,7 +371,7 @@
     - mongodb_statefulset.resources is defined
     - mongodb_statefulset.resources | length > 0
     - mongodb_statefulset.resources[0].status.readyReplicas is defined
-    - mongodb_statefulset.resources[0].status.readyReplicas ==  (mongodb_replicas|int)
+    - mongodb_statefulset.resources[0].status.readyReplicas ==  (mongodb_replicas_check|int)
 
 - name: "community : install : Wait for mas-mongo-ce-arb stateful set to be ready"
   when: target_mongodb_version is version('4.4.0','>=') # this statefulset will only exist in Mongo v4.4+


### PR DESCRIPTION
When running load test Eric discovered that we ran into an issue with Mongo being scaled down and having all of it's setting overwritten during an upgrade. We do no preserve Mongo settings meaning the environment variables need to be set to what you have or you lose everything.

This new functionality will preserve your settings by default and adds a new environment variable that allows you to revert spec or overwrite the spec how you see fit to allow the existing functionality to still be used. 