### PR TITLE
[patch] Adds wait timer in app compatibility check for upgrade

### DIFF
--- a/ibm/mas_devops/roles/suite_app_upgrade/tasks/check_app_compatibility.yml
+++ b/ibm/mas_devops/roles/suite_app_upgrade/tasks/check_app_compatibility.yml
@@ -161,8 +161,17 @@
   debug:
     var: app_ws_cr_lookup
 
-- name: "{{ mas_app_id }} : Check that the Application Workspace CRs are in a healthy state"
-  assert:
-    that:
-      - app_ws_cr_lookup.resources is defined
-      - app_ws_cr_lookup.resources | json_query('[*].status.conditions[?type==`Ready`][].reason') | select ('in', ['Ready', 'WorkspaceReady']) | list | length == app_ws_cr_lookup.resources | length
+- name: '{{ mas_app_id }} : Check that the Application Workspace CRs are in a healthy state'
+  kubernetes.core.k8s_info:
+    api_version: "{{ app_info[mas_app_id].api_version }}"
+    kind: "{{ app_info[mas_app_id].ws_kind }}"
+    namespace: "{{ mas_app_namespace }}"
+    label_selectors:
+      - mas.ibm.com/instanceId={{ mas_instance_id }}
+      - mas.ibm.com/applicationId={{ mas_app_id }}
+  retries: 20 # about 40 minutes
+  delay: 120 # 2 minutes
+  until:
+    - app_ws_cr_lookup.resources is defined
+    - app_ws_cr_lookup.resources | json_query('[*].status.conditions[?type==`Ready`][].reason') | select ('in', ['Ready', 'WorkspaceReady']) | list | length == app_ws_cr_lookup.resources | length
+  register: app_ws_cr_lookup


### PR DESCRIPTION
### Description:
Replaces assert condition's 1 time check with a wait condition to check for ready state in compatibility check for upgrade. The current wait timer is set to 40 mins (2 mins delay) same as how the check is after the upgrade.

### Related Links:
MASCORE-5257

### Testing:
Tested in a quickburn.
[HTNew Upgrade Logs 250128 0905.log](https://github.com/user-attachments/files/18571924/HTNew.Upgrade.Logs.250128.0905.log)

<img width="1430" alt="Screenshot 2025-01-28 at 15 34 09" src="https://github.com/user-attachments/assets/2d0c87a2-d4fa-4a77-9ccd-1f477c358f95" />
