### PR TITLE
[patch] [MASCORE-5063] Problems with Restoring PV data - DT420492

### DIFF
--- a/ibm/mas_devops/common_tasks/backup_restore/check_backup_vars.yml
+++ b/ibm/mas_devops/common_tasks/backup_restore/check_backup_vars.yml
@@ -129,16 +129,16 @@
       when: masbr_backup_from_version is not defined or masbr_backup_from_version | length == 0
       include_tasks: "{{ role_path }}/../../common_tasks/backup_restore/list_storage_job_folders.yml"
       vars:
-        - masbr_ls_job_type: "backup"
-        - masbr_ls_filter: "| grep -P '^{{ masbr_job_name_prefix }}-full-.*(?<!Failed)$' | sort -r | head -1"
+        masbr_ls_job_type: "backup"
+        masbr_ls_filter: "| grep -P '^{{ masbr_job_name_prefix }}-full-.*(?<!Failed)$' | sort -r | head -1"
 
     # when 'masbr_backup_from_version' is specified
     - name: "Get the Full backup job name by specified masbr_backup_from_version"
       when: masbr_backup_from_version is defined and masbr_backup_from_version | length > 0
       include_tasks: "{{ role_path }}/../../common_tasks/backup_restore/list_storage_job_folders.yml"
       vars:
-        - masbr_ls_job_type: "backup"
-        - masbr_ls_filter: "| grep '^{{ masbr_job_name_prefix }}-full-{{ masbr_backup_from_version }}$' | sort -r | head -1"
+        masbr_ls_job_type: "backup"
+        masbr_ls_filter: "| grep '^{{ masbr_job_name_prefix }}-full-{{ masbr_backup_from_version }}$' | sort -r | head -1"
 
     - name: "Fail if not found any previous Full backup job"
       assert:

--- a/ibm/mas_devops/common_tasks/backup_restore/check_restore_vars.yml
+++ b/ibm/mas_devops/common_tasks/backup_restore/check_restore_vars.yml
@@ -92,8 +92,8 @@
 - name: "Find the restore-from job name"
   include_tasks: "{{ role_path }}/../../common_tasks/backup_restore/list_storage_job_folders.yml"
   vars:
-    - masbr_ls_job_type: "backup"
-    - masbr_ls_filter: "| grep '^{{ masbr_job_component.name }}-.*-{{ masbr_restore_from_version }}$'"
+    masbr_ls_job_type: "backup"
+    masbr_ls_filter: "| grep '^{{ masbr_job_component.name }}-.*-{{ masbr_restore_from_version }}$'"
 
 - name: "Fail if not found the restore-from job name"
   assert:
@@ -185,8 +185,8 @@
     - name: "Check the existence of the based on full backup job"
       include_tasks: "{{ role_path }}/../../common_tasks/backup_restore/list_storage_job_folders.yml"
       vars:
-        - masbr_ls_job_type: "backup"
-        - masbr_ls_filter: "| grep {{ masbr_restore_basedon }}"
+        masbr_ls_job_type: "backup"
+        masbr_ls_filter: "| grep {{ masbr_restore_basedon }}"
 
     - name: "Fail if not found the based on full backup job"
       assert:

--- a/ibm/mas_devops/common_tasks/backup_restore/copy_pod_files_to_storage.yml
+++ b/ibm/mas_devops/common_tasks/backup_restore/copy_pod_files_to_storage.yml
@@ -6,9 +6,15 @@
     masbr_storage_job_folder: >-
       {{ masbr_storage_local_folder }}/{{ masbr_cf_job_type }}s/{{ masbr_cf_job_name }}
 
-- name: "Debug: local storage job folder"
+- name: "Debug: All PV variables"
   debug:
