### PR TITLE
[patch] Push versioned container image of ansible-devops-ee on publish

### DIFF
--- a/.github/workflows/ansible-publish.yml
+++ b/.github/workflows/ansible-publish.yml
@@ -60,9 +60,11 @@ jobs:
         if: github.event_name == 'release'
         run: |
           podman tag ibmmas/ansible-devops-ee quay.io/ibmmas/ansible-devops-ee:latest
+          podman tag ibmmas/ansible-devops-ee quay.io/ibmmas/ansible-devops-ee:${{ env.DOCKER_TAG }}
           podman images
           podman login --username "${{ secrets.QUAYIO_USERNAME }}" --password "${{ secrets.QUAYIO_PASSWORD }}" quay.io
           podman push quay.io/ibmmas/ansible-devops-ee:latest
+          podman push quay.io/ibmmas/ansible-devops-ee:${{ env.DOCKER_TAG }} 
 
       - name: Trigger ibm-mas/cli rebuild on Ansible Collection release
         run: |


### PR DESCRIPTION
Need to push the versioned imaged as well as latest on publish. For now I have manually created the 23.4.0 image from the latest in quay.io. This change will push that as part of the release.