### PR TITLE
[patch] Fix usage of MASBR_BACKUP_DATA

### DIFF
--- a/ibm/mas_devops/common_tasks/backup_restore/check_backup_vars.yml
+++ b/ibm/mas_devops/common_tasks/backup_restore/check_backup_vars.yml
@@ -48,7 +48,10 @@
     masbr_job_data_list: "{{ masbr_job_data_list | default([], true) }}"
 
 - name: "Set fact: specified backup data"
-  when: masbr_backup_data is defined and masbr_backup_data | length > 0
+  when:
+    - masbr_backup_data is defined
+    - masbr_backup_data | length > 0
+    - (_ignore_masbr_backup_data is not defined) or (_ignore_masbr_backup_data is defined and not _ignore_masbr_backup_data)
   block:
     - name: "Set fact: reset masbr_job_data_specified"
       set_fact:

--- a/ibm/mas_devops/roles/db2/tasks/backup/main.yml
+++ b/ibm/mas_devops/roles/db2/tasks/backup/main.yml
@@ -25,6 +25,7 @@
 - name: "Before run tasks"
   include_tasks: "{{ role_path }}/../../common_tasks/backup_restore/before_run_tasks.yml"
   vars:
+    _ignore_masbr_backup_data: true
     _job_type: "backup"
     _component_before_task_path: "{{ role_path }}/tasks/before-backup-restore.yml"
 

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/backup.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/backup.yml
@@ -34,6 +34,7 @@
 - name: "Before run tasks"
   include_tasks: "{{ role_path }}/../../common_tasks/backup_restore/before_run_tasks.yml"
   vars:
+    _ignore_masbr_backup_data: true
     _job_type: "backup"
     _component_before_task_path: "{{ role_path }}/tasks/providers/{{ mongodb_provider }}/before-backup-restore.yml"
 

--- a/ibm/mas_devops/roles/suite_app_backup_restore/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_app_backup_restore/defaults/main.yml
@@ -7,3 +7,14 @@ masbr_action: "{{ lookup('env', 'MASBR_ACTION') }}"
 # Manage PVC paths to backup/restore, format: "<pvcName>:<mountPath>/<subPath>" separated by commas
 # For example: "pvc-docs:/doclinks/attachments,pvc-maxlogs:/maxlogs"
 masbr_manage_pvc_paths: "{{ lookup('env', 'MASBR_MANAGE_PVC_PATHS') | default('', true) }}"
+
+# Backup/Restore - Supported job types per app
+# https://ibm-mas.github.io/ansible-devops/roles/suite_app_backup_restore/#masbr_backup_data
+# https://ibm-mas.github.io/ansible-devops/roles/suite_app_backup_restore/#masbr_restore_data
+supported_job_data_item_types:
+  health: ["namespace", "wsl"]
+  iot: ["namespace"]
+  manage: ["namespace", "pv"]
+  monitor: ["namespace"]
+  optimizer: ["namespace"]
+  visualinspection: ["namespace", pv]

--- a/ibm/mas_devops/roles/suite_app_backup_restore/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_backup_restore/tasks/main.yml
@@ -84,6 +84,11 @@
           - seq: "1"
             phase: "New"
 
+    - name: Debug stuff
+      ansible.builtin.debug:
+        msg:
+          - "mas_app_id ......................................... {{ mas_app_id }}"
+          - "supported_job_data_item_types[mas_app_id] .......... {{ supported_job_data_item_types[mas_app_id] }}"
 
     # Run backup/restore tasks for each data type
     # TODO: check and ignore unsupported data type
@@ -98,6 +103,7 @@
       loop: "{{ masbr_job_data_list }}"
       loop_control:
         loop_var: job_data_item
+      when: job_data_item.type in supported_job_data_item_types[mas_app_id]
 
   rescue:
     # Update job status: Failed

--- a/ibm/mas_devops/roles/suite_backup_restore/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_backup_restore/defaults/main.yml
@@ -1,3 +1,6 @@
 ---
 masbr_action: "{{ lookup('env', 'MASBR_ACTION') }}"
 mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
+
+# Backup/Restore - Supported job types
+supported_job_data_item_types: ["namespace"]

--- a/ibm/mas_devops/roles/suite_backup_restore/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_backup_restore/tasks/main.yml
@@ -75,6 +75,7 @@
       loop: "{{ masbr_job_data_list }}"
       loop_control:
         loop_var: job_data_item
+      when: job_data_item.type in supported_job_data_item_types
 
   rescue:
     # Update job status: Failed


### PR DESCRIPTION
## Description

## Related issues

- https://github.com/ibm-mas/ansible-devops/issues/1492

## Testing

- I ran the backup for mongo and also for hot

```bash
TASK [ibm.mas_devops.suite_app_backup_restore : Summary] ***********************
ok: [localhost] => {
    "msg": [
        "Job name ........................... iot-fvtcore-full-20241001153655",
        "Job status ......................... InProgress",
        "Job storage location ............... /Users/rawa/github.ibm.com/ibm-mas/ansible-devops/tmp/backups/iot-fvtcore-full-20241001153655"
    ]
}

PLAY RECAP *********************************************************************
localhost                  : ok=578  changed=75   unreachable=0    failed=0    skipped=517  rescued=0    ignored=0 
```