### PR TITLE
[patch] Increase rosa deprovision wait time

### DIFF
--- a/ibm/mas_devops/roles/ocp_deprovision/tasks/providers/rosa.yml
+++ b/ibm/mas_devops/roles/ocp_deprovision/tasks/providers/rosa.yml
@@ -73,8 +73,8 @@
   shell: rosa describe cluster -c {{ cluster_name }} -o json
   register: cluster_lookup
   failed_when: "cluster_lookup.rc > 1"
-  retries: 60
-  delay: 60 # 60s * 60 retries = 1 hour
+  retries: 90
+  delay: 60 # 60s * 90 retries = 1.5 hours
   until: cluster_lookup.rc == 1
 
 


### PR DESCRIPTION
Deprovision time for ROSA is sometimes taking more than an hour. Increase wait time to 1.5 hours to cover this.