### PR TITLE
[patch] Update Ansible dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 build:
 	ansible-galaxy collection build --output-path . ibm/mas_devops --force
 install:
-	ansible-galaxy collection install ibm-mas_devops-100.0.0.tar.gz --force --no-deps
+	ansible-galaxy collection install ibm-mas_devops-100.0.0.tar.gz --force
 clean:
 	rm -f ibm-mas_devops-100.0.0.tar.gz
 	rm -f ibm/mas_devops/ibm-mas_devops-100.0.0.tar.gz

--- a/ibm/mas_devops/galaxy.yml
+++ b/ibm/mas_devops/galaxy.yml
@@ -20,10 +20,11 @@ tags:
   - mas
   - rhocp
 dependencies:
-  "kubernetes.core": ">=2.4.0,<3.0.0"
+  "kubernetes.core": ">=5.1.0"
+  # 1.71.2 introduced breaking changes
   "ibm.cloudcollection": ">=1.37.1,<=1.51.0"
-  "ansible.utils": ">=2.11.0"
-  "community.general": ">=9.5.0"
+  "ansible.utils": ">=5.1.2"
+  "community.general": ">=10.3.0"
 repository: https://github.com/ibm-mas/ansible-devops
 documentation: https://ibm-mas.github.io/ansible-devops/
 homepage: https://ibm-mas.github.io/ansible-devops/

--- a/ibm/mas_devops/plugins/action/apply_subscription.py
+++ b/ibm/mas_devops/plugins/action/apply_subscription.py
@@ -2,7 +2,7 @@
 
 import logging
 import urllib3
-from ansible_collections.kubernetes.core.plugins.module_utils.common import get_api_client
+from ansible_collections.kubernetes.core.plugins.module_utils.k8s.client import get_api_client
 from ansible.errors import AnsibleError
 from ansible.plugins.action import ActionBase
 

--- a/ibm/mas_devops/plugins/action/get_default_storage_classes.py
+++ b/ibm/mas_devops/plugins/action/get_default_storage_classes.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import urllib3
-from ansible_collections.kubernetes.core.plugins.module_utils.common import get_api_client
+from ansible_collections.kubernetes.core.plugins.module_utils.k8s.client import get_api_client
 from ansible.plugins.action import ActionBase
 
 from mas.devops.mas import getDefaultStorageClasses

--- a/ibm/mas_devops/plugins/action/update_ibm_entitlement.py
+++ b/ibm/mas_devops/plugins/action/update_ibm_entitlement.py
@@ -2,7 +2,7 @@
 
 import logging
 import urllib3
-from ansible_collections.kubernetes.core.plugins.module_utils.common import get_api_client
+from ansible_collections.kubernetes.core.plugins.module_utils.k8s.client import get_api_client
 from ansible.errors import AnsibleError
 from ansible.plugins.action import ActionBase
 

--- a/ibm/mas_devops/plugins/action/verify_app_version.py
+++ b/ibm/mas_devops/plugins/action/verify_app_version.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from ansible_collections.kubernetes.core.plugins.module_utils.common import get_api_client
+from ansible_collections.kubernetes.core.plugins.module_utils.k8s.client import get_api_client
 
 from ansible.plugins.action import ActionBase
 from ansible.errors import AnsibleError

--- a/ibm/mas_devops/plugins/action/verify_catalogsources.py
+++ b/ibm/mas_devops/plugins/action/verify_catalogsources.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from ansible_collections.kubernetes.core.plugins.module_utils.common import get_api_client
+from ansible_collections.kubernetes.core.plugins.module_utils.k8s.client import get_api_client
 
 from ansible.plugins.action import ActionBase
 from ansible.errors import AnsibleError

--- a/ibm/mas_devops/plugins/action/verify_core_version.py
+++ b/ibm/mas_devops/plugins/action/verify_core_version.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from ansible_collections.kubernetes.core.plugins.module_utils.common import get_api_client
+from ansible_collections.kubernetes.core.plugins.module_utils.k8s.client import get_api_client
 
 from ansible.plugins.action import ActionBase
 from ansible.errors import AnsibleError
@@ -21,7 +21,7 @@ class ActionModule(ActionBase):
         delay = self._task.args['delay']
 
         display.v(f"Checking core version is matching ({retries} retries with a {delay} second delay)")
-        
+
         masSuites = dynaClient.resources.get(api_version="core.mas.ibm.com/v1", kind='Suite')
         versionMatching = False
         version = ""

--- a/ibm/mas_devops/plugins/action/verify_subscriptions.py
+++ b/ibm/mas_devops/plugins/action/verify_subscriptions.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from ansible_collections.kubernetes.core.plugins.module_utils.common import get_api_client
+from ansible_collections.kubernetes.core.plugins.module_utils.k8s.client import get_api_client
 
 from ansible.plugins.action import ActionBase
 from ansible.errors import AnsibleError

--- a/ibm/mas_devops/plugins/action/verify_workloads.py
+++ b/ibm/mas_devops/plugins/action/verify_workloads.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from ansible_collections.kubernetes.core.plugins.module_utils.common import get_api_client
+from ansible_collections.kubernetes.core.plugins.module_utils.k8s.client import get_api_client
 
 from ansible.plugins.action import ActionBase
 from ansible.errors import AnsibleError
@@ -100,6 +100,6 @@ class ActionModule(ActionBase):
           )
         else:
           display.v(f"Failure: allResourcesHealthy={allResourcesHealthy}")
-          
+
           notReadyMsg = ', '.join(notReadyResources)
           raise AnsibleError(f"Error: These {resourceName} are not healthy: {notReadyMsg}")


### PR DESCRIPTION
It's been pointed out to me that the Ansible dependencies in this project have not been being maintained, this update brings our dependency stack up to date, with the exception of `ibm.cloudcollection` which we know there is a breaking change in the newest version: https://github.com/ibm-mas/ansible-devops/pull/1634

- Update kubernetes.core to `>=5.1.0`
- Update ansible.utils to `>= 5.1.2`
- Update community.general to `>=10.3.0`