-    msg: "Local storage job folder ......... {{ masbr_storage_job_folder }}"
+    msg:
+      - "Pod Name ................... {{ masbr_cf_pod_name }}"
+      - "Local storage job folder ......... {{ masbr_storage_job_folder }}"
+      - "Folder setup  .................... {{ masbr_cf_paths }}"
+      - "Source Folder .................... {{ item.src_folder }}"
+      - "Destination Folder ............... {{ [masbr_storage_job_folder, item.dest_folder] | path_join }}"
+  loop: "{{ masbr_cf_paths }}"
 
 # Condition 1. src_folder -> dest_folder: copy src_folder/* to dest_folder/*
 - name: "Copy files from pod folder to local storage folder"
@@ -30,7 +36,7 @@
   shell: >-
     mkdir -p {{ [masbr_storage_job_folder, item.dest_folder] | path_join }} &&
     oc cp --retries=50 -c {{ masbr_cf_container_name }}
-    {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:{{ item.src_file }}
+    {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:{{ [item.src_folder, item.src_file] | path_join }}
     {{ [masbr_storage_job_folder, item.dest_folder, item.src_file|basename] | path_join }}
   loop: "{{ masbr_cf_paths }}"
 
@@ -42,6 +48,6 @@
   shell: >-
     mkdir -p {{ [masbr_storage_job_folder, item.dest_file|dirname] | path_join }} &&
     oc cp --retries=50 -c {{ masbr_cf_container_name }}
-    {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:{{ item.src_file }}
+    {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:{{ [item.src_folder, item.src_file] | path_join }}
     {{ [masbr_storage_job_folder, item.dest_file] | path_join }}
   loop: "{{ masbr_cf_paths }}"

--- a/ibm/mas_devops/common_tasks/backup_restore/copy_storage_files_to_pod.yml
+++ b/ibm/mas_devops/common_tasks/backup_restore/copy_storage_files_to_pod.yml
@@ -8,32 +8,28 @@
     masbr_storage_job_folder: >-
       {{ masbr_storage_local_folder }}/{{ masbr_cf_job_type }}s/{{ masbr_cf_job_name }}
 
-# Local storage job folder
-- name: "Set fact: Define temp directory folder"
-  when:
-    - item.src_folder is defined and item.src_folder | length > 0
-    - item.dest_folder is defined and item.dest_folder | length > 0
-  set_fact:
-    temp_dest_folder: >-
-      {{ [item.dest_folder, masbr_job_version] | path_join }}
-
-- name: "Debug: local storage job folder"
+- name: "Debug: All PV variables"
   debug:
-    msg: "Local storage job folder .......... {{ masbr_storage_job_folder }}"
+    msg:
+      - "Local storage job folder ......... {{ masbr_storage_job_folder }}"
+      - "Folder setup  .................... {{ masbr_cf_paths }}"
+      - "Source Folder .................... {{ [masbr_storage_job_folder, item.src_folder] | path_join }}"
+      - "Destination Folder ............... {{ item.dest_folder }}"
+  loop: "{{ masbr_cf_paths }}"
 
 # Condition 1. src_folder -> dest_folder: copy src_folder/* to dest_folder/*
 #
 # - exec into masbr_cf_pod_name/masbr_cf_container_name, create temp folder
 # - cp from src_folder to temp folder inside masbr_cf_pod_name/masbr_cf_container_name
-# - exec into masbr_cf_pod_name/masbr_cf_container_name, move temp_dest_folder to dest_folder and delete temp_dest_folder
+# - exec into masbr_cf_pod_name/masbr_cf_container_name, move item.temp_dest_folder to dest_folder and delete temp_dest_folder
 - name: "Copy files from local storage folder to pod folder"
   when:
     - item.src_folder is defined and item.src_folder | length > 0
     - item.dest_folder is defined and item.dest_folder | length > 0
   shell: >-
-    oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'mkdir -p {{ temp_dest_folder }}' \
-    && oc cp --retries=50 -c {{ masbr_cf_container_name }} {{ [masbr_storage_job_folder, item.src_folder] | path_join }} {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:{{ temp_dest_folder }} \
-    && oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'mv -f {{ temp_dest_folder }}/* {{ item.dest_folder }} && rm -rf {{ temp_dest_folder }}'
+    oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'mkdir -p {{ [item.dest_folder, masbr_job_version] | path_join }}' \
+    && oc cp --retries=50 -c {{ masbr_cf_container_name }} {{ [masbr_storage_job_folder, item.src_folder] | path_join }} {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:{{ [item.dest_folder, masbr_job_version] | path_join }} \
+    && oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'mv -f {{ [item.dest_folder, masbr_job_version] | path_join }}/* {{ item.dest_folder }} && rm -rf {{ [item.dest_folder, masbr_job_version] | path_join }}'
   loop: "{{ masbr_cf_paths }}"
 
 # Condition 2. src_file -> dest_folder: copy src_file to dest_folder/src_file
@@ -43,18 +39,18 @@
     - item.dest_folder is defined and item.dest_folder | length > 0
   shell: >-
     oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'mkdir -p {{ item.dest_folder }}' \
-    && oc cp --retries=50 -c {{ masbr_cf_container_name }} {{ [masbr_storage_job_folder, item.src_file] | path_join }} {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:{{ item.dest_folder }}
+    && oc cp --retries=50 -c {{ masbr_cf_container_name }} {{ [masbr_storage_job_folder, item.src_folder, item.src_file] | path_join }} {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:{{ item.dest_folder }}
   loop: "{{ masbr_cf_paths }}"
 
 # Condition 3. src_file -> dest_file
 # - exec into masbr_cf_pod_name/masbr_cf_container_name, create temp folder
 # - cp from src_folder to temp folder inside masbr_cf_pod_name/masbr_cf_container_name
-# - exec into masbr_cf_pod_name/masbr_cf_container_name, move temp_dest_folder to dest_folder and delete temp_dest_folder
+# - exec into masbr_cf_pod_name/masbr_cf_container_name, move temp_dest_folder to item.dest_folder and delete temp_dest_folder
 - name: "Copy file from local storage folder to pod file"
   when:
     - item.src_file is defined and item.src_file | length > 0
-    - item.dest_file is defined and item.dest_file | length > 0
+    - item.dest_folder is defined and item.dest_folder | length > 0
   shell: >-
-    oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'mkdir -p {{ temp_dest_folder }}' \
-    && oc cp --retries=50 -c {{ masbr_cf_container_name }} {{ [masbr_storage_job_folder, item.src_file] | path_join }} {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:{{ temp_dest_folder }} \
-    && oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'mv -f {{ temp_dest_folder }}/{{ item.src_file|basename }} {{ item.dest_file }} && rm -rf {{ temp_dest_folder }}'
+    oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'mkdir -p {{ [item.dest_folder, masbr_job_version] | path_join }}' \
+    && oc cp --retries=50 -c {{ masbr_cf_container_name }} {{ [temp_src_folder, item.src_file] | path_join }} {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:{{ [item.dest_folder, masbr_job_version] | path_join }} \
+    && oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'mv -f {{ [item.dest_folder, masbr_job_version] | path_join }}/{{ item.src_file|basename }} {{ item.dest_folder }} && rm -rf {{ [item.dest_folder, masbr_job_version] | path_join }}'

--- a/ibm/mas_devops/common_tasks/backup_restore/copy_storage_files_to_pod.yml
+++ b/ibm/mas_devops/common_tasks/backup_restore/copy_storage_files_to_pod.yml
@@ -28,7 +28,7 @@
     - item.dest_folder is defined and item.dest_folder | length > 0
   shell: >-
     oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'mkdir -p {{ [item.dest_folder, masbr_job_version] | path_join }}' \
-    && oc cp --retries=50 -c {{ masbr_cf_container_name }} {{ [masbr_storage_job_folder, item.src_folder] | path_join }} {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:{{ [item.dest_folder, masbr_job_version] | path_join }} \
+    && oc cp --retries=50 -c {{ masbr_cf_container_name }} {{ [masbr_storage_job_folder, item.src_folder] | path_join }}/* {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:{{ [item.dest_folder, masbr_job_version] | path_join }} \
     && oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'mv -f {{ [item.dest_folder, masbr_job_version] | path_join }}/* {{ item.dest_folder }} && rm -rf {{ [item.dest_folder, masbr_job_version] | path_join }}'
   loop: "{{ masbr_cf_paths }}"
 

--- a/ibm/mas_devops/common_tasks/backup_restore/copy_storage_files_to_pod.yml
+++ b/ibm/mas_devops/common_tasks/backup_restore/copy_storage_files_to_pod.yml
@@ -8,6 +8,15 @@
     masbr_storage_job_folder: >-
       {{ masbr_storage_local_folder }}/{{ masbr_cf_job_type }}s/{{ masbr_cf_job_name }}
 
+# Local storage job folder
+- name: "Set fact: Define temp directory folder"
+  when:
+    - item.src_folder is defined and item.src_folder | length > 0
+    - item.dest_folder is defined and item.dest_folder | length > 0
+  set_fact:
+    temp_dest_folder: >-
+      {{ [item.dest_folder, masbr_job_version] | path_join }}
+
 - name: "Debug: local storage job folder"
   debug:
     msg: "Local storage job folder .......... {{ masbr_storage_job_folder }}"
@@ -22,9 +31,9 @@
     - item.src_folder is defined and item.src_folder | length > 0
     - item.dest_folder is defined and item.dest_folder | length > 0
   shell: >-
-    oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'temp_dest_folder={{ [item.dest_folder, masbr_job_version] | path_join }} && mkdir -p ${temp_dest_folder}' \
-    && oc cp --retries=50 -c {{ masbr_cf_container_name }} {{ [masbr_storage_job_folder, item.src_folder] | path_join }} {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:${temp_dest_folder} \
-    && oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'mv -f ${temp_dest_folder}/* {{ item.dest_folder }} && rm -rf ${temp_dest_folder}'
+    oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'mkdir -p {{ temp_dest_folder }}' \
+    && oc cp --retries=50 -c {{ masbr_cf_container_name }} {{ [masbr_storage_job_folder, item.src_folder] | path_join }} {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:{{ temp_dest_folder }} \
+    && oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'mv -f {{ temp_dest_folder }}/* {{ item.dest_folder }} && rm -rf {{ temp_dest_folder }}'
   loop: "{{ masbr_cf_paths }}"
 
 # Condition 2. src_file -> dest_folder: copy src_file to dest_folder/src_file
@@ -46,6 +55,6 @@
     - item.src_file is defined and item.src_file | length > 0
     - item.dest_file is defined and item.dest_file | length > 0
   shell: >-
-    oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'temp_dest_folder={{ [item.dest_file|dirname, masbr_job_version] | path_join }} && mkdir -p ${temp_dest_folder}' \
-    && oc cp --retries=50 -c {{ masbr_cf_container_name }} {{ [masbr_storage_job_folder, item.src_file] | path_join }} {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:${temp_dest_folder} \
-    && oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'mv -f ${temp_dest_folder}/{{ item.src_file|basename }} {{ item.dest_file }} && rm -rf ${temp_dest_folder}'
+    oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'mkdir -p {{ temp_dest_folder }}' \
+    && oc cp --retries=50 -c {{ masbr_cf_container_name }} {{ [masbr_storage_job_folder, item.src_file] | path_join }} {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:{{ temp_dest_folder }} \
+    && oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'mv -f {{ temp_dest_folder }}/{{ item.src_file|basename }} {{ item.dest_file }} && rm -rf {{ temp_dest_folder }}'

--- a/ibm/mas_devops/common_tasks/templates/backup_restore/backup-namespace-resources.sh.j2
+++ b/ibm/mas_devops/common_tasks/templates/backup_restore/backup-namespace-resources.sh.j2
@@ -47,6 +47,13 @@ function backupResources {
     done
 }
 
+if command -v yq &> /dev/null; then
+    echo "yq is installed, continuing"
+else
+    echo "yq not found! please install yq before performing a backup"
+    exit 1
+fi
+
 
 {% if masbr_ns_backup_resources is defined and masbr_ns_backup_resources | length > 0 %}
 {% for ns_resources in masbr_ns_backup_resources %}

--- a/ibm/mas_devops/roles/suite_app_backup_restore/tasks/restore-pv.yml
+++ b/ibm/mas_devops/roles/suite_app_backup_restore/tasks/restore-pv.yml
@@ -36,7 +36,7 @@
         phase: "Completed"
 
 
-- name: "Restoe pv data"
+- name: "Restore pv data"
   when: mas_app_pv_list | length > 0
   block:
     # Copy pv data from specified storage location


### PR DESCRIPTION
Sorry for the misleading branch title, the issue was originally assigned under SLS before I realized it was a manage specific issue for backup and restoring pod files. 

Steps to test this were as follows

Run the back up using these commands:

```
export MASBR_ACTION=backup
export MASBR_MANAGE_PVC_PATHS="manage-doclinks:/DOCLINKS"
export MASBR_STORAGE_LOCAL_FOLDER=/tmp/backup
export ROLE_NAME="suite_app_backup_restore"
export MAS_WORKSPACE_ID=masdev
rm -rf /tmp/backup
mkdir -p /tmp/backup
ansible-playbook ibm.mas_devops.run_role
```

Backup complete successfully:

Specific task we want to see succeed
```
TASK [ibm.mas_devops.suite_app_backup_restore : Copy files from pod folder to local storage folder] **************
changed: [localhost] => (item={'src_folder': '/DOCLINKS', 'dest_folder': 'pv/manage-doclinks/DOCLINKS'})
```

```
TASK [ibm.mas_devops.suite_app_backup_restore : Summary] *********************************************************
ok: [localhost] => {
    "msg": [
        "Job name ........................... manage-fvt15045-full-20250110151631",
        "Job status ......................... Completed",
        "Job storage location ............... /tmp/backup/backups/manage-fvt15045-full-20250110151631"
    ]
}
```

DOCLINKS folder output locally:

```
ls /tmp/backup/backups/manage-fvt15045-full-20250110151631/pv/manage-doclinks/DOCLINKS
test.txt
```

After I performed the restore using the following commands:

```
export MASBR_ACTION=restore
export MASBR_MANAGE_PVC_PATHS="manage-doclinks:/DOCLINKS"
export MASBR_RESTORE_FROM_VERSION=20250110151631
export MASBR_STORAGE_LOCAL_FOLDER=/tmp/backup
export ROLE_NAME="suite_app_backup_restore"
export MAS_WORKSPACE_ID=masdev
ansible-playbook ibm.mas_devops.run_role
```


Restore completed successfully:

Specific task we wanted to see:
```
TASK [ibm.mas_devops.suite_app_backup_restore : Copy files from local storage folder to pod folder] **************
changed: [localhost] => (item={'src_folder': 'pv/manage-doclinks/DOCLINKS', 'dest_folder': '/DOCLINKS'})

TASK [ibm.mas_devops.suite_app_backup_restore : Summary] *********************************************************
ok: [localhost] => {
    "msg": [
        "Job name ........................... manage-fvt15045-full-20250110151631-20250110151732",
        "Job status ......................... Completed",
        "Job storage location ............... /tmp/backup/restores/manage-fvt15045-full-20250110151631-20250110151732"
    ]
}
```

How the DOCLINKS folder looks inside the pod

```
oc exec -ti fvt15045-masdev-manage-maxinst-85cb69ff48-vk6gx bash
bash-4.4$ cd /DOCLINKS/
bash-4.4$ ls
test.txt
```


