### PR TITLE
[patch] Fix gpu-certified-operator default channel

### DIFF
--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -27,10 +27,10 @@ mirror:
         - name: gpu-operator-certified  # Required by ibm.mas_devops.nvidia_gpu role
           channels:
             - name: v23.3
-            # We don't use the v24.6 channel, but oc-mirror fails when the default channel is not included
+            # We don't use the v24.9 channel, but oc-mirror fails when the default channel is not included
             # - https://access.redhat.com/solutions/7013461
             # - https://issues.redhat.com/browse/OCPBUGS-385
-            - name: v24.6
+            - name: v24.9
         - name: kubeturbo-certified  # Required by ibm.mas_devops.kubeturbo role
           channels:
             - name: stable


### PR DESCRIPTION
nvidia pushed a new version of the gpu-certified-operator (version 24.9.0) on 31/10/24 this broke our ability to mirror the redhat operators. Tested with 4.14 but should fix all OCP releases as it's common code. Specific command tested:

```
mas mirror-redhat -m direct -d /tmp/mirror --no-confirm \
      -H $REGISTRY_HOST -P $REGISTRY_PORT -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD \
      --pullsecret /mnt/pullsecret/pull-secret.json \
      --release 4.14 \
      --mirror-operators
```