### PR TITLE
[patch] create unique certificate for each db2 instance

### DIFF
--- a/ibm/mas_devops/roles/db2/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/db2/tasks/install/main.yml
@@ -317,7 +317,7 @@
   kubernetes.core.k8s_info:
     api_version: v1
     kind: Secret
-    name: "db2u-certificate"
+    name: "db2u-certificate-{{db2_instance_name}}"
     namespace: "{{db2_namespace}}"
   register: _db2_instance_certificates
 

--- a/ibm/mas_devops/roles/db2/templates/certs/certificate.yml.j2
+++ b/ibm/mas_devops/roles/db2/templates/certs/certificate.yml.j2
@@ -1,7 +1,7 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: "db2u-certificate"
+  name: "db2u-certificate-{{db2_instance_name}}"
   namespace: "{{ db2_namespace }}"
 {% if custom_labels is defined and custom_labels.items() %}
   labels:
@@ -10,7 +10,7 @@ metadata:
 {% endfor %}
 {% endif %}
 spec:
-  secretName: "db2u-certificate"
+  secretName: "db2u-certificate-{{db2_instance_name}}"
   duration: "175200h0m0s"
   renewBefore: "2160h0m0s"
   issuerRef:

--- a/ibm/mas_devops/roles/db2/templates/db2ucluster.yml.j2
+++ b/ibm/mas_devops/roles/db2/templates/db2ucluster.yml.j2
@@ -57,7 +57,7 @@ spec:
       settings:
         dftTableOrg: "{{db2_table_org }}"
       ssl:
-        secretName: "db2u-certificate"
+        secretName: "db2u-certificate-{{db2_instance_name}}"
         certLabel: "CN=db2u"
     instance:
 {% if db2_instance_registry is defined and db2_instance_registry != "" %}


### PR DESCRIPTION
## Create unique Certificate resource for each DB2 instance

Currently if multiple DB2 instances are installed and configured the existing Certificate Resource contents will be overwritten by the last install. This becomes a problem as the dnsNames entries (SAN) will be updated. This will result in pre-existing instances using a certificate that contains no matching SAN entry in the certificate for the hostname. 

This is being tracked internally with the following JIRA:

- https://jsw.ibm.com/browse/MASCORE-4553

## Testing and results

After this change there will be a unique Certificate and correpsonding Secret resource for each DB2 instance. The unique Certificates will have the same CA however. Take for example a DB2 install for an instance identified by `db2u-db01. A Certificate and Secret named `db2u-certificate-db2u-db01` will be created:

```bash
oc get Certificate                                   
NAME                         READY   SECRET                       AGE
db2u-ca-certificate          True    db2u-ca                      2m51s
db2u-certificate-db2u-db01   True    db2u-certificate-db2u-db01   2m43s
```

And then querying for the Secret:

```bash
oc get Secret | grep db2u-certificate-db2u-db01
db2u-certificate-db2u-db01                         kubernetes.io/tls                     3      5m35s
```

It is also observed that the `dnsNames` are correct for the Certiificate:

```
  dnsNames:
  - db2u-db01-db2u.apps.grantcounty.cp.fyre.ibm.com
  - '*.db2u-db01-db2u.apps.grantcounty.cp.fyre.ibm.com'
  - c-db2u-db01-db2u-engn-svc.db2u.svc
  - '*.c-db2u-db01-db2u-engn-svc.db2u.svc'
```

And the `Db2uCluster` instance is reaady:

```bash
c get Db2uCluster 
NAME        STATE   MAINTENANCESTATE   AGE
db2u-db01   Ready   None               17m
```