### PR TITLE
[MINOR] change from CPD 4.8.0 to 5.0.0

### DIFF
--- a/ibm/mas_devops/common_vars/casebundles/v9-241107-amd64.yml
+++ b/ibm/mas_devops/common_vars/casebundles/v9-241107-amd64.yml
@@ -13,7 +13,7 @@ ibm_licensing_version: 4.2.7                 # Operator version 4.2.7 (https://g
 common_svcs_version: 4.8.0                   # check once why we have 4.3.0 in all previous versions since so long it's 4.3.0   # Operator version 4.3.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
 common_svcs_version_1: 4.7.0+20240702.100000 # svcs 4.8.0 still uses some 4.7.0 images so need to mirror both
 cp4d_platform_version: 5.0.0+20240716.101015 # Operator version 5.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/4.0.0%2B20231213.115030)
-ibm_zen_version: 6.0.1-32                    # For CPD5 ibm-zen has to be explicitily mirrored
+ibm_zen_version: 6.0.1                       # For CPD5 ibm-zen has to be explicitily mirrored
 
 db2u_version: 6.0.1+20240704.142950.9960     # Operator version 110509.0.2 to find the version 6.0.1, search CASE_VERSION in db2u, catalog.yaml into ibm-maximo-operator-catalog (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
 events_version: 5.0.1                        # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)

--- a/ibm/mas_devops/common_vars/casebundles/v9-241107-amd64.yml
+++ b/ibm/mas_devops/common_vars/casebundles/v9-241107-amd64.yml
@@ -13,7 +13,7 @@ ibm_licensing_version: 4.2.7                 # Operator version 4.2.7 (https://g
 common_svcs_version: 4.8.0                   # check once why we have 4.3.0 in all previous versions since so long it's 4.3.0   # Operator version 4.3.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
 common_svcs_version_1: 4.7.0+20240702.100000 # svcs 4.8.0 still uses some 4.7.0 images so need to mirror both
 cp4d_platform_version: 5.0.0+20240716.101015 # Operator version 5.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/4.0.0%2B20231213.115030)
-ibm_zen_version: 6.0.1                       # For CPD5 ibm-zen has to be explicitily mirrored
+ibm_zen_version: 6.0.1+20240708.121250.32    # For CPD5 ibm-zen has to be explicitily mirrored
 
 db2u_version: 6.0.1+20240704.142950.9960     # Operator version 110509.0.2 to find the version 6.0.1, search CASE_VERSION in db2u, catalog.yaml into ibm-maximo-operator-catalog (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
 events_version: 5.0.1                        # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)

--- a/ibm/mas_devops/common_vars/casebundles/v9-241107-amd64.yml
+++ b/ibm/mas_devops/common_vars/casebundles/v9-241107-amd64.yml
@@ -10,8 +10,10 @@ catalog_digest: sha256:7925f996210de3665537b28a76d696472711afbb05bf71efa8fbc6b44
 # Dependencies
 # -----------------------------------------------------------------------------
 ibm_licensing_version: 4.2.7                 # Operator version 4.2.7 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-licensing)
-common_svcs_version: 4.3.0                   # check once why we have 4.3.0 in all previous versions since so long it's 4.3.0   # Operator version 4.3.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
-cp4d_platform_version: 4.0.0+20231213.115030 # Operator version 5.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/4.0.0%2B20231213.115030)
+common_svcs_version: 4.8.0                   # check once why we have 4.3.0 in all previous versions since so long it's 4.3.0   # Operator version 4.3.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-common-services)
+common_svcs_version_1: 4.7.0+20240702.100000 # svcs 4.8.0 still uses some 4.7.0 images so need to mirror both
+cp4d_platform_version: 5.0.0+20240716.101015 # Operator version 5.0.0 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-cp-datacore/4.0.0%2B20231213.115030)
+ibm_zen_version: 6.0.1-32                    # For CPD5 ibm-zen has to be explicitily mirrored
 
 db2u_version: 6.0.1+20240704.142950.9960     # Operator version 110509.0.2 to find the version 6.0.1, search CASE_VERSION in db2u, catalog.yaml into ibm-maximo-operator-catalog (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-db2uoperator)
 events_version: 5.0.1                        # Operator version 5.0.1 (https://github.com/IBM/cloud-pak/tree/master/repo/case/ibm-events-operator)

--- a/ibm/mas_devops/playbooks/mirror_dependencies.yml
+++ b/ibm/mas_devops/playbooks/mirror_dependencies.yml
@@ -315,37 +315,37 @@
 #        manifest_name: ibm-cp-datacore
 #        manifest_version: "5.0.0"
 
