### PR TITLE
[patch] ensure mongo v6 is default version

### DIFF
--- a/ibm/mas_devops/common_vars/casebundles/v9-241003-amd64.yml
+++ b/ibm/mas_devops/common_vars/casebundles/v9-241003-amd64.yml
@@ -73,7 +73,7 @@ uds_extras_version: 1.5.0
 
 # Extra Images for Mongo
 # ------------------------------------------------------------------------------
-mongo_extras_version_default: 7.0.12
+mongo_extras_version_default: 6.0.12
 mongo_extras_version: "{{ lookup('env', 'MONGODB_VERSION') | default(mongo_extras_version_default, True) }}"
 
 # Variables used to mirror additional mongo image versions


### PR DESCRIPTION
we're not ready yet to make v7 the default mongo version in the catalog