### PR TITLE
[patch] Db2 backup/restore: fix copy local to pod script

### DIFF
--- a/ibm/mas_devops/common_tasks/backup_restore/copy_storage_files_to_pod.yml
+++ b/ibm/mas_devops/common_tasks/backup_restore/copy_storage_files_to_pod.yml
@@ -24,13 +24,9 @@
         - item.src_folder is defined and item.src_folder | length > 0
         - item.dest_folder is defined and item.dest_folder | length > 0
       shell: >-
-        oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c
-          'temp_dest_folder={{ [item.dest_folder, masbr_job_version] | path_join }} && mkdir -p ${temp_dest_folder}'
-        && oc cp --retries=50 -c {{ masbr_cf_container_name }}
-          {{ [masbr_storage_job_folder, item.src_folder] | path_join }}
-          {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:${temp_dest_folder}
-        && oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c
-          'mv -f ${temp_dest_folder}/* {{ item.dest_folder }} && rm -rf ${temp_dest_folder}'
+        oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'temp_dest_folder={{ [item.dest_folder, masbr_job_version] | path_join }} && mkdir -p ${temp_dest_folder}' \
+        && oc cp --retries=50 -c {{ masbr_cf_container_name }} {{ [masbr_storage_job_folder, item.src_folder] | path_join }} {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:${temp_dest_folder} \
+        && oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'mv -f ${temp_dest_folder}/* {{ item.dest_folder }} && rm -rf ${temp_dest_folder}'
       loop: "{{ masbr_cf_paths }}"
 
     # Condition 2. src_file -> dest_folder: copy src_file to dest_folder/src_file
@@ -39,11 +35,8 @@
         - item.src_file is defined and item.src_file | length > 0
         - item.dest_folder is defined and item.dest_folder | length > 0
       shell: >-
-        oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c
-          'mkdir -p {{ item.dest_folder }}'
-        && oc cp --retries=50 -c {{ masbr_cf_container_name }}
-          {{ [masbr_storage_job_folder, item.src_file] | path_join }}
-          {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:{{ item.dest_folder }}
+        oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'mkdir -p {{ item.dest_folder }}' \
+        && oc cp --retries=50 -c {{ masbr_cf_container_name }} {{ [masbr_storage_job_folder, item.src_file] | path_join }} {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:{{ item.dest_folder }}
       loop: "{{ masbr_cf_paths }}"
 
     # Condition 3. src_file -> dest_file
@@ -55,13 +48,9 @@
         - item.src_file is defined and item.src_file | length > 0
         - item.dest_file is defined and item.dest_file | length > 0
       shell: >-
-        oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c
-          'temp_dest_folder={{ [item.dest_file|dirname, masbr_job_version] | path_join }} && mkdir -p ${temp_dest_folder}'
-        && oc cp --retries=50 -c {{ masbr_cf_container_name }}
-          {{ [masbr_storage_job_folder, item.src_file] | path_join }}
-          {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:${temp_dest_folder}
-        && oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c
-          'mv -f ${temp_dest_folder}/{{ item.src_file|basename }} {{ item.dest_file }} && rm -rf ${temp_dest_folder}'
+        oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'temp_dest_folder={{ [item.dest_file|dirname, masbr_job_version] | path_join }} && mkdir -p ${temp_dest_folder}' \
+        && oc cp --retries=50 -c {{ masbr_cf_container_name }} {{ [masbr_storage_job_folder, item.src_file] | path_join }} {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:${temp_dest_folder} \
+        && oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'mv -f ${temp_dest_folder}/{{ item.src_file|basename }} {{ item.dest_file }} && rm -rf ${temp_dest_folder}'
       loop: "{{ masbr_cf_paths }}"
 
 


### PR DESCRIPTION
This script is used by db2 restore and it was failing to create a directory in pod which is a pre step for copying the local backed up archive to pod directory.

fixes the error in log

<img width="1273" alt="Screenshot 2024-11-21 at 10 26 27" src="https://github.com/user-attachments/assets/770c4744-3a62-4e6e-94bb-ab327f4c048b">

Steps taken to test the fix.
1. Use environment with DB2 and Manage configured
2. Exec into `c-mas-fvtstable-masdev-manage-db2u-0` pod in db2u namespace
3. RAN a db2 command `select * from MAXIMO.maxvars where varname='ADMINRESTART';`
4. Confirmed ADMINRESTART had `OFF` value by default
5. RAN `ansible-playbook ibm.mas_devops.br_db2` with  `backup` action
6. After backup is done, Exec into `c-mas-fvtstable-masdev-manage-db2u-0` pod in db2u namespace again
7. Change the `ADMINRESTART` value to ON.
8. RAN `ansible-playbook ibm.mas_devops.br_db2` with  `restore` action
9. Once restore is done successfully, Exec'ed into `c-mas-fvtstable-masdev-manage-db2u-0` and verified `ADMINRESTART` is changed back to OFF


<img width="1248" alt="Screenshot 2024-11-21 at 10 32 58" src="https://github.com/user-attachments/assets/93f6ae21-aaea-4457-813c-3ba8cd334249">


