### PR TITLE
[patch] [MASCORE-4344] Grafana role overwriting critical k8s configuration resource

### DIFF
--- a/ibm/mas_devops/roles/grafana/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/grafana/tasks/install/main.yml
@@ -17,11 +17,29 @@
   register: uwm_secret_lookup
   no_log: true
 
+- name: "install : Check for existing user workload monitoring configmap"
+  kubernetes.core.k8s_info:
+    api: v1
+    kind: ConfigMap
+    name: cluster-monitoring-config
+    namespace: openshift-monitoring
+  register: cluster_monitoring_configmap
+
+# If the monitoring config doesn't exist we just create a new configmap with just the enableUserWorkload added
+- name: "install : Creating a new configmap for user workload monitoring"
+  when: cluster_monitoring_configmap.resources | length == 0
+  set_fact:
+    cluster_monitoring_data: "{{ {'enableUserWorkload': True} }}"
+
+# If the monitoring config does exist, we can just grap the existing yaml and override the enableUserWorkload value
+- name: "update : extracting existing data from configmap"
+  when: cluster_monitoring_configmap.resources | length > 0
+  set_fact:
+    cluster_monitoring_data: "{{ cluster_monitoring_configmap.resources[0].data['config.yaml'] | from_yaml | combine({'enableUserWorkload': True}) }}"
+
 - name: "install : Configure User Workload Monitoring"
-  when: uwm_secret_lookup.resources | length == 0
   kubernetes.core.k8s:
     template: templates/cluster-monitoring-config.yml.j2
-
 
 - name: "Debug version"
   debug:

--- a/ibm/mas_devops/roles/grafana/templates/cluster-monitoring-config.yml.j2
+++ b/ibm/mas_devops/roles/grafana/templates/cluster-monitoring-config.yml.j2
@@ -1,3 +1,4 @@
+# We use to_yaml and trim to ensure formatting, booleans and numbers are represented correctly
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -5,4 +6,6 @@ metadata:
   namespace: openshift-monitoring
 data:
   config.yaml: |
-    enableUserWorkload: true
+    {% for key, value in cluster_monitoring_data.items() %}
+    {{ key }}: {{ value | to_yaml | trim }}
+    {% endfor %}


### PR DESCRIPTION
This fixes a bug where if the user had his own stuff defined in his config map for grafana we would just overwrite the entire configmap with our own and they would lose all their settings. This helps make sure we check if the configmap exists first and if so we carry the settings over and append the one setting we're trying to set. 