### PR TITLE
[patch] fix restore for manage role

### DIFF
--- a/ibm/mas_devops/roles/suite_app_backup_restore/tasks/get-app-info.yml
+++ b/ibm/mas_devops/roles/suite_app_backup_restore/tasks/get-app-info.yml
@@ -40,6 +40,7 @@
   assert:
     that: mas_app_version is defined
     fail_msg: "{{ mas_app_kind }}/{{ mas_app_cr_name }} does not exists!"
+  when: masbr_action is defined and masbr_action == "backup"
 
 - name: "Set fact: {{ mas_app_kind }}/{{ mas_app_cr_name }} status"
   set_fact:
@@ -51,7 +52,7 @@
 
 # When performing restore, we shouldn't care about the status of app.
 - name: "Fail if {{ mas_app_kind }}/{{ mas_app_cr_name }} is not ready"
-  when: false
+  when: masbr_action is defined and masbr_action == "backup"
   assert:
     that: mas_app_ready is defined and mas_app_ready
     fail_msg: "{{ mas_app_kind }}/{{ mas_app_cr_name }} is not ready!"
@@ -83,6 +84,7 @@
   assert:
     that: mas_ws_version is defined
     fail_msg: "{{ mas_ws_kind }}/{{ mas_ws_cr_name }} does not exists!"
+  when: masbr_action is defined and masbr_action == "backup"
 
 - name: "Set fact: {{ mas_ws_kind }}/{{ mas_ws_cr_name }} status"
   set_fact:
@@ -94,7 +96,7 @@
 
 # When performing restore, we shouldn't care about the status of app.
 - name: "Fail if {{ mas_ws_kind }}/{{ mas_ws_cr_name }} is not ready"
-  when: false
+  when: masbr_action is defined and masbr_action == "backup"
   assert:
     that: mas_ws_ready is defined and mas_ws_ready
     fail_msg: "{{ mas_ws_kind }}/{{ mas_ws_cr_name }} is not ready!"
@@ -103,6 +105,7 @@
 # Output app information
 # -----------------------------------------------------------------------------
 - name: "Debug: {{ mas_app_id | capitalize }} information"
+  when: masbr_action is defined and masbr_action == "backup"
   debug:
     msg:
       - "{{ mas_app_kind }}/{{ mas_app_cr_name }} version ............ {{ mas_app_version }}"

--- a/ibm/mas_devops/roles/suite_app_backup_restore/tasks/manage/pv-info.yml
+++ b/ibm/mas_devops/roles/suite_app_backup_restore/tasks/manage/pv-info.yml
@@ -22,16 +22,18 @@
 - name: "Set fact: workspace pv spec"
   set_fact:
     manage_ws_pvs: "{{ _ws_output.resources[0].spec.settings.deployment.persistentVolumes }}"
+  when: masbr_manage_pvc_paths is defined and masbr_manage_pvc_paths | length > 0
 
 - name: "Debug: workspace pv spec"
   debug:
     msg: "{{ manage_ws_pvs }}"
+  when: manage_ws_pvs is defined
 
 
 # Only go on processing when manage has pv defined
 # -----------------------------------------------------------------------------
 - name: "Only go on processing when manage has pv defined"
-  when: manage_ws_pvs | length > 0
+  when: manage_ws_pvs is defined and manage_ws_pvs | length > 0
   block:
     # Get maxinst pod information
     - name: "Get maxinst pod information"

--- a/ibm/mas_devops/roles/suite_app_backup_restore/tasks/manage/restore-namespace.yml
+++ b/ibm/mas_devops/roles/suite_app_backup_restore/tasks/manage/restore-namespace.yml
@@ -17,12 +17,29 @@
     .name="{{ mas_workspace_id }}-manage-encryptionsecret-operator"
     )' {{ masbr_ns_restore_folder }}/Secret-{{ masbr_restore_from_workspace }}-manage-encryptionsecret-operator.yaml;
 
-- name: "Apply encryption secret yaml files"
+# Restore namespace resoruces
+# -------------------------------------------------------------------------
+# Loop through the folder
+- name: "Get the list of files from restore directory"
+  find:
+    paths: "{{ masbr_ns_restore_folder }}"
+    patterns: '*.yml,*.yaml'
+    recurse: no
+  register: find_result
+
+- name: "Apply configs"
   kubernetes.core.k8s:
-    apply: true
-    src: "{{ masbr_ns_restore_folder }}/{{ _ns_resource_file_name }}"
-  loop:
-    - "Secret-{{ masbr_restore_from_workspace }}-manage-encryptionsecret.yaml"
-    - "Secret-{{ masbr_restore_from_workspace }}-manage-encryptionsecret-operator.yaml"
-  loop_control:
-    loop_var: _ns_resource_file_name
+    state: present
+    definition: "{{ lookup('template', item.path) }}"
+  with_items: "{{ find_result.files }}"
+  when: find_result is defined
+
+# - name: "Apply encryption secret yaml files"
+#   kubernetes.core.k8s:
+#     apply: true
+#     src: "{{ masbr_ns_restore_folder }}/{{ _ns_resource_file_name }}"
+#   loop:
+#     - "Secret-{{ masbr_restore_from_workspace }}-manage-encryptionsecret.yaml"
+#     - "Secret-{{ masbr_restore_from_workspace }}-manage-encryptionsecret-operator.yaml"
+#   loop_control:
+#     loop_var: _ns_resource_file_name


### PR DESCRIPTION
This change will not run certain tasks in pv-info.yamk when `masbr_manage_pvc_paths` is not defined.
Also it now applies backed up manage resources.