### PR TITLE
[patch] get_default_storage_classes should always set failed=False

### DIFF
--- a/ibm/mas_devops/plugins/action/get_default_storage_classes.py
+++ b/ibm/mas_devops/plugins/action/get_default_storage_classes.py
@@ -27,11 +27,16 @@ class ActionModule(ActionBase):
         dynClient = get_api_client()
         storageClasses = getDefaultStorageClasses(dynClient)
 
+        # We don't want to fail if we can't find any default storage classes, doing so will
+        # result in roles/playbooks failing in environments where none of the default
+        # storage classes are available.  We use the success=false to track when we couldn't
+        # find a default storage class, which does not trigger Ansible treating the action as
+        # failed.
         if storageClasses.provider is None:
             return dict(
-                message=f"Failed to find default storage classes",
+                message=f"Failed to find any default supported storage classes",
                 success=False,
-                failed=True,
+                failed=False,
                 changed=False,
                 **vars(storageClasses)
             )


### PR DESCRIPTION
We don't want to fail if we can't find any default storage classes, doing so will result in roles/playbooks failing in environments where none of the default storage classes are available.  We use the success=false to track when we couldn't find a default storage class, which does not trigger Ansible treating the action as failed.