### PR TITLE
[patch] Fixes manage namespace uninstall stuck in terminating state

### DIFF
--- a/ibm/mas_devops/roles/suite_app_uninstall/app_specific/tasks/pre/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_uninstall/app_specific/tasks/pre/manage.yml
@@ -14,8 +14,6 @@
     kind: "{{ item.kind }}"
     namespace: "{{ item.metadata.namespace }}"
     name: "{{ item.metadata.name }}"
-    wait: true
-    wait_timeout: 600 # 10 minutes
   loop: "{{ app_serverbundle_lookup.resources }}"
 
 - name: Wait for ManageServerBundle CR to be deleted
@@ -44,8 +42,6 @@
     kind: "{{ item.kind }}"
     namespace: "{{ item.metadata.namespace }}"
     name: "{{ item.metadata.name }}"
-    wait: true
-    wait_timeout: 600 # 10 minutes
   loop: "{{ app_deployment_lookup.resources }}"
 
 - name: Wait for ManageDeployment CR to be deleted

--- a/ibm/mas_devops/roles/suite_app_uninstall/app_specific/tasks/pre/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_uninstall/app_specific/tasks/pre/manage.yml
@@ -1,4 +1,36 @@
-# 1. Delete ManageDeployment CR
+# 1. Delete ManageServerBundle CR
+# -----------------------------------------------------------------------------
+- name: "Get ManageServerBundle CR"
+  kubernetes.core.k8s_info:
+    api_version: "apps.mas.ibm.com/v1"
+    kind: "ManageServerBundle"
+    namespace: "{{ mas_app_namespace }}"
+  register: app_serverbundle_lookup
+
+- name: "Delete ManageServerBundle CR"
+  kubernetes.core.k8s:
+    state: absent
+    api_version: "{{ item.apiVersion }}"
+    kind: "{{ item.kind }}"
+    namespace: "{{ item.metadata.namespace }}"
+    name: "{{ item.metadata.name }}"
+    wait: true
+    wait_timeout: 600 # 20 minutes
+  loop: "{{ app_serverbundle_lookup.resources }}"
+
+- name: Wait for ManageServerBundle CR to be deleted
+  k8s_info:
+    kind: '{{ item.kind }}'
+    api_version: "{{ item.apiVersion }}"
+    name: '{{ item.metadata.name }}'
+    namespace: "{{ item.metadata.namespace }}"
+  register: bundle_destroy
+  until: bundle_destroy.resources == []
+  retries: 120
+  delay: 10
+  loop: "{{ app_serverbundle_lookup.resources }}"
+
+# 2. Delete ManageDeployment CR
 # -----------------------------------------------------------------------------
 - name: "Get ManageDeployment CR"
   kubernetes.core.k8s_info:
@@ -15,5 +47,19 @@
     namespace: "{{ item.metadata.namespace }}"
     name: "{{ item.metadata.name }}"
     wait: true
-    wait_timeout: 1200 # 20 minutes
+    wait_timeout: 600 # 20 minutes
+    wait_condition:
+      
+  loop: "{{ app_deployment_lookup.resources }}"
+
+- name: Wait for ManageDeployment CR to be deleted
+  k8s_info:
+    kind: '{{ item.kind }}'
+    api_version: "{{ item.apiVersion }}"
+    name: '{{ item.metadata.name }}'
+    namespace: "{{ item.metadata.namespace }}"
+  register: deployment_destroy
+  until: deployment_destroy.resources == []
+  retries: 120
+  delay: 10
   loop: "{{ app_deployment_lookup.resources }}"

