### PR TITLE
[patch] fix conflicting DB config

### DIFF
--- a/ibm/mas_devops/roles/suite_db2_setup_for_manage/vars/main.yml
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_manage/vars/main.yml
@@ -27,7 +27,7 @@ db2_configs:
           LOGSECOND: '156'
           LOGFILSIZ: '32768'
           LOGARCHMETH1: 'DISK:/mnt/bludata0/db2/archive_log/'
-          MIRRORLOGPATH: '/mnt/backup/MIRRORLOGPATH'
+          MIRRORLOGPATH: '/mnt/backup'
           STMT_CONC: 'LITERALS'
           DDL_CONSTRAINT_DEF: 'YES'
           TRACKMOD: 'YES'
@@ -41,8 +41,6 @@ db2_configs:
           AUTO_REORG: 'OFF'
           AUTO_DB_BACKUP: 'OFF'
           WLM_ADMISSION_CTRL: 'NO'
-          SHEAPTHRES_SHR: 'automatic'
-          SORTHEAP: 'automatic'
           AUTHN_CACHE_USERS: '100'
           AUTHN_CACHE_DURATION: '10'
       instance:


### PR DESCRIPTION
https://jsw.ibm.com/browse/MASCORE-4517

TS017131353 (SC) - DB config is not applied during db2u instance startup

A few of the db2 configs applied jus before Manage install is causing conflits and resulting in 
```
SQL1668N  The operation failed because the operation is not supported with 
this environment. Reason code: "9".
```

The fix was discussed with the db2 team on this slack thread: https://ibm-cloudplatform.slack.com/archives/C019EJ0QH4Y/p1729189859898779?thread_ts=1728336840.156449&cid=C019EJ0QH4Y 

i have tested this manually on tech foundation cluster and i was able to apply the updated db2config successfully 

`update db cfg for BLUDB using  APPLHEAPSZ 8192 AUTOMATIC AUTHN_CACHE_DURATION 10 AUTHN_CACHE_USERS 100 AUTO_DB_BACKUP OFF AUTO_DEL_REC_OBJ ON AUTO_MAINT ON AUTO_REORG OFF AUTO_REVAL DEFERRED AUTO_RUNSTATS ON AUTO_TBL_MAINT ON CATALOGCACHE_SZ 800 CHNGPGS_THRESH 40 CUR_COMMIT ON DATABASE_MEMORY AUTOMATIC DBHEAP AUTOMATIC DDL_CONSTRAINT_DEF YES DEC_TO_CHAR_FMT NEW DFT_QUERYOPT 5 DFT_SCHEMAS_DCC NO DFT_TABLE_ORG ROW EXTBL_LOCATION /mnt/blumeta0/db2/load;/mnt/blumeta0/home;/mnt/bludata0/scratch;/mnt/external;/mnt/backup EXTBL_STRICT_IO NO INDEXREC ACCESS LOCKLIST AUTOMATIC LOCKTIMEOUT 300 LOGARCHMETH1 DISK:/mnt/bludata0/db2/archive_log/ LOGBUFSZ 1024 LOGFILSIZ 32768 LOGPRIMARY 100 LOGSECOND 156 LOG_APPL_INFO NO LOG_DDL_STMTS NO MAXFILOP 61440 NUM_DB_BACKUPS 60 NUM_IOCLEANERS AUTOMATIC NUM_IOSERVERS AUTOMATIC PCKCACHESZ AUTOMATIC REC_HIS_RETENTN 60 SOFTMAX 0 STAT_HEAP_SZ AUTOMATIC STMTHEAP 20000 STMT_CONC LITERALS TRACKMOD YES WLM_ADMISSION_CTRL NO` 


<img width="1199" alt="image" src="https://github.com/user-attachments/assets/8bb274ac-58bb-492b-883f-9d61ecf76db9">


