### PR TITLE
[patch] Fixes ibmcloud_api_key issue in COS deprovision for ibmcloud

### DIFF
--- a/ibm/mas_devops/roles/cos/tasks/providers/ibm/deprovision.yml
+++ b/ibm/mas_devops/roles/cos/tasks/providers/ibm/deprovision.yml
@@ -39,7 +39,7 @@
 - name: Fetch IBM Cloud Resource Group Id
   ibm.cloudcollection.ibm_resource_group_info:
     name: "{{ cos_resourcegroup }}"
-    cos_apikey: "{{ cos_apikey }}"
+    ibmcloud_api_key: "{{ cos_apikey }}"
   register: rg_info
 
 - name: Fetch IBM COS Information
@@ -48,7 +48,7 @@
     resource_group_id: "{{ rg_info.resource.id }}"
     service: "{{ cos_service }}"
     location: "{{ cos_location_info }}"
-    cos_apikey: "{{ cos_apikey  }}"
+    ibmcloud_api_key: "{{ cos_apikey  }}"
   register: cos_info
   failed_when: cos_info.rc != 0 and "No resource instance found" not in cos_info.stderr
 
@@ -77,7 +77,7 @@
         service: "cloud-object-storage"
         plan: "{{ cos_plan_type }}"
         location: "{{ cos_location_info }}"
-        cos_apikey: "{{ cos_apikey  }}"
+        ibmcloud_api_key: "{{ cos_apikey  }}"
         state: absent
       register: cos_deprovision_output
 


### PR DESCRIPTION
### Description:
Deprovision of COS in IBM Cloud is failing because of incorrect parameter name used. Functions of ibm.cloudcollection require ibmcloud_api_key as a parameter and instead cos_apikey is passed. This changes fixes that reference.

### Related Links:
MASCORE-4641

### Testing:
Tested the role locally.
<img width="1720" alt="Screenshot 2024-12-02 at 18 10 06" src="https://github.com/user-attachments/assets/320d7b59-569a-4d99-b683-8c463ff38beb">
