### PR TITLE
[patch] set ibm.cloudcollection max version to 1.51.0

### DIFF
--- a/ibm/mas_devops/galaxy.yml
+++ b/ibm/mas_devops/galaxy.yml
@@ -21,7 +21,7 @@ tags:
   - rhocp
 dependencies:
   "kubernetes.core": ">=2.4.0,<3.0.0"
-  "ibm.cloudcollection": ">=1.37.1,<2.0.0"
+  "ibm.cloudcollection": ">=1.37.1,<=1.51.0"
   "ansible.utils": ">=2.11.0"
   "community.general": ">=9.5.0"
 repository: https://github.com/ibm-mas/ansible-devops


### PR DESCRIPTION
cos_bucket role is failing due to the latest version of ibm.cloudcollection version (1.71.2). Hence, setting the max version to 1.51.0 until ansible-devops is ready to adopt 1.71.2 version. 

Bug reference: MASCORE-5436

Tested the fix using cli:

<img width="1124" alt="image" src="https://github.com/user-attachments/assets/6523ab5d-c335-4a5a-951c-e08a3f0654d0" />
<img width="784" alt="image" src="https://github.com/user-attachments/assets/5bbbc452-74c5-4542-a499-58e515351074" />
