### PR TITLE
[patch] Use correct variable for mongo extras

### DIFF
--- a/ibm/mas_devops/playbooks/mirror_dependencies.yml
+++ b/ibm/mas_devops/playbooks/mirror_dependencies.yml
@@ -107,13 +107,13 @@
         - mirror_mode != "from-filesystem"
       vars:
         extras_name: mongoce
-        extras_version: "{{ mas_catalog_metadata.mongo_extras_version }}"
+        extras_version: "{{ mas_catalog_metadata.mongo_extras_version_default }}"
 
     - role: ibm.mas_devops.mirror_images
       when: mirror_mongoce
       vars:
         manifest_name: extras_mongoce
-        manifest_version: "{{ mas_catalog_metadata.mongo_extras_version }}"
+        manifest_version: "{{ mas_catalog_metadata.mongo_extras_version_default }}"
 
     # Mirror Mongo v4 specifically when requested
     - role: ibm.mas_devops.mirror_extras_prepare


### PR DESCRIPTION
We're loading `mongo_extras_version` from the catalog manifest instead of `mongo_extras_version_default`.

```
TASK [ibm.mas_devops.mirror_extras_prepare : extras : Select task to run] ******
ok: [localhost] => changed=false
ansible_facts:
task_name: extras
TASK [ibm.mas_devops.mirror_extras_prepare : extras : Generate manifests] ******
included: /opt/app-root/lib64/python3.9/site-packages/ansible_collections/ibm/mas_devops/roles/mirror_extras_prepare/tasks/extras.yml for localhost
TASK [ibm.mas_devops.mirror_extras_prepare : mongoce : Fail if required properties are not provided] ***
ok: [localhost] => changed=false
msg: All assertions passed
TASK [ibm.mas_devops.mirror_extras_prepare : mongoce : Load variables] *********
fatal: [localhost]: FAILED! => changed=false
ansible_facts: {}
ansible_included_var_files: []
message: |-
Could not find or access 'mongoce_{{ lookup('env', 'MONGODB_VERSION') | default(mongo_extras_version_default, True) }}.yml'
Searched in:
/opt/app-root/lib64/python3.9/site-packages/ansible_collections/ibm/mas_devops/roles/mirror_extras_prepare/vars/mongoce_{{ lookup('env', 'MONGODB_VERSION') | default(mongo_extras_version_default, True) }}.yml
/opt/app-root/lib64/python3.9/site-packages/ansible_collections/ibm/mas_devops/roles/mirror_extras_prepare/mongoce_{{ lookup('env', 'MONGODB_VERSION') | default(mongo_extras_version_default, True) }}.yml
/opt/app-root/lib64/python3.9/site-packages/ansible_collections/ibm/mas_devops/roles/mirror_extras_prepare/tasks/vars/mongoce_{{ lookup('env', 'MONGODB_VERSION') | default(mongo_extras_version_default, True) }}.yml
/opt/app-root/lib64/python3.9/site-packages/ansible_collections/ibm/mas_devops/roles/mirror_extras_prepare/tasks/mongoce_{{ lookup('env', 'MONGODB_VERSION') | default(mongo_extras_version_default, True) }}.yml
/opt/app-root/lib64/python3.9/site-packages/ansible_collections/ibm/mas_devops/playbooks/vars/mongoce_{{ lookup('env', 'MONGODB_VERSION') | default(mongo_extras_version_default, True) }}.yml
/opt/app-root/lib64/python3.9/site-packages/ansible_collections/ibm/mas_devops/playbooks/mongoce_{{ lookup('env', 'MONGODB_VERSION') | default(mongo_extras_version_default, True) }}.yml on the Ansible Controller.
If you are using a module and expect the file to exist on the remote, see the remote_src option
NO MORE HOSTS LEFT *************************************************************
PLAY RECAP *********************************************************************
localhost : ok=7 changed=0 unreachable=0 failed=1 skipped=22 rescued=0 ignored=0
```