### PR TITLE
[patch] used asterisk where . should be

### DIFF
--- a/ibm/mas_devops/common_tasks/backup_restore/copy_storage_files_to_pod.yml
+++ b/ibm/mas_devops/common_tasks/backup_restore/copy_storage_files_to_pod.yml
@@ -28,7 +28,7 @@
     - item.dest_folder is defined and item.dest_folder | length > 0
   shell: >-
     oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'mkdir -p {{ [item.dest_folder, masbr_job_version] | path_join }}' \
-    && oc cp --retries=50 -c {{ masbr_cf_container_name }} {{ [masbr_storage_job_folder, item.src_folder] | path_join }}/* {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:{{ [item.dest_folder, masbr_job_version] | path_join }} \
+    && oc cp --retries=50 -c {{ masbr_cf_container_name }} {{ [masbr_storage_job_folder, item.src_folder] | path_join }}/. {{ masbr_cf_namespace }}/{{ masbr_cf_pod_name }}:{{ [item.dest_folder, masbr_job_version] | path_join }} \
     && oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'mv -f {{ [item.dest_folder, masbr_job_version] | path_join }}/* {{ item.dest_folder }} && rm -rf {{ [item.dest_folder, masbr_job_version] | path_join }}'
   loop: "{{ masbr_cf_paths }}"
 


### PR DESCRIPTION
When fixing the backup, I managed to let an untested change get through causing it to fail. I must've not saved my final change when committing.