-    - name: ibm.mas_devops.mirror_case_prepare
-      when:
-        - mirror_cp4d
-        - mirror_mode != "from-filesystem"
-      vars:
-        case_name: ibm-cp-datacore
-        case_version: "5.0.0+20240619.104646"
-        exclude_images: []
-        ibmpak_skip_dependencies: true
+#    - name: ibm.mas_devops.mirror_case_prepare
+#      when:
+#        - mirror_cp4d
+#        - mirror_mode != "from-filesystem"
+#      vars:
+#        case_name: ibm-cp-datacore
+#        case_version: "5.0.0+20240619.104646"
+#        exclude_images: []
+#        ibmpak_skip_dependencies: true
+#
+#    - name: ibm.mas_devops.mirror_images
+#      when: mirror_cp4d
+#      vars:
+#        manifest_name: ibm-cp-datacore
+#        manifest_version: "5.0.0+20240619.104646"
 
-    - name: ibm.mas_devops.mirror_images
-      when: mirror_cp4d
-      vars:
-        manifest_name: ibm-cp-datacore
-        manifest_version: "5.0.0+20240619.104646"
-
-    - name: ibm.mas_devops.mirror_case_prepare
-      when:
-        - mirror_cp4d
-        - mirror_mode != "from-filesystem"
-      vars:
-        case_name: ibm-cp-datacore
-        case_version: "5.0.0+20240627.200436"
-        exclude_images: []
-        ibmpak_skip_dependencies: true
-
-    - name: ibm.mas_devops.mirror_images
-      when: mirror_cp4d
-      vars:
-        manifest_name: ibm-cp-datacore
-        manifest_version: "5.0.0+20240627.200436"
+#    - name: ibm.mas_devops.mirror_case_prepare
+#      when:
+#        - mirror_cp4d
+#        - mirror_mode != "from-filesystem"
+#      vars:
+#        case_name: ibm-cp-datacore
+#        case_version: "5.0.0+20240627.200436"
+#        exclude_images: []
+#        ibmpak_skip_dependencies: true
+#
+#    - name: ibm.mas_devops.mirror_images
+#      when: mirror_cp4d
+#      vars:
+#        manifest_name: ibm-cp-datacore
+#        manifest_version: "5.0.0+20240627.200436"
 
     - name: ibm.mas_devops.mirror_case_prepare
       when:

--- a/ibm/mas_devops/playbooks/mirror_dependencies.yml
+++ b/ibm/mas_devops/playbooks/mirror_dependencies.yml
@@ -299,28 +299,28 @@
         manifest_version: "{{ cp4d_platform_version }}"
 
 
+#    - name: ibm.mas_devops.mirror_case_prepare
+#      when:
+#        - mirror_cp4d
+#        - mirror_mode != "from-filesystem"
+#      vars:
+#        case_name: ibm-cp-datacore
+#        case_version: "5.0.0"
+#        exclude_images: []
+#        ibmpak_skip_dependencies: true
+#
+#    - name: ibm.mas_devops.mirror_images
+#      when: mirror_cp4d
+#      vars:
+#        manifest_name: ibm-cp-datacore
+#        manifest_version: "5.0.0"
+
     - name: ibm.mas_devops.mirror_case_prepare
       when:
         - mirror_cp4d
         - mirror_mode != "from-filesystem"
       vars:
-        case_name: ibm-cp-datacore
-        case_version: "5.0.0"
-        exclude_images: []
-        ibmpak_skip_dependencies: true
-
-    - name: ibm.mas_devops.mirror_images
-      when: mirror_cp4d
-      vars:
-        manifest_name: ibm-cp-datacore
-        manifest_version: "5.0.0"
-
-    - name: ibm.mas_devops.mirror_case_prepare
-      when:
-        - mirror_cp4d
-        - mirror_mode != "from-filesystem"
-      vars:
-        case_name: ibm-cp-datacore
+        case_name: ibm-cp-datacore3
         case_version: "5.0.0+20240619.104646"
         exclude_images: []
         ibmpak_skip_dependencies: true
@@ -328,7 +328,7 @@
     - name: ibm.mas_devops.mirror_images
       when: mirror_cp4d
       vars:
-        manifest_name: ibm-cp-datacore
+        manifest_name: ibm-cp-datacore3
         manifest_version: "5.0.0+20240619.104646"
 
     - name: ibm.mas_devops.mirror_case_prepare
@@ -363,21 +363,21 @@
         manifest_name: ibm-cp-datacore
         manifest_version: "5.0.0+20240716.101015"
 