--- a/ibm/mas_devops/roles/suite_app_uninstall/app_specific/tasks/pre/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_uninstall/app_specific/tasks/pre/manage.yml
@@ -1,0 +1,39 @@
+# 1. Delete ManageServerbundle CR
+# -----------------------------------------------------------------------------
+- name: "Get all {{ mas_app_id }} Server Bundles"
+  kubernetes.core.k8s_info:
+    api_version: "apps.mas.ibm.com/v1"
+    kind: "ManageServerBundle"
+    namespace: "{{ mas_app_namespace }}"
+  register: app_bundles_lookup
+
+- name: "Delete all {{ mas_app_id }} Server Bundles"
+  kubernetes.core.k8s:
+    state: absent
+    api_version: "{{ item.apiVersion }}"
+    kind: "{{ item.kind }}"
+    namespace: "{{ item.metadata.namespace }}"
+    name: "{{ item.metadata.name }}"
+    wait: true
+    wait_timeout: 600 # 10 minutes
+  loop: "{{ app_bundles_lookup.resources }}"
+
+# 2. Delete ManageDeployment CR
+# -----------------------------------------------------------------------------
+- name: "Get ManageDeployment CR"
+  kubernetes.core.k8s_info:
+    api_version: "apps.mas.ibm.com/v1"
+    kind: "ManageDeployment"
+    namespace: "{{ mas_app_namespace }}"
+  register: app_deployment_lookup
+
+- name: "Delete all {{ mas_app_id }} Server Bundles"
+  kubernetes.core.k8s:
+    state: absent
+    api_version: "{{ item.apiVersion }}"
+    kind: "{{ item.kind }}"
+    namespace: "{{ item.metadata.namespace }}"
+    name: "{{ item.metadata.name }}"
+    wait: true
+    wait_timeout: 600 # 10 minutes
+  loop: "{{ app_deployment_lookup.resources }}"

--- a/ibm/mas_devops/roles/suite_app_uninstall/app_specific/tasks/pre/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_uninstall/app_specific/tasks/pre/manage.yml
@@ -1,24 +1,4 @@
-# 1. Delete ManageServerbundle CR
-# -----------------------------------------------------------------------------
-- name: "Get all {{ mas_app_id }} Server Bundles"
-  kubernetes.core.k8s_info:
-    api_version: "apps.mas.ibm.com/v1"
-    kind: "ManageServerBundle"
-    namespace: "{{ mas_app_namespace }}"
-  register: app_bundles_lookup
-
-- name: "Delete all {{ mas_app_id }} Server Bundles"
-  kubernetes.core.k8s:
-    state: absent
-    api_version: "{{ item.apiVersion }}"
-    kind: "{{ item.kind }}"
-    namespace: "{{ item.metadata.namespace }}"
-    name: "{{ item.metadata.name }}"
-    wait: true
-    wait_timeout: 600 # 10 minutes
-  loop: "{{ app_bundles_lookup.resources }}"
-
-# 2. Delete ManageDeployment CR
+# 1. Delete ManageDeployment CR
 # -----------------------------------------------------------------------------
 - name: "Get ManageDeployment CR"
   kubernetes.core.k8s_info:
@@ -27,7 +7,7 @@
     namespace: "{{ mas_app_namespace }}"
   register: app_deployment_lookup
 
-- name: "Delete all {{ mas_app_id }} Server Bundles"
+- name: "Delete ManageDeployment CR"
   kubernetes.core.k8s:
     state: absent
     api_version: "{{ item.apiVersion }}"
@@ -35,5 +15,5 @@
     namespace: "{{ item.metadata.namespace }}"
     name: "{{ item.metadata.name }}"
     wait: true
-    wait_timeout: 600 # 10 minutes
+    wait_timeout: 1200 # 20 minutes
   loop: "{{ app_deployment_lookup.resources }}"

--- a/ibm/mas_devops/roles/suite_app_uninstall/app_specific/tasks/pre/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_uninstall/app_specific/tasks/pre/manage.yml
@@ -20,10 +20,9 @@
 
 - name: Wait for ManageServerBundle CR to be deleted
   k8s_info:
-    kind: '{{ item.kind }}'
-    api_version: "{{ item.apiVersion }}"
-    name: '{{ item.metadata.name }}'
-    namespace: "{{ item.metadata.namespace }}"
+    kind: 'ManageServerBundle'
+    api_version: "apps.mas.ibm.com/v1"
+    namespace: "{{ mas_app_namespace }}"
   register: bundle_destroy
   until: bundle_destroy.resources == []
   retries: 120 # 20 minutes
@@ -51,10 +50,9 @@
 
 - name: Wait for ManageDeployment CR to be deleted
   k8s_info:
