### PR TITLE
[patch] Add missing api_version to k8s_info lookup

### DIFF
--- a/ibm/mas_devops/roles/cp4d/tasks/wait/wait-zenmetastore-edb.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/wait/wait-zenmetastore-edb.yml
@@ -3,6 +3,7 @@
 # -----------------------------------------------------------------------------
 - name: "wait-zenmetastore-edb : Wait for Zen Metastore EDB Cluster to be created"
   kubernetes.core.k8s_info:
+    api_version: postgresql.k8s.enterprisedb.io/v1
     kind: Cluster
     namespace: "{{ cpd_instance_namespace }}"
     name: "zen-metastore-edb"
@@ -17,6 +18,7 @@
   block:
     - name: "wait-zenmetastore-edb : Fetch the license expiry date"
       kubernetes.core.k8s_info:
+        api_version: postgresql.k8s.enterprisedb.io/v1
         kind: Cluster
         namespace: "{{ cpd_instance_namespace }}"
         name: "zen-metastore-edb"
@@ -80,6 +82,7 @@
 
     - name: "wait-zenmetastore-edb : Check and display the license expiry date"
       kubernetes.core.k8s_info:
+        api_version: postgresql.k8s.enterprisedb.io/v1
         kind: Cluster
         namespace: "{{ cpd_instance_namespace }}"
         name: "zen-metastore-edb"
@@ -100,6 +103,7 @@
 # -----------------------------------------------------------------------------
 - name: "wait-zenmetastore-edb : Wait for ZenMetastore pods to be become ready"
   kubernetes.core.k8s_info:
+    api_version: postgresql.k8s.enterprisedb.io/v1
     kind: Cluster
     namespace: "{{ cpd_instance_namespace }}"
     name: "zen-metastore-edb"


### PR DESCRIPTION
Fix description
----

Edited wait-zenmetastore-edb.yml to include the api version of the Postgres cluster

This is a minor fix to solve issue reported at https://github.com/ibm-mas/ansible-devops/issues/1612

Tested locally by editing the file and manually running cp4d role

```
TASK [ibm.mas_devops.cp4d : wait-zenmetastore-edb : Wait for ZenMetastore pods to be become ready] *****************************************************************************************************************
ok: [localhost] => changed=false 
  api_found: true
  attempts: 1
  resources:
  - apiVersion: postgresql.k8s.enterprisedb.io/v1
    kind: Cluster
    metadata:
...
      conditions:
      - lastTransitionTime: '2025-01-08T05:56:07Z'
        message: Cluster is Ready
        reason: ClusterIsReady
        status: 'True'
        type: Ready
      - lastTransitionTime: '2025-01-07T22:28:22Z'
        message: Continuous archiving is working
        reason: ContinuousArchivingSuccess
        status: 'True'
        type: ContinuousArchiving
      - lastTransitionTime: '2025-01-07T22:29:18Z'
        message: velero addon is disabled
        reason: Disabled
        status: 'False'
        type: k8s.enterprisedb.io/velero
      - lastTransitionTime: '2025-01-07T22:29:18Z'
        message: external-backup-adapter addon is disabled
        reason: Disabled
        status: 'False'
        type: k8s.enterprisedb.io/externalBackupAdapter
      - lastTransitionTime: '2025-01-07T22:29:18Z'
        message: external-backup-adapter-cluster addon is enabled
        reason: Enabled
        status: 'True'
        type: k8s.enterprisedb.io/externalBackupAdapterCluster
      - lastTransitionTime: '2025-01-07T22:29:18Z'
        message: kasten addon is disabled
        reason: Disabled
        status: 'False'
        type: k8s.enterprisedb.io/kasten
      configMapResourceVersion:
        metrics:
          postgresql-operator-default-monitoring: '157907541'
      currentPrimary: zen-metastore-edb-1
      currentPrimaryTimestamp: '2025-01-08T05:55:55.797353Z'
      healthyPVC:
      - zen-metastore-edb-1
      - zen-metastore-edb-2
      instanceNames:
      - zen-metastore-edb-1
      - zen-metastore-edb-2
      instances: 2
      instancesReportedState:
        zen-metastore-edb-1:
          isPrimary: true
          timeLineID: 3
        zen-metastore-edb-2:
          isPrimary: false
          timeLineID: 3
      instancesStatus:
        healthy:
        - zen-metastore-edb-1
        - zen-metastore-edb-2
      latestGeneratedNode: 2
      licenseStatus:
        issuer: IBM (on behalf of EDB)
        licenseExpiration: '2999-12-31T00:00:00Z'
        licenseStatus: Valid license (IBM - Data & Analytics (ibmda_cloudpak))
        repositoryAccess: false
        valid: true
      onlineUpdateEnabled: true
      phase: Cluster in healthy state
      poolerIntegrations:
        pgBouncerIntegration: {}
      pvcCount: 2
      readService: zen-metastore-edb-r
      readyInstances: 2
      secretsResourceVersion:
        applicationSecretVersion: '157907506'
        clientCaSecretVersion: '157883761'
        replicationSecretVersion: '157891469'
        serverCaSecretVersion: '157883761'
        serverSecretVersion: '157891395'
        superuserSecretVersion: '157907505'
      targetPrimary: zen-metastore-edb-1
      targetPrimaryTimestamp: '2025-01-08T05:53:31.865869Z'
      timelineID: 3
      topology:
        instances:
          zen-metastore-edb-1: {}
          zen-metastore-edb-2: {}
        nodesUsed: 2
        successfullyExtracted: true
      writeService: zen-metastore-edb-rw
```


CP4D role finished successfully:

```
TASK [ibm.mas_devops.cp4d : Debug : Cloud Pak for Data 5.0.0 details] **********************************************************************************************************************************************
ok: [localhost] => 
  msg:
  - CP4D Dashboard ......................... https://cpd-ibm-cpd.apps.xxxxxx.com
  - CP4D Admin Username .................... admin
  - CP4D Admin Password .................... Found in 'admin-user-details' secret under 'ibm-cpd' namespace

PLAY RECAP *********************************************************************************************************************************************************************************************************
localhost                  : ok=138  changed=11   unreachable=0    failed=0    skipped=33   rescued=0    ignored=0   
```