### PR TITLE
[patch] Fix cos_bucket picking incorrect resourcegroup

### DIFF
--- a/ibm/mas_devops/roles/cos_bucket/tasks/providers/ibm/create.yml
+++ b/ibm/mas_devops/roles/cos_bucket/tasks/providers/ibm/create.yml
@@ -33,7 +33,7 @@
 - name: "Create IBM COS Bucket: Debug general info"
   debug:
     msg:
-      - "IBM Cloud Resource Group ........... {{ ibmcloud_resourcegroup }}"
+      - "IBM Cloud Resource Group ........... {{ cos_resourcegroup }}"
       - "IBM COS url ........................ {{ cos_url }}"
       - "IBM COS instance name .............. {{ cos_instance_name }}"
       - "IBM COS location info .............. {{ cos_location_info }}"
@@ -52,7 +52,7 @@
 # ---------------------------------------------------------------------------------------------------------------------
 - name: "ibm : Retrieve resource group guid"
   ibm.cloudcollection.ibm_resource_group_info:
-    name: "{{ ibmcloud_resourcegroup }}"
+    name: "{{ cos_resourcegroup }}"
     ibmcloud_api_key: "{{ cos_apikey }}"
   register: rg_info
 

--- a/ibm/mas_devops/roles/cos_bucket/tasks/providers/ibm/delete.yml
+++ b/ibm/mas_devops/roles/cos_bucket/tasks/providers/ibm/delete.yml
@@ -16,7 +16,7 @@
 - name: "Delete IBM COS Bucket: Debug general info"
   debug:
     msg:
-      - "IBM Cloud Resource Group ........... {{ ibmcloud_resourcegroup }}"
+      - "IBM Cloud Resource Group ........... {{ cos_resourcegroup }}"
       - "IBM COS url ........................ {{ cos_url }}"
       - "IBM COS instance name .............. {{ cos_instance_name }}"
       - "IBM COS location info .............. {{ cos_location_info }}"
@@ -28,7 +28,7 @@
 # ---------------------------------------------------------------------------------------------------------------------
 - name: "ibm : Retrieve resource group guid"
   ibm.cloudcollection.ibm_resource_group_info:
-    name: "{{ ibmcloud_resourcegroup }}"
+    name: "{{ cos_resourcegroup }}"
     ibmcloud_api_key: "{{ cos_apikey }}"
   register: rg_info
 


### PR DESCRIPTION
Different env settings are required based on provider to provide Resource group and cos_resourcegroup is ignored for 'IBM' even though it is being assigned with ibm_cloud_resourcegroup by default. Hence, updating the script to use cos_resourcegroup while creating/deleting the bucket. 

https://github.com/ibm-mas/ansible-devops/blob/master/ibm/mas_devops/roles/cos_bucket/defaults/main.yml#L15

Changes have been tested in pfvt (with different branch - svtemp) and results are here => https://dashboard.masdev.wiotp.sl.hursley.ibm.com/tests/stfin