### PR TITLE
[patch] Updates wait_timeout for namespace deletion in suite_app_uninstall

### DIFF
--- a/ibm/mas_devops/roles/suite_app_uninstall/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_uninstall/tasks/main.yml
@@ -129,7 +129,7 @@
     kind: Namespace
     name: "{{ mas_app_namespace }}"
     wait: true
-    wait_timeout: 300 # 5 minutes
+    wait_timeout: 600 # 10 minutes
 
 # 4. Run Application Specific Post-Uninstall Tasks if there are any
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
### Description:
Uninstall for manage fails intermittently as it gets timed out after 5 mins waiting for namespace to be deleted. This change updates the waiting timeout to 10 mins.
https://dashboard.masdev.wiotp.sl.hursley.ibm.com/tests/fvtuninstall/testsuite/ibm-mas-devops/app-manage-uninstall