-    kind: '{{ item.kind }}'
-    api_version: "{{ item.apiVersion }}"
-    name: '{{ item.metadata.name }}'
-    namespace: "{{ item.metadata.namespace }}"
+    kind: 'ManageDeployment'
+    api_version: apps.mas.ibm.com/v1"
+    namespace: "{{ mas_app_namespace }}"
   register: deployment_destroy
   until: deployment_destroy.resources == []
   retries: 120 # 20 minutes

--- a/ibm/mas_devops/roles/suite_app_uninstall/app_specific/tasks/pre/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_uninstall/app_specific/tasks/pre/manage.yml
@@ -28,7 +28,6 @@
   until: bundle_destroy.resources == []
   retries: 120 # 20 minutes
   delay: 10
-  loop: "{{ app_serverbundle_lookup.resources }}"
 
 # 2. Delete ManageDeployment CR
 # -----------------------------------------------------------------------------
@@ -60,4 +59,3 @@
   until: deployment_destroy.resources == []
   retries: 120 # 20 minutes
   delay: 10
-  loop: "{{ app_deployment_lookup.resources }}"

--- a/ibm/mas_devops/roles/suite_app_uninstall/app_specific/tasks/pre/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_uninstall/app_specific/tasks/pre/manage.yml
@@ -15,7 +15,7 @@
     namespace: "{{ item.metadata.namespace }}"
     name: "{{ item.metadata.name }}"
     wait: true
-    wait_timeout: 600 # 20 minutes
+    wait_timeout: 600 # 10 minutes
   loop: "{{ app_serverbundle_lookup.resources }}"
 
 - name: Wait for ManageServerBundle CR to be deleted
@@ -26,7 +26,7 @@
     namespace: "{{ item.metadata.namespace }}"
   register: bundle_destroy
   until: bundle_destroy.resources == []
-  retries: 120
+  retries: 120 # 20 minutes
   delay: 10
   loop: "{{ app_serverbundle_lookup.resources }}"
 
@@ -47,7 +47,7 @@
     namespace: "{{ item.metadata.namespace }}"
     name: "{{ item.metadata.name }}"
     wait: true
-    wait_timeout: 600 # 20 minutes
+    wait_timeout: 600 # 10 minutes
   loop: "{{ app_deployment_lookup.resources }}"
 
 - name: Wait for ManageDeployment CR to be deleted
@@ -58,6 +58,6 @@
     namespace: "{{ item.metadata.namespace }}"
   register: deployment_destroy
   until: deployment_destroy.resources == []
-  retries: 120
+  retries: 120 # 20 minutes
   delay: 10
   loop: "{{ app_deployment_lookup.resources }}"

--- a/ibm/mas_devops/roles/suite_app_uninstall/app_specific/tasks/pre/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_uninstall/app_specific/tasks/pre/manage.yml
@@ -48,8 +48,6 @@
     name: "{{ item.metadata.name }}"
     wait: true
     wait_timeout: 600 # 20 minutes
-    wait_condition:
-      
   loop: "{{ app_deployment_lookup.resources }}"
 
 - name: Wait for ManageDeployment CR to be deleted


### PR DESCRIPTION
### Description:
When executing suite_app_uninstall role, the manage namespace deletion gets stuck in terminating state because it waits for ManageServerBundle and ManageDeployment CRs to be deleted. Hence, for a clean uninstall, I have added pre-steps in the role to be executed for manage which will delete those CRs first.

### Related Links:
MASCORE-4950

### Testing:
Tested in a quickburn with 1 and multiple server bundles.

Cluster with 1 server bundle:
[HTNew Uninstall Logs 250103.log](https://github.com/user-attachments/files/18314332/HTNew.Uninstall.Logs.250103.log)
<img width="1334" alt="Screenshot 2025-01-03 at 15 29 39" src="https://github.com/user-attachments/assets/359f4ab3-e320-4766-bf6b-36f932292856" />

Cluster with multiple server bundles:
[HTNew Uninstall Log 250104.log](https://github.com/user-attachments/files/18314335/HTNew.Uninstall.Log.250104.log)
<img width="1335" alt="Screenshot 2025-01-04 at 17 18 03" src="https://github.com/user-attachments/assets/f400e52c-baf4-4e0a-93f0-1898eb2bfe55" />
