### PR TITLE
[patch] Add additional verification after manage config

### DIFF
--- a/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
@@ -110,3 +110,8 @@
 - name: "Run Manage specific post-configuration"
   when: mas_app_id is in ['manage'] # applications which have something to process after configuration
   include_tasks: "tasks/{{ mas_app_id }}/post-config/main.yml"
+
+- ansible.builtin.include_role:
+    name: ibm.mas_devops.suite_app_verify
+  when: mas_app_id is in ['manage'] # applications which have something to process after configuration
+    

--- a/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
@@ -114,4 +114,3 @@
 - ansible.builtin.include_role:
     name: ibm.mas_devops.suite_app_verify
   when: mas_app_id is in ['manage'] # applications which have something to process after configuration
-    

--- a/ibm/mas_devops/roles/suite_dns/README.md
+++ b/ibm/mas_devops/roles/suite_dns/README.md
@@ -122,7 +122,7 @@ Role Variables - IBM Cloud Internet Services DNS Integration
 
 ### cis_email
 
-- **Required** if `dns_provider` is set to `cis`
+- **Required** if `dns_provider` is set to `cis`. This is the e-mail that will be used in the Cluster Issuer resource, created by this role, to connect with the certificate manager (i.e. Let's Encrypt).
 - Environment Variable: `CIS_EMAIL`
 - Default: None
 


### PR DESCRIPTION
After post-configuration is executed for Manage in suite-app-config, there is no checking to ManageWorkspace is healthy before the role is finished. This PR adds the same verification performed before post-configuration runs, afterwards.

Test completed in fvt personal:

<img width="682" alt="image" src="https://github.com/user-attachments/assets/c8877519-341d-461e-9e11-4ad02821569a">

----

@durera it includes a quick update in cis_email README as we briefly talked yesterday during your tests