### PR TITLE
[patch] Add dash to the cluster name to have indenitifer the vpc in ocp_efs role

### DIFF
--- a/ibm/mas_devops/roles/ocp_efs/tasks/efs-setup.yml
+++ b/ibm/mas_devops/roles/ocp_efs/tasks/efs-setup.yml
@@ -19,7 +19,7 @@
 
 - name: "efs-setup : Query to Filter the Cluster VPC Id from the list of VPCs"
   vars:
-    query: "Vpcs[?(Tags[?contains(Value,'{{ cluster_name }}' )])].VpcId"
+    query: "Vpcs[?(Tags[?contains(Value,'{{ cluster_name }}-' )])].VpcId"
   set_fact:
     vpcid: "{{ vpc_ids.stdout|from_json|json_query(query) }}"
 


### PR DESCRIPTION
Small change to allow the efs role to distinguish between similar named clusters.

Adding the `-` means we can find the cluster `fvtsaas` when we also have a `fvtsaas2` cluster. The value in the tags for the vpc has the vpic id like `fvtsaas-xgsrr-vpc`