### PR TITLE
[patch] Fix missing catalog_digest

### DIFF
--- a/ibm/mas_devops/playbooks/mirror_dependencies.yml
+++ b/ibm/mas_devops/playbooks/mirror_dependencies.yml
@@ -84,6 +84,7 @@
         - mirror_mode != "from-filesystem"
       vars:
         extras_name: catalog
+        catalog_digest: "{{ mas_catalog_metadata.catalog_digest }}"
 
     - role: ibm.mas_devops.mirror_images
       when: mirror_catalog


### PR DESCRIPTION
## Failure with mirroring of the catalog

The catalog_digest is not being set when executing mirroring. The variable is available in  `mas_catalog_metadata.catalog_digest` and should be set when preparing the extra images. 