-    - name: ibm.mas_devops.mirror_case_prepare
-      when:
-        - mirror_cp4d
-        - mirror_mode != "from-filesystem"
-      vars:
-        case_name: ibm-cp-datacore
-        case_version: "5.0.1"
-        exclude_images: []
-        ibmpak_skip_dependencies: true
+#    - name: ibm.mas_devops.mirror_case_prepare
+#      when:
+#        - mirror_cp4d
+#        - mirror_mode != "from-filesystem"
+#      vars:
+#        case_name: ibm-cp-datacore
+#        case_version: "5.0.1"
+#        exclude_images: []
+#        ibmpak_skip_dependencies: true
 
-    - name: ibm.mas_devops.mirror_images
-      when: mirror_cp4d
-      vars:
-        manifest_name: ibm-cp-datacore
-        manifest_version: "5.0.1"
+#    - name: ibm.mas_devops.mirror_images
+#      when: mirror_cp4d
+#      vars:
+#        manifest_name: ibm-cp-datacore
+#        manifest_version: "5.0.1"
 
     - name: ibm.mas_devops.mirror_case_prepare
       when:

--- a/ibm/mas_devops/playbooks/mirror_dependencies.yml
+++ b/ibm/mas_devops/playbooks/mirror_dependencies.yml
@@ -299,6 +299,21 @@
         manifest_version: "{{ cp4d_platform_version }}"
 
 
+    - name: ibm.mas_devops.mirror_case_prepare
+      when:
+        - mirror_cp4d
+        - mirror_mode != "from-filesystem"
+      vars:
+        case_name: ibm-cp-datacore
+        case_version: "5.0.0"
+        exclude_images: []
+        ibmpak_skip_dependencies: true
+
+    - name: ibm.mas_devops.mirror_images
+      when: mirror_cp4d
+      vars:
+        manifest_name: ibm-cp-datacore
+        manifest_version: "5.0.0"
     # 6.2 CP4D Platform - IBM Licensing dependency
     # -------------------------------------------------------------------------
     - name: ibm.mas_devops.mirror_case_prepare

--- a/ibm/mas_devops/playbooks/mirror_dependencies.yml
+++ b/ibm/mas_devops/playbooks/mirror_dependencies.yml
@@ -239,7 +239,7 @@
       vars:
         manifest_name: ibm-zen
         manifest_version: "6.0.1"
-        
+
     # Mirroring another version for Cloud Pak Foundation Services
     - name: ibm.mas_devops.mirror_case_prepare
       when:

--- a/ibm/mas_devops/playbooks/mirror_dependencies.yml
+++ b/ibm/mas_devops/playbooks/mirror_dependencies.yml
@@ -314,6 +314,135 @@
       vars:
         manifest_name: ibm-cp-datacore
         manifest_version: "5.0.0"
