### PR TITLE
[patch] set DocumentDB to version 5.0.0

### DIFF
--- a/ibm/mas_devops/roles/mongodb/README.md
+++ b/ibm/mas_devops/roles/mongodb/README.md
@@ -379,10 +379,10 @@ DocumentDB Admin Credentials Secret Name
 - Value: `{{ docdb_cluster_name }}-admin-credentials`
 
 ### docdb_engine_version
-DocumentDB Engine version
+DocumentDB Engine version. Only version 5.0.0 is supported by Maximo Application Suite.
 
 - Environment variable: `DOCDB_ENGINE_VERSION`
-- Default Value: `4.0.0`
+- Default Value: `5.0.0`
 
 ### docdb_master_username
 DocumentDB master username

--- a/ibm/mas_devops/roles/mongodb/defaults/main.yml
+++ b/ibm/mas_devops/roles/mongodb/defaults/main.yml
@@ -64,7 +64,7 @@ docdb_instance_identifier_prefix: "{{ lookup('env', 'DOCDB_INSTANCE_IDENTIFIER_P
 docdb_instance_number: "{{ lookup('env', 'DOCDB_INSTANCE_NUMBER') | default(3, True) }}"
 docdb_instance_class: "{{ lookup('env', 'DOCDB_INSTANCE_CLASS') | default('db.t3.medium', True) }}"
 docdb_master_username: "{{ lookup('env', 'DOCDB_MASTER_USERNAME') | default('docdbadmin', True) }}" # refere other dbs admin usernames <mas-instance-id>-admin
-docdb_engine_version: "{{ lookup('env', 'DOCDB_ENGINE_VERSION') | default('4.0.0', True) }}"
+docdb_engine_version: "{{ lookup('env', 'DOCDB_ENGINE_VERSION') | default('5.0.0', True) }}"
 
 # cidr for subnets in 3 different availabilty zones
 docdb_cidr_az1: "{{ lookup('env', 'DOCDB_CIDR_AZ1') }}"


### PR DESCRIPTION
## Use DocumentDB 5.0.0 as the default

Maximo Application Suite only supported DocumentDB 5.0.0. This should be the default for any provisioning of DocumentDB instances. Also, any references to DocumentDB in documentation should make it clear that only DocumentDB 5.0.0 is supported. 