### PR TITLE
[patch] Wait for olm to update operatorcondition on upgrade

### DIFF
--- a/ibm/mas_devops/roles/suite_upgrade/tasks/upgrade.yml
+++ b/ibm/mas_devops/roles/suite_upgrade/tasks/upgrade.yml
@@ -32,6 +32,12 @@
   debug:
     var: updated_suite_sub_info
 
+# No easy way to determine the end of the installPlanGeneration as it depends on if we have a patch versions of the 
+# new version in the catalog. No patch versions means just one installPlanGeneration increase. Catalog has patches means
+# two installPlanGenerateion increase. Wait for 5 minutes like we do for apps
+- name: "Pause for 5 minutes before checking upgrade status..."
+  pause:
+    minutes: 5
 
 # 3. Lookup the OperatorCondition
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/suite_upgrade/tasks/upgrade.yml
+++ b/ibm/mas_devops/roles/suite_upgrade/tasks/upgrade.yml
@@ -32,7 +32,7 @@
   debug:
     var: updated_suite_sub_info
 
-# No easy way to determine the end of the installPlanGeneration as it depends on if we have a patch versions of the 
+# No easy way to determine the end of the installPlanGeneration as it depends on if we have a patch versions of the
 # new version in the catalog. No patch versions means just one installPlanGeneration increase. Catalog has patches means
 # two installPlanGenerateion increase. Wait for 5 minutes like we do for apps
 - name: "Pause for 5 minutes before checking upgrade status..."


### PR DESCRIPTION
Fixes an issue where the upgrade check is getting the version in the operatorcondition that is not the final version of the operator. This happens when doing an upgrade and OLM goes from 8.11.10 -> 9.0.0 -> 9.0.3. The verification was catching the operatorcondition at the 9.0.0 and was then expecting that to be the final reconciled version.

The check is tricky as when upgrading to a level that has no patch levels then it is only one hop i.e. from 9.0.3 -> 9.1.0.

The suite_app_upgrade task has a 5 minute pause for this exact issue so we can copy that for now.