+
+    - name: ibm.mas_devops.mirror_case_prepare
+      when:
+        - mirror_cp4d
+        - mirror_mode != "from-filesystem"
+      vars:
+        case_name: ibm-cp-datacore
+        case_version: "5.0.0+20240619.104646"
+        exclude_images: []
+        ibmpak_skip_dependencies: true
+
+    - name: ibm.mas_devops.mirror_images
+      when: mirror_cp4d
+      vars:
+        manifest_name: ibm-cp-datacore
+        manifest_version: "5.0.0+20240619.104646"
+
+    - name: ibm.mas_devops.mirror_case_prepare
+      when:
+        - mirror_cp4d
+        - mirror_mode != "from-filesystem"
+      vars:
+        case_name: ibm-cp-datacore
+        case_version: "5.0.0+20240627.200436"
+        exclude_images: []
+        ibmpak_skip_dependencies: true
+
+    - name: ibm.mas_devops.mirror_images
+      when: mirror_cp4d
+      vars:
+        manifest_name: ibm-cp-datacore
+        manifest_version: "5.0.0+20240627.200436"
+
+    - name: ibm.mas_devops.mirror_case_prepare
+      when:
+        - mirror_cp4d
+        - mirror_mode != "from-filesystem"
+      vars:
+        case_name: ibm-cp-datacore
+        case_version: "5.0.0+20240716.101015"
+        exclude_images: []
+        ibmpak_skip_dependencies: true
+
+    - name: ibm.mas_devops.mirror_images
+      when: mirror_cp4d
+      vars:
+        manifest_name: ibm-cp-datacore
+        manifest_version: "5.0.0+20240716.101015"
+
+    - name: ibm.mas_devops.mirror_case_prepare
+      when:
+        - mirror_cp4d
+        - mirror_mode != "from-filesystem"
+      vars:
+        case_name: ibm-cp-datacore
+        case_version: "5.0.1"
+        exclude_images: []
+        ibmpak_skip_dependencies: true
+
+    - name: ibm.mas_devops.mirror_images
+      when: mirror_cp4d
+      vars:
+        manifest_name: ibm-cp-datacore
+        manifest_version: "5.0.1"
+
+    - name: ibm.mas_devops.mirror_case_prepare
+      when:
+        - mirror_cp4d
+        - mirror_mode != "from-filesystem"
+      vars:
+        case_name: ibm-cp-datacore
+        case_version: "5.0.1+20240729.142100"
+        exclude_images: []
+        ibmpak_skip_dependencies: true
+
+    - name: ibm.mas_devops.mirror_images
+      when: mirror_cp4d
+      vars:
+        manifest_name: ibm-cp-datacore
+        manifest_version: "5.0.1+20240729.142100"
+
+    - name: ibm.mas_devops.mirror_case_prepare
+      when:
+        - mirror_cp4d
+        - mirror_mode != "from-filesystem"
+      vars:
+        case_name: ibm-cp-datacore
+        case_version: "5.0.2+20240822.103346.587.602.2"
+        exclude_images: []
+        ibmpak_skip_dependencies: true
+
+    - name: ibm.mas_devops.mirror_images
+      when: mirror_cp4d
+      vars:
+        manifest_name: ibm-cp-datacore
+        manifest_version: "5.0.2+20240822.103346.587.602.2"
+
+    - name: ibm.mas_devops.mirror_case_prepare
+      when:
+        - mirror_cp4d
+        - mirror_mode != "from-filesystem"
+      vars:
+        case_name: ibm-cp-datacore
+        case_version: "5.0.2+20240827.192834.587.602.2"
+        exclude_images: []
+        ibmpak_skip_dependencies: true
+
+    - name: ibm.mas_devops.mirror_images
+      when: mirror_cp4d
+      vars:
+        manifest_name: ibm-cp-datacore
+        manifest_version: "5.0.2+20240827.192834.587.602.2"
+
+    - name: ibm.mas_devops.mirror_case_prepare
+      when:
+        - mirror_cp4d
+        - mirror_mode != "from-filesystem"
+      vars:
+        case_name: ibm-cp-datacore
+        case_version: "5.0.3+20240923.222506.742.603.15"
+        exclude_images: []
+        ibmpak_skip_dependencies: true
+
+    - name: ibm.mas_devops.mirror_images
+      when: mirror_cp4d
+      vars:
+        manifest_name: ibm-cp-datacore
+        manifest_version: "5.0.3+20240923.222506.742.603.15"
+
     # 6.2 CP4D Platform - IBM Licensing dependency
     # -------------------------------------------------------------------------
     - name: ibm.mas_devops.mirror_case_prepare

--- a/ibm/mas_devops/playbooks/mirror_dependencies.yml
+++ b/ibm/mas_devops/playbooks/mirror_dependencies.yml
@@ -36,6 +36,7 @@
     mirror_cp4d: "{{ lookup('env', 'MIRROR_CP4D') | default ('False', True) | bool }}"
     cpd_48_or_higher: "{{ cpd_product_version is defined and cpd_product_version is version('4.8.0','>=') | bool }}"
     cpd_48: "{{ cpd_product_version is defined and cpd_product_version is version('4.8.0','==') | bool }}"
+    cpd_50_or_higher: "{{ cpd_product_version is defined and cpd_product_version is version('5.0.0','>=') | bool }}"
 
     # 7. Watson Studio Local
     # -------------------------------------------------------------------------
@@ -218,6 +219,27 @@
         manifest_name: ibm-cp-common-services
         manifest_version: "4.8.0"
 
+    - name: ibm.mas_devops.mirror_case_prepare
+      when:
+        - cpd_50_or_higher and mirror_cp4d
+        - mirror_mode != "from-filesystem"
+      vars:
+        case_name: ibm-zen
+        case_version: "6.0.1"
+        exclude_images:
+          - ibm-auditlogging
+          - ibm-cpp
+          - ibm-cs-healthcheck
+          - ibm-cs-monitoring
+          - ibm-events-operator
+        ibmpak_skip_dependencies: false
+
+    - name: ibm.mas_devops.mirror_images
+      when: cpd_50_or_higher and mirror_cp4d
+      vars:
+        manifest_name: ibm-zen
+        manifest_version: "6.0.1"
+        
     # Mirroring another version for Cloud Pak Foundation Services
     - name: ibm.mas_devops.mirror_case_prepare
       when:

--- a/ibm/mas_devops/playbooks/mirror_dependencies.yml
+++ b/ibm/mas_devops/playbooks/mirror_dependencies.yml
@@ -395,21 +395,21 @@
         manifest_name: ibm-cp-datacore
         manifest_version: "5.0.1+20240729.142100"
 
