### PR TITLE
[patch] Fix Execution Environment publish release

### DIFF
--- a/build/ee/requirements.yml
+++ b/build/ee/requirements.yml
@@ -1,5 +1,4 @@
 ---
 collections:
   - name: ibm.mas_devops
-    type: file
     version: "100.0.0"


### PR DESCRIPTION
The publishing of the release of the execution environment is broken as the galaxy requirements was still using file. This is only seen in the publish phase