### PR TITLE
[patch] Remove OCP 4.12 & 4.13 from rotation

### DIFF
--- a/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
@@ -30,11 +30,11 @@
   vars:
     rotate_ocp_version:
       Monday: 4.16
-      Tuesday: 4.14
-      Wednesday: 4.13
-      Thursday: 4.15
+      Tuesday: 4.15
+      Wednesday: 4.14
+      Thursday: 4.16
       Friday: 4.15
-      Saturday: 4.16
+      Saturday: 4.14
       Sunday: 4.16
 
 - name: "Set default OCP version"

--- a/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
@@ -32,7 +32,7 @@
       Monday: 4.16
       Tuesday: 4.14
       Wednesday: 4.13
-      Thursday: 4.12
+      Thursday: 4.15
       Friday: 4.15
       Saturday: 4.16
       Sunday: 4.16


### PR DESCRIPTION
Removing ocp 12 from cluster version rotation.