### PR TITLE
[patch] Set cpd_product_version  from catalog metadata

### DIFF
--- a/ibm/mas_devops/playbooks/mirror_dependencies.yml
+++ b/ibm/mas_devops/playbooks/mirror_dependencies.yml
@@ -79,7 +79,7 @@
     - name: "Set default cpd_product_version (if necessary)"
       when: cpd_product_version == ""
       set_fact:
-        cpd_product_version: mas_catalog_metadata.cpd_product_version_default
+        cpd_product_version: "{{ mas_catalog_metadata.cpd_product_version_default }}"
 
   roles:
     # 1. IBM Maximo Operator Catalog

--- a/ibm/mas_devops/playbooks/mirror_dependencies.yml
+++ b/ibm/mas_devops/playbooks/mirror_dependencies.yml
@@ -75,6 +75,12 @@
       assert:
         that: mas_catalog_metadata.failed == false
 
+    # If the CPD_PRODUCT_VERSION environment variable wasn't set, then use the default from the catalog metadata
+    - name: "Set default cpd_product_version (if necessary)"
+      when: cpd_product_version == ""
+      set_fact:
+        cpd_product_version: mas_catalog_metadata.cpd_product_version_default
+
   roles:
     # 1. IBM Maximo Operator Catalog
     # -------------------------------------------------------------------------


### PR DESCRIPTION
With the switch to using `ibm.mas_devops.get_catalog_info` we now need an extra task to set `cpd_product_version` if it's not set explicitly using the `CPD_PRODUCT_VERSION` environment variable.