### PR TITLE
[patch] fix restore for core and fix tar command in restore tasks 

### DIFF
--- a/ibm/mas_devops/roles/db2/tasks/restore/copy-db2-backup-file.yml
+++ b/ibm/mas_devops/roles/db2/tasks/restore/copy-db2-backup-file.yml
@@ -19,7 +19,7 @@
     {{ exec_in_pod_begin }}
     mkdir -p {{ db2_restore_folder }}/{{ _job_name }} &&
     tar -xzf {{ db2_restore_folder }}/{{ _job_name }}.tar.gz
-    -C {{ db2_restore_folder }}/{{ _job_name }} . &&
+    -C {{ db2_restore_folder }}/{{ _job_name }} &&
     ls {{ db2_restore_folder }}/{{ _job_name }}
     {{ exec_in_pod_end }}
   register: _extract_output

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/restore-database-perform.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/restore-database-perform.yml
@@ -43,7 +43,7 @@
     {{ exec_in_pod_begin }}
     mkdir -p {{ mongodb_restore_folder }}/{{ _job_name }} &&
     tar -xzf {{ mongodb_restore_folder }}/{{ _job_name }}.tar.gz
-    -C {{ mongodb_restore_folder }}/{{ _job_name }} . &&
+    -C {{ mongodb_restore_folder }}/{{ _job_name }} &&
     ls -lA {{ mongodb_restore_folder }}/{{ _job_name }}
     {{ exec_in_pod_end }}
   register: _extract_output

--- a/ibm/mas_devops/roles/suite_app_backup_restore/tasks/restore-namespace.yml
+++ b/ibm/mas_devops/roles/suite_app_backup_restore/tasks/restore-namespace.yml
@@ -55,7 +55,7 @@
       changed_when: true
       shell: >
         tar -xzf {{ masbr_local_job_folder }}/{{ masbr_job_data_type }}/{{ masbr_ns_restore_from_name }}.tar.gz
-        -C {{ masbr_ns_restore_folder }} . &&
+        -C {{ masbr_ns_restore_folder }} &&
         ls -lA {{ masbr_ns_restore_folder }}
       register: _extract_output
 

--- a/ibm/mas_devops/roles/suite_backup_restore/tasks/restore-namespace.yml
+++ b/ibm/mas_devops/roles/suite_backup_restore/tasks/restore-namespace.yml
@@ -53,7 +53,7 @@
       shell: >
         mkdir -p {{ masbr_ns_restore_folder }}/{{ masbr_ns_restore_from_name }} &&
         tar -xzf {{ masbr_ns_restore_folder }}/{{ masbr_ns_restore_from_name }}.tar.gz
-        -C {{ masbr_ns_restore_folder }}/{{ masbr_ns_restore_from_name }} . &&
+        -C {{ masbr_ns_restore_folder }}/{{ masbr_ns_restore_from_name }} &&
         ls -lA {{ masbr_ns_restore_folder }}/{{ masbr_ns_restore_from_name }}
       register: _extract_output
 
@@ -66,7 +66,20 @@
 
     # Restore namespace resoruces
     # -------------------------------------------------------------------------
-    # (TODO)
+    # Loop through the folder
+    - name: "Get the list of files from restore directory"
+      find:
+        paths: "{{ masbr_ns_restore_folder }}/{{ masbr_ns_restore_from_name }}"
+        patterns: '*.yml,*.yaml'
+        recurse: no
+      register: find_result
+
+    - name: "Apply configs"
+      kubernetes.core.k8s:
+        state: present
+        definition: "{{ lookup('template', item.path) }}"
+      with_items: "{{ find_result.files }}"
+      when: find_result is defined
 
 
     # Update database restore status: Completed


### PR DESCRIPTION
Problems addressed

1. `tar` command used to extract the restored archive was failing silently 
2. For Core restore, restore namespace resources wasn't implemented.
 
<img width="1216" alt="Screenshot 2024-11-19 at 14 33 30" src="https://github.com/user-attachments/assets/ac2b140e-d8e4-4829-86bc-cebd0efc8910">