-    - name: ibm.mas_devops.mirror_case_prepare
-      when:
-        - mirror_cp4d
-        - mirror_mode != "from-filesystem"
-      vars:
-        case_name: ibm-cp-datacore
-        case_version: "5.0.2+20240822.103346.587.602.2"
-        exclude_images: []
-        ibmpak_skip_dependencies: true
-
-    - name: ibm.mas_devops.mirror_images
-      when: mirror_cp4d
-      vars:
-        manifest_name: ibm-cp-datacore
-        manifest_version: "5.0.2+20240822.103346.587.602.2"
+#    - name: ibm.mas_devops.mirror_case_prepare
+#      when:
+#        - mirror_cp4d
+#        - mirror_mode != "from-filesystem"
+#      vars:
+#        case_name: ibm-cp-datacore
+#        case_version: "5.0.2+20240822.103346.587.602.2"
+#        exclude_images: []
+#        ibmpak_skip_dependencies: true
+#
+#    - name: ibm.mas_devops.mirror_images
+#      when: mirror_cp4d
+#      vars:
+#        manifest_name: ibm-cp-datacore
+#        manifest_version: "5.0.2+20240822.103346.587.602.2"
 
     - name: ibm.mas_devops.mirror_case_prepare
       when:

--- a/ibm/mas_devops/playbooks/mirror_dependencies.yml
+++ b/ibm/mas_devops/playbooks/mirror_dependencies.yml
@@ -204,7 +204,7 @@
         - mirror_mode != "from-filesystem"
       vars:
         case_name: ibm-cp-common-services
-        case_version: "4.7.0"
+        case_version: "4.7.0+20240702.100000"
         exclude_images:
           - ibm-auditlogging
           - ibm-cpp
@@ -217,7 +217,7 @@
       when: mirror_common_svcs or (cpd_48_or_higher and mirror_cp4d)
       vars:
         manifest_name: ibm-cp-common-services
-        manifest_version: "4.7.0"
+        manifest_version: "4.7.0+20240702.100000"
 
     - name: ibm.mas_devops.mirror_case_prepare
       when:
@@ -363,54 +363,6 @@
         manifest_version: "{{ cp4d_platform_version }}"
 
 
-#    - name: ibm.mas_devops.mirror_case_prepare
-#      when:
-#        - mirror_cp4d
-#        - mirror_mode != "from-filesystem"
-#      vars:
-#        case_name: ibm-cp-datacore
-#        case_version: "5.0.0"
-#        exclude_images: []
-#        ibmpak_skip_dependencies: true
-#
-#    - name: ibm.mas_devops.mirror_images
-#      when: mirror_cp4d
-#      vars:
-#        manifest_name: ibm-cp-datacore
-#        manifest_version: "5.0.0"
-
-#    - name: ibm.mas_devops.mirror_case_prepare
-#      when:
-#        - mirror_cp4d
-#        - mirror_mode != "from-filesystem"
-#      vars:
-#        case_name: ibm-cp-datacore
-#        case_version: "5.0.0+20240619.104646"
-#        exclude_images: []
-#        ibmpak_skip_dependencies: true
-#
-#    - name: ibm.mas_devops.mirror_images
-#      when: mirror_cp4d
-#      vars:
-#        manifest_name: ibm-cp-datacore
-#        manifest_version: "5.0.0+20240619.104646"
-
-#    - name: ibm.mas_devops.mirror_case_prepare
-#      when:
-#        - mirror_cp4d
-#        - mirror_mode != "from-filesystem"
-#      vars:
-#        case_name: ibm-cp-datacore
-#        case_version: "5.0.0+20240627.200436"
-#        exclude_images: []
-#        ibmpak_skip_dependencies: true
-#
-#    - name: ibm.mas_devops.mirror_images
-#      when: mirror_cp4d
-#      vars:
-#        manifest_name: ibm-cp-datacore
-#        manifest_version: "5.0.0+20240627.200436"
-
     - name: ibm.mas_devops.mirror_case_prepare
       when:
         - mirror_cp4d
@@ -426,86 +378,6 @@
       vars:
         manifest_name: ibm-cp-datacore
         manifest_version: "5.0.0+20240716.101015"
