### PR TITLE
[minor] Add Kafka Cluster CA certificate validityDays

### DIFF
--- a/ibm/mas_devops/roles/kafka/templates/redhat/clusters/large.yml.j2
+++ b/ibm/mas_devops/roles/kafka/templates/redhat/clusters/large.yml.j2
@@ -176,3 +176,8 @@ spec:
         memory: 128Mi
     logging: debug
     enableSaramaLogging: true
+  # -------------------------------------------------------
+  clusterCa:
+    renewalDays: 30
+    validityDays: 7200
+    generateCertificateAuthority: true

--- a/ibm/mas_devops/roles/kafka/templates/redhat/clusters/small.yml.j2
+++ b/ibm/mas_devops/roles/kafka/templates/redhat/clusters/small.yml.j2
@@ -176,3 +176,8 @@ spec:
         memory: 128Mi
     logging: debug
     enableSaramaLogging: true
+  # -------------------------------------------------------
+  clusterCa:
+    renewalDays: 30
+    validityDays: 7200
+    generateCertificateAuthority: true


### PR DESCRIPTION
Add parameter `Kafka.spec.clusterCa.validityDays: 7200` (20 years) to Kafka for Cluster CA certificates.

https://strimzi.io/docs/operators/latest/deploying#con-certificate-renewal-str

The default validity period for Kafka Cluster CA certificates is 365 days. This patch adds parameter `Kafka.spec.clusterCa.validityDays: 7200` / 20 years.

Without this parameter the Kafka Operator generates a new CA certificate every year that needs to be imported into MAS.

Just for the record. The following steps are required in MAS after the Kafka CA certificate has been renewed.

Import new certificate

```
oc get secret maskafka-cluster-ca-cert \
-n strimzi \
-o=jsonpath='{.data.ca\.crt}' | base64 -d > maskafka-ca.crt
```

```
instance=dev
```

```
openssl x509 -in maskafka-ca.crt -noout -dates -subject -serial

cat << EOF > patch-kafkacfg-cert.yaml
spec:
  certificates:
  - alias: maskafka-ca
    crt: |
$(cat maskafka-ca.crt | sed "s/^/      /")
EOF

cat << EOF > patch-kafka-cert.yaml
spec:
  settings:
    deployment:
      importedCerts:
      - alias: strimzi-ca0
        crt: |-
$(cat maskafka-ca.crt | sed "s/^/          /")
EOF
```

```
oc patch KafkaCfg $instance-kafka-system -n mas-$instance-core \
--type merge \
--patch-file patch-kafkacfg-cert.yaml
```

```
name=$(oc get ManageWorkspace \
-n mas-$instance-manage \
-o jsonpath={..metadata.name})

oc patch ManageWorkspace $instance-mas -n mas-$instance-manage \
--type merge \
--patch-file patch-kafka-cert.yaml
```

```
oc get KafkaCfg -A
oc get ManageWorkspace -A

oc get KafkaCfg -n mas-$instance-core $instance-kafka-system \
-o jsonpath={.spec.certificates[].crt} | \
openssl x509 -noout -dates -subject -serial

oc get ManageWorkspace \
-n mas-$instance-manage \
-o jsonpath={..spec.settings.deployment.importedCerts[].crt} | \
openssl x509 -noout -dates -subject -serial

oc get ManageWorkspace \
-n mas-$instance-manage \
-o jsonpath={..spec.settings.deployment.importedCerts[].alias}
```