### PR TITLE
[patch] Add db2_namespace to backup/restore job

### DIFF
--- a/ibm/mas_devops/playbooks/br_health.yml
+++ b/ibm/mas_devops/playbooks/br_health.yml
@@ -7,6 +7,7 @@
     mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
     mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') }}"
     db2_instance_id: "{{ lookup('env', 'DB2_INSTANCE_NAME') }}"
+    db2_namespace: "{{ lookup('env', 'DB2_NAMESPACE') }}"
 
     # Define what action to perform
     masbr_action: "{{ lookup('env', 'MASBR_ACTION') }}"
@@ -70,7 +71,8 @@
             value: "{{ mas_workspace_id }}"
           - name: "DB2_INSTANCE_NAME"
             value: "{{ db2_instance_id }}"
-
+          - name: "DB2_NAMESPACE"
+            value: "{{ db2_namespace }}"
 
     # Run backup/restore tasks locally
     # -------------------------------------------------------------------------

--- a/ibm/mas_devops/playbooks/br_iot.yml
+++ b/ibm/mas_devops/playbooks/br_iot.yml
@@ -7,6 +7,7 @@
     mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
     mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') }}"
     db2_instance_id: "{{ lookup('env', 'DB2_INSTANCE_NAME') }}"
+    db2_namespace: "{{ lookup('env', 'DB2_NAMESPACE') }}"
 
     # Define what action to perform
     masbr_action: "{{ lookup('env', 'MASBR_ACTION') }}"
@@ -70,7 +71,8 @@
             value: "{{ mas_workspace_id }}"
           - name: "DB2_INSTANCE_NAME"
             value: "{{ db2_instance_id }}"
-
+          - name: "DB2_NAMESPACE"
+            value: "{{ db2_namespace }}"
 
     # Run backup/restore tasks locally
     # -------------------------------------------------------------------------

--- a/ibm/mas_devops/playbooks/br_manage.yml
+++ b/ibm/mas_devops/playbooks/br_manage.yml
@@ -7,6 +7,7 @@
     mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
     mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') }}"
     db2_instance_id: "{{ lookup('env', 'DB2_INSTANCE_NAME') }}"
+    db2_namespace: "{{ lookup('env', 'DB2_NAMESPACE') }}"
 
     # Define what action to perform
     masbr_action: "{{ lookup('env', 'MASBR_ACTION') }}"
@@ -70,7 +71,8 @@
             value: "{{ mas_workspace_id }}"
           - name: "DB2_INSTANCE_NAME"
             value: "{{ db2_instance_id }}"
-
+          - name: "DB2_NAMESPACE"
+            value: "{{ db2_namespace }}"
 
     # Run backup/restore tasks locally
     # -------------------------------------------------------------------------

--- a/ibm/mas_devops/playbooks/br_monitor.yml
+++ b/ibm/mas_devops/playbooks/br_monitor.yml
@@ -7,6 +7,7 @@
     mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
     mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') }}"
     db2_instance_id: "{{ lookup('env', 'DB2_INSTANCE_NAME') }}"
+    db2_namespace: "{{ lookup('env', 'DB2_NAMESPACE') }}"
 
     # Define what action to perform
     masbr_action: "{{ lookup('env', 'MASBR_ACTION') }}"
@@ -70,7 +71,8 @@
             value: "{{ mas_workspace_id }}"
           - name: "DB2_INSTANCE_NAME"
             value: "{{ db2_instance_id }}"
-
+          - name: "DB2_NAMESPACE"
+            value: "{{ db2_namespace }}"
 
     # Run backup/restore tasks locally
     # -------------------------------------------------------------------------

--- a/ibm/mas_devops/playbooks/br_optimizer.yml
+++ b/ibm/mas_devops/playbooks/br_optimizer.yml
@@ -7,6 +7,7 @@
     mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
     mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') }}"
     db2_instance_id: "{{ lookup('env', 'DB2_INSTANCE_NAME') }}"
+    db2_namespace: "{{ lookup('env', 'DB2_NAMESPACE') }}"
 
     # Define what action to perform
     masbr_action: "{{ lookup('env', 'MASBR_ACTION') }}"
@@ -70,7 +71,8 @@
             value: "{{ mas_workspace_id }}"
           - name: "DB2_INSTANCE_NAME"
             value: "{{ db2_instance_id }}"
-
+          - name: "DB2_NAMESPACE"
+            value: "{{ db2_namespace }}"
 
     # Run backup/restore tasks locally
     # -------------------------------------------------------------------------


### PR DESCRIPTION
When running a backup/restore playbook that runs the action in a job, it is not passing the DB2_NAMESPACE that is set and so defaults to `db2u`

Updated each br playbook that backusp db2.

Tested here shows the namespace set, when I exported `DB2_NAMESPACE` before running the `br_manage` playbook:

![image- 2024-10-23 at 12 16 36](https://github.com/user-attachments/assets/32eaf083-c3d4-4b43-99f9-203be9b90d7b)