-
-#    - name: ibm.mas_devops.mirror_case_prepare
-#      when:
-#        - mirror_cp4d
-#        - mirror_mode != "from-filesystem"
-#      vars:
-#        case_name: ibm-cp-datacore
-#        case_version: "5.0.1"
-#        exclude_images: []
-#        ibmpak_skip_dependencies: true
-
-#    - name: ibm.mas_devops.mirror_images
-#      when: mirror_cp4d
-#      vars:
-#        manifest_name: ibm-cp-datacore
-#        manifest_version: "5.0.1"
-
-    - name: ibm.mas_devops.mirror_case_prepare
-      when:
-        - mirror_cp4d
-        - mirror_mode != "from-filesystem"
-      vars:
-        case_name: ibm-cp-datacore
-        case_version: "5.0.1+20240729.142100"
-        exclude_images: []
-        ibmpak_skip_dependencies: true
-
-    - name: ibm.mas_devops.mirror_images
-      when: mirror_cp4d
-      vars:
-        manifest_name: ibm-cp-datacore
-        manifest_version: "5.0.1+20240729.142100"
-
-#    - name: ibm.mas_devops.mirror_case_prepare
-#      when:
-#        - mirror_cp4d
-#        - mirror_mode != "from-filesystem"
-#      vars:
-#        case_name: ibm-cp-datacore
-#        case_version: "5.0.2+20240822.103346.587.602.2"
-#        exclude_images: []
-#        ibmpak_skip_dependencies: true
-#
-#    - name: ibm.mas_devops.mirror_images
-#      when: mirror_cp4d
-#      vars:
-#        manifest_name: ibm-cp-datacore
-#        manifest_version: "5.0.2+20240822.103346.587.602.2"
-
-    - name: ibm.mas_devops.mirror_case_prepare
-      when:
-        - mirror_cp4d
-        - mirror_mode != "from-filesystem"
-      vars:
-        case_name: ibm-cp-datacore
-        case_version: "5.0.2+20240827.192834.587.602.2"
-        exclude_images: []
-        ibmpak_skip_dependencies: true
-
-    - name: ibm.mas_devops.mirror_images
-      when: mirror_cp4d
-      vars:
-        manifest_name: ibm-cp-datacore
-        manifest_version: "5.0.2+20240827.192834.587.602.2"
-
-    - name: ibm.mas_devops.mirror_case_prepare
-      when:
-        - mirror_cp4d
-        - mirror_mode != "from-filesystem"
-      vars:
-        case_name: ibm-cp-datacore
-        case_version: "5.0.3+20240923.222506.742.603.15"
-        exclude_images: []
-        ibmpak_skip_dependencies: true
-
-    - name: ibm.mas_devops.mirror_images
-      when: mirror_cp4d
-      vars:
-        manifest_name: ibm-cp-datacore
-        manifest_version: "5.0.3+20240923.222506.742.603.15"
 
     # 6.2 CP4D Platform - IBM Licensing dependency
     # -------------------------------------------------------------------------

--- a/ibm/mas_devops/playbooks/mirror_dependencies.yml
+++ b/ibm/mas_devops/playbooks/mirror_dependencies.yml
@@ -204,6 +204,27 @@
         - mirror_mode != "from-filesystem"
       vars:
         case_name: ibm-cp-common-services
+        case_version: "4.7.0"
+        exclude_images:
+          - ibm-auditlogging
+          - ibm-cpp
+          - ibm-cs-healthcheck
+          - ibm-cs-monitoring
+          - ibm-events-operator
+        ibmpak_skip_dependencies: false
+
+    - name: ibm.mas_devops.mirror_images
+      when: mirror_common_svcs or (cpd_48_or_higher and mirror_cp4d)
+      vars:
+        manifest_name: ibm-cp-common-services
+        manifest_version: "4.7.0"
+
+    - name: ibm.mas_devops.mirror_case_prepare
+      when:
+        - mirror_common_svcs or (cpd_48_or_higher and mirror_cp4d)
+        - mirror_mode != "from-filesystem"
+      vars:
+        case_name: ibm-cp-common-services
         case_version: "4.8.0"
         exclude_images:
           - ibm-auditlogging

--- a/ibm/mas_devops/playbooks/mirror_dependencies.yml
+++ b/ibm/mas_devops/playbooks/mirror_dependencies.yml
@@ -246,7 +246,7 @@
         - mirror_mode != "from-filesystem"
       vars:
         case_name: ibm-zen
-        case_version: "6.0.1"
+        case_version: "6.0.1-32"
         exclude_images:
           - ibm-auditlogging
           - ibm-cpp
@@ -259,7 +259,7 @@
       when: cpd_50_or_higher and mirror_cp4d
       vars:
         manifest_name: ibm-zen
-        manifest_version: "6.0.1"
+        manifest_version: "6.0.1-32"
 
     # Mirroring another version for Cloud Pak Foundation Services
     - name: ibm.mas_devops.mirror_case_prepare

--- a/ibm/mas_devops/playbooks/mirror_dependencies.yml
+++ b/ibm/mas_devops/playbooks/mirror_dependencies.yml
@@ -240,6 +240,10 @@
         manifest_name: ibm-cp-common-services
         manifest_version: "4.8.0"
 
+    - name: 50 or over?
+      debug:
+        message: "{{cpd_product_version}} >= {{version('5.0.0','>=')}}"
+    cpd_50_or_higher: "{{ cpd_product_version is defined and cpd_product_version is version('5.0.0','>=') | bool }}"
     - name: ibm.mas_devops.mirror_case_prepare
       when:
         - cpd_50_or_higher and mirror_cp4d

