### PR TITLE
[patch] Switch Prometheus SA token creation from oc cli to ansible module

### DIFF
--- a/ibm/mas_devops/roles/grafana/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/grafana/tasks/install/main.yml
@@ -84,17 +84,17 @@
 # As per https://docs.openshift.com/container-platform/4.8/monitoring/enabling-monitoring-for-user-defined-projects.html#enabling-monitoring-for-user-defined-projects
 # use the external thanos url
 
+- name: Get prometheus secret
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: prometheus-serviceaccount-token
+    namespace: "{{ grafana_v5_namespace }}"
+  register: prometheus_secret
 
-- name: Create the prometheus token
-  shell: "oc create token prometheus-serviceaccount -n {{ grafana_namespace }}"
-  register: prometheus_token_resp
-  retries: 10
-  delay: 30 # seconds
-  until: prometheus_token_resp.rc == 0
-
-- name: Get prometheus token
+- name: Get prometheus secret
   set_fact:
-    prometheus_token: "{{prometheus_token_resp.stdout_lines | first}}"
+    prometheus_token: "{{ prometheus_secret.resources[0].data.token |  b64decode }}"
 
 - name: "install : Get Thanos Querier route in openshift-monitoring namespace"
   kubernetes.core.k8s_info:

--- a/ibm/mas_devops/roles/grafana/templates/grafana/v5/grafana-prometheus-serviceaccount.yml.j2
+++ b/ibm/mas_devops/roles/grafana/templates/grafana/v5/grafana-prometheus-serviceaccount.yml.j2
@@ -5,6 +5,15 @@ metadata:
   name: prometheus-serviceaccount
   namespace: "{{ grafana_v5_namespace }}"
 ---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: prometheus-serviceaccount-token
+  namespace: "{{ grafana_v5_namespace }}"
+  annotations:
+    kubernetes.io/service-account.name: prometheus-serviceaccount
+type: kubernetes.io/service-account-token
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:


### PR DESCRIPTION
In order not to use the 'oc cli'. We switch the creation of the token of the prometheus service account via the creation of a dedicated secret and we retrieve it via the ansible k8s_info module.

Since Openshit 4.16, the creation of an SA no longer automatically generates a token. So we have to create it.