### PR TITLE
[patch] Fix oc exec commands

### DIFF
--- a/ibm/mas_devops/common_tasks/backup_restore/copy_storage_files_to_pod.yml
+++ b/ibm/mas_devops/common_tasks/backup_restore/copy_storage_files_to_pod.yml
@@ -21,13 +21,12 @@
         - item.dest_folder is defined and item.dest_folder | length > 0
       shell: >-
         oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c
-        'temp_dest_folder={{ [item.dest_folder, masbr_job_version] | path_join }} &&
-        mkdir -p ${temp_dest_folder} &&
-        oc cp --retries=50 -c {{ masbr_cf_container_name }}
-        {{ [masbr_storage_job_folder, item.src_folder] | path_join }}
-        {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:${temp_dest_folder} &&
-        mv -f ${temp_dest_folder}/* {{ item.dest_folder }} &&
-        rm -rf ${temp_dest_folder}'
+          'temp_dest_folder={{ [item.dest_folder, masbr_job_version] | path_join }} && mkdir -p ${temp_dest_folder}'
+        && oc cp --retries=50 -c {{ masbr_cf_container_name }}
+          {{ [masbr_storage_job_folder, item.src_folder] | path_join }}
+          {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:${temp_dest_folder}
+        && mv -f ${temp_dest_folder}/* {{ item.dest_folder }}
+        && rm -rf ${temp_dest_folder}
       loop: "{{ masbr_cf_paths }}"
 
      # Condition 2. src_file -> dest_folder: copy src_file to dest_folder/src_file
@@ -37,10 +36,10 @@
         - item.dest_folder is defined and item.dest_folder | length > 0
       shell: >-
         oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c
-        'mkdir -p {{ item.dest_folder }}' &&
-        oc cp --retries=50 -c {{ masbr_cf_container_name }}
-        {{ [masbr_storage_job_folder, item.src_file] | path_join }}
-        {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:{{ item.dest_folder }}
+          'mkdir -p {{ item.dest_folder }}'
+        && oc cp --retries=50 -c {{ masbr_cf_container_name }}
+          {{ [masbr_storage_job_folder, item.src_file] | path_join }}
+          {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:{{ item.dest_folder }}
       loop: "{{ masbr_cf_paths }}"
 
      # Condition 3. src_file -> dest_file
@@ -50,13 +49,13 @@
         - item.dest_file is defined and item.dest_file | length > 0
       shell: >-
         oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c
-        'temp_dest_folder={{ [item.dest_file|dirname, masbr_job_version] | path_join }} &&
-        mkdir -p ${temp_dest_folder} &&
-        oc cp --retries=50 -c {{ masbr_cf_container_name }}
-        {{ [masbr_storage_job_folder, item.src_file] | path_join }}
-        {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:${temp_dest_folder} &&
-        mv -f ${temp_dest_folder}/{{ item.src_file|basename }} {{ item.dest_file }} &&
-        rm -rf ${temp_dest_folder}'
+          'temp_dest_folder={{ [item.dest_file|dirname, masbr_job_version] | path_join }} &&
+          mkdir -p ${temp_dest_folder}'
+        && oc cp --retries=50 -c {{ masbr_cf_container_name }}
+          {{ [masbr_storage_job_folder, item.src_file] | path_join }}
+          {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:${temp_dest_folder}
+        && mv -f ${temp_dest_folder}/{{ item.src_file|basename }} {{ item.dest_file }}
+        && rm -rf ${temp_dest_folder}'
       loop: "{{ masbr_cf_paths }}"
 
 

--- a/ibm/mas_devops/common_tasks/backup_restore/copy_storage_files_to_pod.yml
+++ b/ibm/mas_devops/common_tasks/backup_restore/copy_storage_files_to_pod.yml
@@ -14,7 +14,11 @@
       debug:
         msg: "Local storage job folder .......... {{ masbr_storage_job_folder }}"
 
-     # Condition 1. src_folder -> dest_folder: copy src_folder/* to dest_folder/*
+    # Condition 1. src_folder -> dest_folder: copy src_folder/* to dest_folder/*
+    #
+    # - exec into masbr_cf_pod_name/masbr_cf_container_name, create temp folder
+    # - cp from src_folder to temp folder inside masbr_cf_pod_name/masbr_cf_container_name
+    # - exec into masbr_cf_pod_name/masbr_cf_container_name, move temp_dest_folder to dest_folder and delete temp_dest_folder
     - name: "Copy files from local storage folder to pod folder"
       when:
         - item.src_folder is defined and item.src_folder | length > 0
@@ -25,11 +29,11 @@
         && oc cp --retries=50 -c {{ masbr_cf_container_name }}
           {{ [masbr_storage_job_folder, item.src_folder] | path_join }}
           {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:${temp_dest_folder}
-        && mv -f ${temp_dest_folder}/* {{ item.dest_folder }}
-        && rm -rf ${temp_dest_folder}
+        && oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c
+          'mv -f ${temp_dest_folder}/* {{ item.dest_folder }} && rm -rf ${temp_dest_folder}'
       loop: "{{ masbr_cf_paths }}"
 
-     # Condition 2. src_file -> dest_folder: copy src_file to dest_folder/src_file
+    # Condition 2. src_file -> dest_folder: copy src_file to dest_folder/src_file
     - name: "Copy file from local storage folder to pod folder"
       when:
         - item.src_file is defined and item.src_file | length > 0
@@ -42,20 +46,22 @@
           {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:{{ item.dest_folder }}
       loop: "{{ masbr_cf_paths }}"
 
-     # Condition 3. src_file -> dest_file
+    # Condition 3. src_file -> dest_file
+    # - exec into masbr_cf_pod_name/masbr_cf_container_name, create temp folder
+    # - cp from src_folder to temp folder inside masbr_cf_pod_name/masbr_cf_container_name
+    # - exec into masbr_cf_pod_name/masbr_cf_container_name, move temp_dest_folder to dest_folder and delete temp_dest_folder
     - name: "Copy file from local storage folder to pod file"
       when:
         - item.src_file is defined and item.src_file | length > 0
         - item.dest_file is defined and item.dest_file | length > 0
       shell: >-
         oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c
-          'temp_dest_folder={{ [item.dest_file|dirname, masbr_job_version] | path_join }} &&
-          mkdir -p ${temp_dest_folder}'
+          'temp_dest_folder={{ [item.dest_file|dirname, masbr_job_version] | path_join }} && mkdir -p ${temp_dest_folder}'
         && oc cp --retries=50 -c {{ masbr_cf_container_name }}
           {{ [masbr_storage_job_folder, item.src_file] | path_join }}
           {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:${temp_dest_folder}
-        && mv -f ${temp_dest_folder}/{{ item.src_file|basename }} {{ item.dest_file }}
-        && rm -rf ${temp_dest_folder}'
+        && oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c
+          'mv -f ${temp_dest_folder}/{{ item.src_file|basename }} {{ item.dest_file }} && rm -rf ${temp_dest_folder}'
       loop: "{{ masbr_cf_paths }}"
 
 


### PR DESCRIPTION
This update corrects the syntax of a couple of `shell` tasks when transferring files out of pods when running the backup/restore in non-local mode.

- Fixes #1531