--- a/ibm/mas_devops/playbooks/mirror_dependencies.yml
+++ b/ibm/mas_devops/playbooks/mirror_dependencies.yml
@@ -36,7 +36,6 @@
     mirror_cp4d: "{{ lookup('env', 'MIRROR_CP4D') | default ('False', True) | bool }}"
     cpd_48_or_higher: "{{ cpd_product_version is defined and cpd_product_version is version('4.8.0','>=') | bool }}"
     cpd_48: "{{ cpd_product_version is defined and cpd_product_version is version('4.8.0','==') | bool }}"
-    cpd_50_or_higher: "{{ cpd_product_version is defined and cpd_product_version is version('5.0.0','>=') | bool }}"
 
     # 7. Watson Studio Local
     # -------------------------------------------------------------------------
@@ -200,57 +199,12 @@
 
     - name: ibm.mas_devops.mirror_case_prepare
       when:
-        - mirror_common_svcs or (cpd_48_or_higher and mirror_cp4d)
-        - mirror_mode != "from-filesystem"
-      vars:
-        case_name: ibm-cp-common-services
-        case_version: "4.7.0+20240702.100000"
-        exclude_images:
-          - ibm-auditlogging
-          - ibm-cpp
-          - ibm-cs-healthcheck
-          - ibm-cs-monitoring
-          - ibm-events-operator
-        ibmpak_skip_dependencies: false
-
-    - name: ibm.mas_devops.mirror_images
-      when: mirror_common_svcs or (cpd_48_or_higher and mirror_cp4d)
-      vars:
-        manifest_name: ibm-cp-common-services
-        manifest_version: "4.7.0+20240702.100000"
-
-    - name: ibm.mas_devops.mirror_case_prepare
-      when:
-        - mirror_common_svcs or (cpd_48_or_higher and mirror_cp4d)
-        - mirror_mode != "from-filesystem"
-      vars:
-        case_name: ibm-cp-common-services
-        case_version: "4.8.0"
-        exclude_images:
-          - ibm-auditlogging
-          - ibm-cpp
-          - ibm-cs-healthcheck
-          - ibm-cs-monitoring
-          - ibm-events-operator
-        ibmpak_skip_dependencies: false
-
-    - name: ibm.mas_devops.mirror_images
-      when: mirror_common_svcs or (cpd_48_or_higher and mirror_cp4d)
-      vars:
-        manifest_name: ibm-cp-common-services
-        manifest_version: "4.8.0"
-
-    - name: 50 or over?
-      debug:
-        message: "{{cpd_product_version}} >= {{version('5.0.0','>=')}}"
-    cpd_50_or_higher: "{{ cpd_product_version is defined and cpd_product_version is version('5.0.0','>=') | bool }}"
-    - name: ibm.mas_devops.mirror_case_prepare
-      when:
-        - cpd_50_or_higher and mirror_cp4d
+        - mirror_cp4d
+        - ibm_zen_version is defined
         - mirror_mode != "from-filesystem"
       vars:
         case_name: ibm-zen
-        case_version: "6.0.1-32"
+        case_version: "{{ ibm_zen_version }}"
         exclude_images:
           - ibm-auditlogging
           - ibm-cpp
@@ -260,10 +214,12 @@
         ibmpak_skip_dependencies: false
 
     - name: ibm.mas_devops.mirror_images
-      when: cpd_50_or_higher and mirror_cp4d
+      when:
+        - mirror_cp4d
+        - ibm_zen_version is defined
       vars:
         manifest_name: ibm-zen
-        manifest_version: "6.0.1-32"
+        manifest_version: "{{ ibm_zen_version }}"
 
     # Mirroring another version for Cloud Pak Foundation Services
     - name: ibm.mas_devops.mirror_case_prepare
@@ -365,23 +321,6 @@
       vars:
         manifest_name: ibm-cp-datacore
         manifest_version: "{{ cp4d_platform_version }}"
-
-
-    - name: ibm.mas_devops.mirror_case_prepare
-      when:
-        - mirror_cp4d
-        - mirror_mode != "from-filesystem"
-      vars:
-        case_name: ibm-cp-datacore
-        case_version: "5.0.0+20240716.101015"
-        exclude_images: []
-        ibmpak_skip_dependencies: true
-
-    - name: ibm.mas_devops.mirror_images
-      when: mirror_cp4d
-      vars:
-        manifest_name: ibm-cp-datacore
-        manifest_version: "5.0.0+20240716.101015"
 
     # 6.2 CP4D Platform - IBM Licensing dependency
     # -------------------------------------------------------------------------

