### PR TITLE
[patch] Lock mas-devops less than v2

### DIFF
--- a/.github/workflows/ansible-publish.yml
+++ b/.github/workflows/ansible-publish.yml
@@ -6,6 +6,11 @@ jobs:
   ansible-publish:
     runs-on: ubuntu-latest
     steps:
+      - name: Install Python v3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Checkout
         uses: actions/checkout@v2.3.1
 
@@ -64,7 +69,7 @@ jobs:
           podman images
           podman login --username "${{ secrets.QUAYIO_USERNAME }}" --password "${{ secrets.QUAYIO_PASSWORD }}" quay.io
           podman push quay.io/ibmmas/ansible-devops-ee:latest
-          podman push quay.io/ibmmas/ansible-devops-ee:${{ env.DOCKER_TAG }} 
+          podman push quay.io/ibmmas/ansible-devops-ee:${{ env.DOCKER_TAG }}
 
       - name: Trigger ibm-mas/cli rebuild on Ansible Collection release
         run: |

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -9,6 +9,11 @@ jobs:
   ansible-build:
     runs-on: ubuntu-latest
     steps:
+      - name: Install Python v3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Checkout
         uses: actions/checkout@v2.3.1
         # Without this option, we don't get the tag information

--- a/ibm/mas_devops/requirements.txt
+++ b/ibm/mas_devops/requirements.txt
@@ -1,1 +1,1 @@
-mas-devops >= 1.11.1
+mas-devops >= 1.11.1, < 2


### PR DESCRIPTION
We're preparing a major version bump that will remove support for ICSP and replace it with IDMS support.  Ahead of this we need to ensure that the current version of the Ansible Collection is set up to not automatically pick up the v2 release of mas-devops from PyPi.