### PR TITLE
[patch]  Add estimates for cpd in readme

### DIFF
--- a/ibm/mas_devops/roles/cp4d/README.md
+++ b/ibm/mas_devops/roles/cp4d/README.md
@@ -23,6 +23,12 @@ The role will automatically install or upgrade (if targeted to an existing CPD d
 
 For more information about CPD versioning, see [IBM Cloud Pak for Data Operator and operand versions 4.9.x](https://www.ibm.com/docs/en/cloud-paks/cp-data/4.8.x?topic=planning-operator-operand-versions) or [IBM Cloud Pak for Data Operator and operand versions 5.0.x](https://www.ibm.com/docs/en/cloud-paks/cp-data/5.0.x?topic=planning-operator-operand-versions)
 
+!!! info
+    - Install CP4D ControlPlane (~1 hour)
+    - Install CP4D Services (~30 Minutes - 1 hour for each service)
+
+    All timings are estimates.
+
 Cloud Pak for Data version mapping to MAS Catalog
 ====
 

--- a/ibm/mas_devops/roles/cp4d_service/README.md
+++ b/ibm/mas_devops/roles/cp4d_service/README.md
@@ -28,6 +28,12 @@ These services can be deployed and configured using this role:
 - [Watson Discovery](https://www.ibm.com/docs/en/cloud-paks/cp-data/4.8.x?topic=services-watson-discovery) required by [Assist](https://www.ibm.com/docs/en/mas-cd/maximo-assist) - Not supported with CPD 5.0
 - [Cognos Analytics](https://www.ibm.com/docs/en/cloud-paks/cp-data/4.8.x?topic=analytics-installing) optional dependency for [Manage application](https://www.ibm.com/docs/en/mas-cd/maximo-manage)
 
+!!! info
+    - Install CP4D Services (~30 Minutes - 1 hour for each service)
+
+    All timings are estimates.
+
+
 Upgrade
 ------------------
 This role also supports seamlessly CPD services minor version upgrades (CPD 4.6.x > CPD 4.8.0 or CPD 4.8.0 > CPD 5.0.0), as well as patch version upgrades (e.g. CPD 4.6.0 -> CPD 4.6.6), with the exception of [Watson Discovery](https://www.ibm.com/docs/en/cloud-paks/cp-data/4.8.x?topic=u-upgrading-from-version-46-2).


### PR DESCRIPTION
Added CPD estimates in the readme 

slack thread - https://ibm-watson-iot.slack.com/archives/C01ABHMP3TP/p1732632434929519?thread_ts=1732204134.914569&cid=C01ABHMP3TP