### PR TITLE
[patch] Fix path in mongodb role

### DIFF
--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/backup-database.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/backup-database.yml
@@ -14,7 +14,7 @@
     # Create mongodb role and user for backing up databases
     # -------------------------------------------------------------------------
     - name: "Create mongodb role and user for backing up databases"
-      include_tasks: "tasks/providers/{{ mongodb_provider }}/create-role-user.yml"
+      include_tasks: "{{ role_path }}/tasks/providers/{{ mongodb_provider }}/create-role-user.yml"
 
 
     # Prepare mongodb database backup folder

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/backup.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/backup.yml
@@ -74,7 +74,7 @@
     # Run backup tasks for each data type
     # -------------------------------------------------------------------------
     - name: "Run backup tasks for each data type"
-      include_tasks: "tasks/providers/{{ mongodb_provider }}/backup-{{ job_data_item.type }}.yml"
+      include_tasks: "{{ role_path }}/tasks/providers/{{ mongodb_provider }}/backup-{{ job_data_item.type }}.yml"
       vars:
         masbr_job_data_seq: "{{ job_data_item.seq }}"
         masbr_job_data_type: "{{ job_data_item.type }}"

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/restore-database.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/restore-database.yml
@@ -14,7 +14,7 @@
     # Create mongodb role and user for backing up databases
     # -------------------------------------------------------------------------
     - name: "Create mongodb role and user for backing up databases"
-      include_tasks: "tasks/providers/{{ mongodb_provider }}/create-role-user.yml"
+      include_tasks: "{{ role_path }}/tasks/providers/{{ mongodb_provider }}/create-role-user.yml"
 
 
     # Prepare mongodb database restore folders

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/restore.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/restore.yml
@@ -77,7 +77,7 @@
     # Run restore tasks for each data type
     # -------------------------------------------------------------------------
     - name: "Run restore tasks for each data type"
-      include_tasks: "tasks/providers/{{ mongodb_provider }}/restore-{{ job_data_item.type }}.yml"
+      include_tasks: "{{ role_path }}/tasks/providers/{{ mongodb_provider }}/restore-{{ job_data_item.type }}.yml"
       vars:
         masbr_job_data_seq: "{{ job_data_item.seq }}"
         masbr_job_data_type: "{{ job_data_item.type }}"


### PR DESCRIPTION
## Description

A customer reported that when they ran `ansible-playbook ibm.mas_devops.br_manage` they would get the following error:
```bash
TASK [ibm.mas_devops.mongodb : Run backup tasks for each data type] ************
fatal: [localhost]: FAILED! => 
  reason: Could not find or access '/opt/app-root/lib64/python3.9/site-packages/ansible_collections/ibm/mas_devops/playbooks/tasks/providers/community/backup-namespace.yml' on the Ansible Controller.
fatal: [localhost]: FAILED! => 
  reason: Could not find or access '/opt/app-root/lib64/python3.9/site-packages/ansible_collections/ibm/mas_devops/playbooks/tasks/providers/community/backup-pv.yml' on the Ansible Controller.
```

`{{ role_path }}` was missing in some tasks whereas others had it. So I've added this var to the path of those that did not have it.

## Related issues

- https://github.com/ibm-mas/ansible-devops/issues/1492

## Testing

I ran a backup test using:

```bash
export MASBR_ACTION=backup
export MASBR_STORAGE_TYPE=local
export MASBR_STORAGE_LOCAL_FOLDER=/Users/rawa/github.ibm.com/ibm-mas/ansible-devops/tmp
export MAS_INSTANCE_ID=fvtcore_d
export MAS_WORKSPACE_ID=masdev
```

output:
```bash
TASK [ibm.mas_devops.mongodb : Summary] ****************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": [
        "Job name ........................... mongodb-fvtcore_d-full-20240927145916",
        "Job status ......................... Completed",
        "Job storage location ............... /Users/rawa/github.ibm.com/ibm-mas/ansible-devops/tmp/backups/mongodb-fvtcore_d-full-20240927145916"
    ]
}

PLAY RECAP *********************************************************************************************************************************************************************************************
localhost                  : ok=194  changed=24   unreachable=0    failed=0    skipped=159  rescued=0    ignored=0  
```