### PR TITLE
[patch] Fixes kafka role not picking supported kafka version

### DIFF
--- a/ibm/mas_devops/roles/kafka/tasks/provider/redhat/lookup-supported-kafka-versions.yml
+++ b/ibm/mas_devops/roles/kafka/tasks/provider/redhat/lookup-supported-kafka-versions.yml
@@ -59,10 +59,11 @@
     - name: "Creating dictionary while looping over page content"
       ignore_errors: true
       vars:
+        url_line: 'td class="description"><a href="https://github.com/strimzi/strimzi-kafka-operator/releases/tag/{{ kafka_csv_version }}'
         key: "{{file_lines[my_idx+3] | replace('<td class=\"version\">','') | replace('</td>','') | regex_replace('<td class.*','') | regex_replace('^\\s*','') | regex_replace(' ', '') | split(',') }}"
       set_fact:
         kafka_supported_versions: "{{ result | default([]) + key }}"
-      when: '''td class="description"><a href="https://github.com/strimzi/strimzi-kafka-operator/releases/tag/{{ kafka_csv_version }}'' in line_item'
+      when: url_line in line_item
       loop: "{{ file_lines }}"
       loop_control:
         loop_var: line_item


### PR DESCRIPTION
### Description:
The jinja templating in the script lookup-supported-kafka-versions.yml which looks up supported versions for kafka was not working since when condition no longer supports jinja templating. Due to this script not picking the latest supported version automatically, several FVTs were failing when calling the role. Hence, changed the logic a bit to achieve the same functionality. 

### Related Links:
MASCORE-4860

### Testing:
Tested by triggering the role locally on a quickburn.

<img width="1326" alt="Screenshot 2024-12-19 at 15 54 37" src="https://github.com/user-attachments/assets/ef6b0343-1fbc-475c-985a-0e95ce6eac5a" />

