### PR TITLE
[patch] make cos_instance_name unique

### DIFF
--- a/ibm/mas_devops/roles/cos/tasks/providers/ibm/provision.yml
+++ b/ibm/mas_devops/roles/cos/tasks/providers/ibm/provision.yml
@@ -4,6 +4,12 @@
     that: cos_apikey is defined and cos_apikey != ""
     fail_msg: "cos_apikey property is required"
 
+# 1. Generate a random 8 char string
+# ---------------------------------------------------------------------------------------------------------------------
+- name: "Set fact: Set a random 8 char string"
+  set_fact:
+    random_uuid: "{{ query('community.general.random_string', upper=false, numbers=false, special=false, length=8) }}"
+
 # 1. Determine the instance name
 # ---------------------------------------------------------------------------------------------------------------------
 - name: Customize CoS Instance Name using mas_instance_id variables
@@ -14,7 +20,7 @@
     - mas_config_dir != ""
     - cos_instance_name is not defined or cos_instance_name == ""
   set_fact:
-    cos_instance_name: "Object Storage for MAS - {{ mas_instance_id }}"
+    cos_instance_name: "Object Storage for MAS - {{ mas_instance_id }}_{{ random_uuid }}"
 
 - name: Fallback to default CoS Instance Name
   when:


### PR DESCRIPTION
https://jsw.ibm.com/browse/MASCORE-4379

Looking at fvt-release are we unable to run multiple in parallel 
Looks like they get upset about COS because all the releases use the same name

We should be fixing that so it uses a unique name, instead of assuming the mas instance id is unique across all runs

slack discussion: https://ibm-watson-iot.slack.com/archives/C031Q7W21FZ/p1730889780253499