### PR TITLE
[patch] no longer exclude events-operator

### DIFF
--- a/ibm/mas_devops/playbooks/mirror_dependencies.yml
+++ b/ibm/mas_devops/playbooks/mirror_dependencies.yml
@@ -192,7 +192,6 @@
           - ibm-cpp
           - ibm-cs-healthcheck
           - ibm-cs-monitoring
-          - ibm-events-operator
         ibmpak_skip_dependencies: false
 
     - role: ibm.mas_devops.mirror_images
@@ -214,7 +213,6 @@
           - ibm-cpp
           - ibm-cs-healthcheck
           - ibm-cs-monitoring
-          - ibm-events-operator
         ibmpak_skip_dependencies: false
 
     - role: ibm.mas_devops.mirror_images
@@ -240,7 +238,6 @@
           - ibm-cpp
           - ibm-cs-healthcheck
           - ibm-cs-monitoring
-          - ibm-events-operator
         ibmpak_skip_dependencies: false
 
     - role: ibm.mas_devops.mirror_images
@@ -266,7 +263,6 @@
           - ibm-cpp
           - ibm-cs-healthcheck
           - ibm-cs-monitoring
-          - ibm-events-operator
         ibmpak_skip_dependencies: false
 
     - role: ibm.mas_devops.mirror_images


### PR DESCRIPTION
Not sure what changed but we now need the events-operator to mirror common services