### PR TITLE
[patch] add large expiration time to the prometheus token creation in the grafana ansible role

### DIFF
--- a/ibm/mas_devops/roles/grafana/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/grafana/tasks/install/main.yml
@@ -86,7 +86,7 @@
 
 
 - name: Create the prometheus token
-  shell: "oc create token prometheus-serviceaccount -n {{ grafana_namespace }}"
+  shell: "oc create token prometheus-serviceaccount -n {{ grafana_namespace }} --duration=4294967296s"
   register: prometheus_token_resp
   retries: 10
   delay: 30 # seconds


### PR DESCRIPTION
The current prometheus token expires after 1 hour, resulting in dashboards rendering 403 error codes 1 hour after grafana is installed.  With this change the prometheus token expiration is much larger.