### PR TITLE
[patch] fix default booleans for suite_dns

### DIFF
--- a/ibm/mas_devops/roles/suite_dns/defaults/main.yaml
+++ b/ibm/mas_devops/roles/suite_dns/defaults/main.yaml
@@ -6,7 +6,7 @@ supported_dns_providers:
   - cis
   - cloudflare
   - route53
-mas_manual_cert_mgmt: "{{ lookup('env', 'MAS_MANUAL_CERT_MGMT')| default(False, true) }}"
+mas_manual_cert_mgmt: "{{ lookup('env', 'MAS_MANUAL_CERT_MGMT')| default(false, true) | bool }}"
 
 # Certificate Manager
 # -----------------------------------------------------------------------------
@@ -50,7 +50,7 @@ cis_email: "{{ lookup('env', 'CIS_EMAIL') }}"
 cis_apikey: "{{ lookup('env', 'CIS_APIKEY') }}"
 cis_crn: "{{ lookup('env', 'CIS_CRN') }}"
 cis_subdomain: "{{ lookup('env', 'CIS_SUBDOMAIN') }}"
-cis_enhanced_security: "{{ lookup('env', 'CIS_ENHANCED_SECURITY') | default(false, false) }}"
+cis_enhanced_security: "{{ lookup('env', 'CIS_ENHANCED_SECURITY') | default(false, false) | bool }}"
 
 # Enhanced IBM CIS DNS Integration Security
 # -----------------------------------------------------------------------------
@@ -59,11 +59,11 @@ cis_proxy: "{{ lookup('env', 'CIS_PROXY') | default(false, true) }}"
 cis_service_name: "{{ lookup('env', 'CIS_SERVICE_NAME')}}"
 
 # Update DNS entry if it already exists
-update_dns: "{{ lookup('env', 'UPDATE_DNS_ENTRIES') | default(true, true) }}"
+update_dns: "{{ lookup('env', 'UPDATE_DNS_ENTRIES') | default(true, true) | bool }}"
 # Force deletion of wildcard dns entries in cis
-delete_wildcards: "{{ lookup('env', 'DELETE_WILDCARDS') | default(false, true)}}"
+delete_wildcards: "{{ lookup('env', 'DELETE_WILDCARDS') | default(false, true)| bool }}"
 # Override and delete any existing edge certificates in cis instance
-override_edge_certs: "{{ lookup('env', 'OVERRIDE_EDGE_CERTS') | default(true, true)}}"
+override_edge_certs: "{{ lookup('env', 'OVERRIDE_EDGE_CERTS') | default(true, true) | bool }}"
 
 cis_apiservice:
   group_name: acme.cis.ibm.com

--- a/ibm/mas_devops/roles/suite_dns/defaults/main.yaml
+++ b/ibm/mas_devops/roles/suite_dns/defaults/main.yaml
@@ -6,7 +6,7 @@ supported_dns_providers:
   - cis
   - cloudflare
   - route53
-mas_manual_cert_mgmt: "{{ lookup('env', 'MAS_MANUAL_CERT_MGMT')| default(false, true) | bool }}"
+mas_manual_cert_mgmt: "{{ lookup('env', 'MAS_MANUAL_CERT_MGMT')| default('false', true) | bool }}"
 
 # Certificate Manager
 # -----------------------------------------------------------------------------
@@ -50,7 +50,7 @@ cis_email: "{{ lookup('env', 'CIS_EMAIL') }}"
 cis_apikey: "{{ lookup('env', 'CIS_APIKEY') }}"
 cis_crn: "{{ lookup('env', 'CIS_CRN') }}"
 cis_subdomain: "{{ lookup('env', 'CIS_SUBDOMAIN') }}"
-cis_enhanced_security: "{{ lookup('env', 'CIS_ENHANCED_SECURITY') | default(false, false) | bool }}"
+cis_enhanced_security: "{{ lookup('env', 'CIS_ENHANCED_SECURITY') | default('false', false) | bool }}"
 
 # Enhanced IBM CIS DNS Integration Security
 # -----------------------------------------------------------------------------
@@ -59,11 +59,11 @@ cis_proxy: "{{ lookup('env', 'CIS_PROXY') | default(false, true) }}"
 cis_service_name: "{{ lookup('env', 'CIS_SERVICE_NAME')}}"
 
 # Update DNS entry if it already exists
-update_dns: "{{ lookup('env', 'UPDATE_DNS_ENTRIES') | default(true, true) | bool }}"
+update_dns: "{{ lookup('env', 'UPDATE_DNS_ENTRIES') | default('true', true) | bool }}"
 # Force deletion of wildcard dns entries in cis
-delete_wildcards: "{{ lookup('env', 'DELETE_WILDCARDS') | default(false, true)| bool }}"
+delete_wildcards: "{{ lookup('env', 'DELETE_WILDCARDS') | default('false', true)| bool }}"
 # Override and delete any existing edge certificates in cis instance
-override_edge_certs: "{{ lookup('env', 'OVERRIDE_EDGE_CERTS') | default(true, true) | bool }}"
+override_edge_certs: "{{ lookup('env', 'OVERRIDE_EDGE_CERTS') | default('true', true) | bool }}"
 
 cis_apiservice:
   group_name: acme.cis.ibm.com


### PR DESCRIPTION
Fixes issue with non boolean default values causing wrong assertions when running this role.

Before this fix when cis_enhanced_security was set to a string False value
```
TASK [ibm.mas_devops.suite_dns : cis : running standard cis suite dns] *********
skipping: [localhost] => changed=false 
  false_condition: not cis_enhanced_security
  skip_reason: Conditional result was `False`
```

After fix:
```
TASK [ibm.mas_devops.suite_dns : cis : running standard cis suite dns] *********
included: /opt/app-root/lib64/python3.9/site-packages/ansible_collections/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_suitedns_basic.yml for localhost
```