### PR TITLE
[patch] remove MIRRORLOGPATH folder creation 

### DIFF
--- a/ibm/mas_devops/roles/suite_db2_setup_for_manage/tasks/apply-db2-config-version.yml
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_manage/tasks/apply-db2-config-version.yml
@@ -23,15 +23,6 @@
     msg:
       - "Pod name ............................... {{ db2_pod_name }}"
 
-- name: "Creating MIRRORLOGPATH folder in {{ db2_pod_name }}"
-  shell: |
-    oc exec -it -n {{ db2_namespace }} {{ db2_pod_name }} -- su -lc "mkdir -p /mnt/backup/MIRRORLOGPATH" db2inst1
-  register: creating_mirrorlog_folder_output
-
-- fail: msg="Failed to create path for MIRRORLOGPATH"
-  when:
-    - creating_mirrorlog_folder_output.rc != 0
-
 - name: "Creating LOGARCHMETH1 folder in {{ db2_pod_name }}"
   shell: |
     oc exec -it -n {{ db2_namespace }} {{ db2_pod_name }} -- su -lc "mkdir -p /mnt/bludata0/db2/archive_log/" db2inst1

--- a/ibm/mas_devops/roles/suite_db2_setup_for_manage/vars/main.yml
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_manage/vars/main.yml
@@ -27,7 +27,7 @@ db2_configs:
           LOGSECOND: '156'
           LOGFILSIZ: '32768'
           LOGARCHMETH1: 'DISK:/mnt/bludata0/db2/archive_log/'
-          MIRRORLOGPATH: '/mnt/backup/MIRRORLOGPATH'
+          MIRRORLOGPATH: '/mnt/backup'
           STMT_CONC: 'LITERALS'
           DDL_CONSTRAINT_DEF: 'YES'
           TRACKMOD: 'YES'
@@ -41,8 +41,6 @@ db2_configs:
           AUTO_REORG: 'OFF'
           AUTO_DB_BACKUP: 'OFF'
           WLM_ADMISSION_CTRL: 'NO'
-          SHEAPTHRES_SHR: 'automatic'
-          SORTHEAP: 'automatic'
           AUTHN_CACHE_USERS: '100'
           AUTHN_CACHE_DURATION: '10'
       instance:


### PR DESCRIPTION
issue: https://github.com/ibm-mas/ansible-devops/issues/1061

https://github.com/ibm-mas/ansible-devops/pull/1567 modifies the db2config to use `/mnt/backup' . we dont need to create a folder for /mnt/backup/MIRRORLOGPATH' anymore as it wont be used due to the above PR. 


 db2 will create NODE0000 directory under /mnt/backup and automatically set MIRRORLOGPATH to /mnt/backup/NODE0000/LOGSTREAM0000/ , so we set MIRRORLOGPATH to /mnt/backup. 
 
 Refer below slack thread for detailed info. 

https://ibm-cloudplatform.slack.com/archives/C019EJ0QH4Y/p1729023737866499?thread_ts=1728336840.156449&cid=C019EJ0QH4Y