### PR TITLE
[patch] Make registry_public_url optional in mirror_ocp

### DIFF
--- a/ibm/mas_devops/roles/mirror_ocp/tasks/main.yml
+++ b/ibm/mas_devops/roles/mirror_ocp/tasks/main.yml
@@ -51,14 +51,25 @@
 # 4. Generate new docker config
 # -----------------------------------------------------------------------------
 - name: Generate Docker config
-  no_log: true # Output contains credentials for all docker registries
-  command: >
-    jq ".auths[\"{{ registry_public_url }}\"]={\"auth\":\"{{ registry_auth | b64encode }}\"}" "{{ redhat_pullsecret }}"
-  register: new_pull_secret
+  when:
+    - registry_public_url is defined
+    - registry_public_url != ""
+  block:
+    - name: Combine Docker config
+      no_log: true # Output contains credentials for all docker registries
+      command: >
+        jq ".auths[\"{{ registry_public_url }}\"]={\"auth\":\"{{ registry_auth | b64encode }}\"}" "{{ redhat_pullsecret }}"
+      register: new_pull_secret
 
-- name: Write Docker config to file
+    - name: Write Docker config to file
+      copy:
+        content: "{{ new_pull_secret.stdout }}"
+        dest: "{{ mirror_working_dir }}/config.json"
+
+- name: Copy Docker config
+  when: (registry_public_url is not defined) or (registry_public_url is defined and registry_public_url == "")
   copy:
-    content: "{{ new_pull_secret.stdout }}"
+    src: "{{ redhat_pullsecret }}"
     dest: "{{ mirror_working_dir }}/config.json"
 
 # 5. Mirror Release


### PR DESCRIPTION
## Description

- We will only generate the docker config and combine if registry_public_url is provided otherwise we move the redhat_pullsecret file directly into .../config.json

## Related issues

- https://github.com/ibm-mas/ansible-devops/issues/1635

## Testing

- I tested the relevant piece of code locally