### PR TITLE
[patch] MAXMIS-897: check if attribute 'deployimagestitching' is defined

### DIFF
--- a/ibm/mas_devops/roles/suite_manage_imagestitching_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_manage_imagestitching_config/tasks/main.yml
@@ -11,11 +11,11 @@
   until:
     - workspaceCR.resources | length > 0
 
-- name: Check if Civil is enabled
+- name: Check if Civil is enabled and image stitching is available
   set_fact:
-    civilEnabled: "{{ workspaceCR.resources[0].status.components.civil is defined and workspaceCR.resources[0].status.components.civil.enabled }}"
+    stitchingAvailable: "{{ workspaceCR.resources[0].status.components.civil is defined and workspaceCR.resources[0].status.components.civil.enabled and workspaceCR.resources[0].status.components.civil.deployimagestitching is defined }}"
 
 - name: Configure stitching
   include_tasks: tasks/configure-stitching.yml
   when:
-    - civilEnabled
+    - stitchingAvailable


### PR DESCRIPTION
Slack discussion:
https://ibm-watson-iot.slack.com/archives/C031Q7W21FZ/p1730994652345789

Jira item: https://jsw.ibm.com/browse/MAXMIS-897

Older releases are using a version of the workspace schema where deployimagestitching is not present
I've added a check for this attribute and skip the role if not present

![afbeelding](https://github.com/user-attachments/assets/cda1c86c-9123-45c3-83f4-d5df51aa0b00)

To test I deployed a pod in Civil's FVT cluster using the latest CLI and ran this playbook:

```
- hosts: localhost
  any_errors_fatal: true
  vars:
    mas_instance_id: civil
    mas_workspace_id: masdev
    mas_ws_cr_name: civil-masdev
    mas_domain: civil.ibmmasfvt.com
    manage_namespace: mas-civil-manage
    stitching_pvcname: manage-imagestitching
    stitching_storage_class: nfs-client
    stitching_storage_size: 20Gi
    stitching_storage_mode: ReadWriteMany
    stitching_storage_mountpath: imagestitching
  roles:
    - ibm.mas_devops.suite_manage_imagestitching_config

```

I tested with a spurious attribute that isn't present ('xxx') for the negative case.