### PR TITLE
[patch] Include amlen operator 1.1.2 with small fix for a timing window

### DIFF
--- a/ibm/mas_devops/common_vars/casebundles/v9-241107-amd64.yml
+++ b/ibm/mas_devops/common_vars/casebundles/v9-241107-amd64.yml
@@ -92,7 +92,7 @@ db2u_extras_version: 1.0.6
 
 # Extra Images for Amlen
 # ------------------------------------------------------------------------------
-amlen_extras_version: 1.1.1
+amlen_extras_version: 1.1.2
 
 # Default Cloud Pak for Data version
 # ------------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/mirror_extras_prepare/vars/amlen_1.1.2.yml
+++ b/ibm/mas_devops/roles/mirror_extras_prepare/vars/amlen_1.1.2.yml
@@ -1,0 +1,16 @@
+---
+extra_images:
+  - name: amlen/operator-bundle
+    registry: quay.io
+    digest: sha256:9242f268798e522e5be5035f5f68dba1677560939d7464896fe71e8bc32be612
+    tag: 1.1.2
+
+  - name: amlen/operator
+    registry: quay.io
+    digest: sha256:bba8f0fa2767f2aa3a308e1d045b9dcfd1a87418471de9a59140d14593428d98
+    tag: 1.1.2
+
+  - name: kubebuilder/kube-rbac-proxy
+    registry: gcr.io
+    digest: sha256:0df4ae70e3bd0feffcec8f5cdb428f4abe666b667af991269ec5cb0bbda65869
+    tag: 1.1.2


### PR DESCRIPTION
Prior to this fix if the operator is restarted whilst it is configuring Amlen it can leave the Amlens in a state that the operator doesn't cover them from. This includes a fix to that timing window.