--- a/ibm/mas_devops/playbooks/mirror_dependencies.yml
+++ b/ibm/mas_devops/playbooks/mirror_dependencies.yml
@@ -197,6 +197,27 @@
         manifest_name: ibm-cp-common-services
         manifest_version: "{{ common_svcs_version }}"
 
+    - name: ibm.mas_devops.mirror_case_prepare
+      when:
+        - mirror_common_svcs or (cpd_48_or_higher and mirror_cp4d)
+        - mirror_mode != "from-filesystem"
+      vars:
+        case_name: ibm-cp-common-services
+        case_version: "4.8.0"
+        exclude_images:
+          - ibm-auditlogging
+          - ibm-cpp
+          - ibm-cs-healthcheck
+          - ibm-cs-monitoring
+          - ibm-events-operator
+        ibmpak_skip_dependencies: false
+
+    - name: ibm.mas_devops.mirror_images
+      when: mirror_common_svcs or (cpd_48_or_higher and mirror_cp4d)
+      vars:
+        manifest_name: ibm-cp-common-services
+        manifest_version: "4.8.0"
+
     # Mirroring another version for Cloud Pak Foundation Services
     - name: ibm.mas_devops.mirror_case_prepare
       when:

--- a/ibm/mas_devops/playbooks/mirror_dependencies.yml
+++ b/ibm/mas_devops/playbooks/mirror_dependencies.yml
@@ -320,7 +320,7 @@
         - mirror_cp4d
         - mirror_mode != "from-filesystem"
       vars:
-        case_name: ibm-cp-datacore3
+        case_name: ibm-cp-datacore
         case_version: "5.0.0+20240619.104646"
         exclude_images: []
         ibmpak_skip_dependencies: true
@@ -328,7 +328,7 @@
     - name: ibm.mas_devops.mirror_images
       when: mirror_cp4d
       vars:
-        manifest_name: ibm-cp-datacore3
+        manifest_name: ibm-cp-datacore
         manifest_version: "5.0.0+20240619.104646"
 
     - name: ibm.mas_devops.mirror_case_prepare

--- a/ibm/mas_devops/roles/cp4d/templates/catalog_sources/5.0.0.yml
+++ b/ibm/mas_devops/roles/cp4d/templates/catalog_sources/5.0.0.yml
@@ -14,7 +14,7 @@ catsrc_info:
       name: cpopen/ibm-common-service-catalog
       registry: icr.io
       tag: 4.8.0
-      digest: sha256:c786c66ee9bfda9063d4e564529af4fcdce96d2ced6ada893d676a3b6897e289
+      digest: sha256:fe2a34d73c9b8519cd04a459c0b5b57458f280a088ac1929fd27f3fdf78d66a6
   zen:
     - catalog_name: ibm-zen-operator-catalog
       catalog_display_name: ibm-zen-6.0.1

--- a/ibm/mas_devops/roles/cp4d/templates/catalog_sources/5.0.0.yml
+++ b/ibm/mas_devops/roles/cp4d/templates/catalog_sources/5.0.0.yml
@@ -13,7 +13,7 @@ catsrc_info:
       catalog_display_name: ibm-cp-common-services-4.8.0
       name: cpopen/ibm-common-service-catalog
       registry: icr.io
-#      tag: 4.8.0
+      tag: 4.8.0
       digest: sha256:c786c66ee9bfda9063d4e564529af4fcdce96d2ced6ada893d676a3b6897e289
   zen:
     - catalog_name: ibm-zen-operator-catalog

--- a/ibm/mas_devops/roles/cp4d/templates/catalog_sources/5.0.0.yml
+++ b/ibm/mas_devops/roles/cp4d/templates/catalog_sources/5.0.0.yml
@@ -4,10 +4,10 @@ catsrc_info:
       catalog_display_name: ibm-cp-datacore-6.0.0-39
       name: cpopen/ibm-cpd-platform-operator-catalog
       registry: icr.io
-      tag: 6.0.0-37
-      digest: sha256:d950e953a55d6ad682a91b38490140115443be096b7ae7cf71e9962d52f5c0d9
-#      tag: 6.0.0-39
-#      digest: sha256:715d2a1132e8a1f542b0b5187956411d943585c31934a51d26d6291a4ee3ef7e
+#      tag: 6.0.0-37
+#      digest: sha256:d950e953a55d6ad682a91b38490140115443be096b7ae7cf71e9962d52f5c0d9
+      tag: 6.0.0-39
+      digest: sha256:715d2a1132e8a1f542b0b5187956411d943585c31934a51d26d6291a4ee3ef7e
   cpfs:
     - catalog_name: opencloud-operators
       catalog_display_name: ibm-cp-common-services-4.8.0


### PR DESCRIPTION
Changes to the catalog to include the new versions needed for CPD 5.0.0 and changes to the mirroring tasks to support them.