### PR TITLE
[PATCH] Add OCP 4.16 into the rotation

### DIFF
--- a/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
@@ -29,7 +29,7 @@
     ocp_version: "{{ rotate_ocp_version[ansible_date_time['weekday']] ~ ('_openshift' if cluster_type == 'roks' else '') }}"
   vars:
     rotate_ocp_version:
-      Monday: 4.15
+      Monday: 4.16
       Tuesday: 4.14
       Wednesday: 4.13
       Thursday: 4.12


### PR DESCRIPTION
Adding OCP 4.16 to the OCP rotation, 4.15 is still the default and still runs over the weekend. The reason for choosing monday was that anyone analyzing test results on monday will typically be looking at tests from Friday and the weekend so it's nice for them to all be using the same OCP level.

Runs on OCP 4.16 have found no problems with Core or IoT so this expands coverage to the other Apps.