### PR TITLE
[patch] add option to overwrite on restore

### DIFF
--- a/docs/playbooks/backup-restore.md
+++ b/docs/playbooks/backup-restore.md
@@ -66,6 +66,7 @@ Configuration - Restore
 | ------------------------------------ | ------------------------ | ----------- |
 | MASBR_ACTION                         | **Yes**                  | Whether to run the playbook to perform a `backup` or a `restore` |
 | MASBR_RESTORE_FROM_VERSION           | **Yes**                  | Set the backup version to use in the restore, this will be in the format of a `YYYMMDDHHMMSS` timestamp (e.g. `20240621021316`) |
+| MASBR_RESTORE_OVERWRITE              | **Yes**                  | Set whether the restore should **overwrite** any existing data or if we should stop and **FAIL** if there is data detected in the directory. **WARNING:** This will overwrite all data when restoring! |
 
 The playbooks are switched to restore mode by setting `MASBR_ACTION` to `restore`. You **must** specify the `MASBR_RESTORE_FROM_VERSION` environment variable to indicate which version of the backup files to use.
 

--- a/ibm/mas_devops/common_tasks/backup_restore/check_restore_vars.yml
+++ b/ibm/mas_devops/common_tasks/backup_restore/check_restore_vars.yml
@@ -18,6 +18,7 @@
     # The information of the backup to be restored from
     # <Required>
     masbr_restore_from_version: "{{ lookup('env', 'MASBR_RESTORE_FROM_VERSION') }}"
+    masbr_restore_overwrite: "{{ lookup('env', 'MASBR_RESTORE_OVERWRITE') }}"
 
     # Data type string separated by commas: e.g.'namespace,pv'
     masbr_restore_data: "{{ lookup('env', 'MASBR_RESTORE_DATA') | default('', true) }}"
@@ -30,6 +31,11 @@
   assert:
     that: masbr_restore_from_version is defined and masbr_restore_from_version != ""
     fail_msg: "masbr_restore_from_version is required for running restore job"
+
+- name: "Fail if masbr_restore_overwrite is not provided"
+  assert:
+    that: masbr_restore_overwrite is defined and masbr_restore_overwrite != ""
+    fail_msg: "masbr_restore_overwrite is required for running restore job"
 
 # Check 'masbr_job_component'
 # -----------------------------------------------------------------------------
@@ -194,6 +200,7 @@
     msg:
       - "Restore job name ....................... {{ masbr_job_name }}"
       - "Restore from ........................... {{ masbr_restore_from }}"
+      - "Restore overwrite existing data ........ {{ masbr_restore_overwrite }}"
       - "Restore component ...................... {{ masbr_job_component }}"
       - "Restore data ........................... {{ masbr_job_data_list }}"
       - "Restore from incremental backup ........ {{ masbr_restore_from_incr }}"

--- a/ibm/mas_devops/common_tasks/backup_restore/copy_storage_files_to_pod.yml
+++ b/ibm/mas_devops/common_tasks/backup_restore/copy_storage_files_to_pod.yml
@@ -12,10 +12,21 @@
   debug:
     msg:
       - "Local storage job folder ......... {{ masbr_storage_job_folder }}"
+      - "Overwrite existing data .......... {{ masbr_restore_overwrite }}"
       - "Folder setup  .................... {{ masbr_cf_paths }}"
       - "Source Folder .................... {{ [masbr_storage_job_folder, item.src_folder] | path_join }}"
       - "Destination Folder ............... {{ item.dest_folder }}"
   loop: "{{ masbr_cf_paths }}"
+
+- name: "Erase all existing data found in destination folders"
+  when:
+    - item.src_folder is defined and item.src_folder | length > 0
+    - item.dest_folder is defined and item.dest_folder | length > 0
+    - masbr_restore_overwrite is defined and masbr_restore_overwrite
+  shell: >-
+    oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'rm -rf {{ item.dest_folder }}/*'
+  loop: "{{ masbr_cf_paths }}"
+
 
 # Condition 1. src_folder -> dest_folder: copy src_folder/* to dest_folder/*
 #

--- a/ibm/mas_devops/common_tasks/backup_restore/copy_storage_files_to_pod.yml
+++ b/ibm/mas_devops/common_tasks/backup_restore/copy_storage_files_to_pod.yml
@@ -27,6 +27,15 @@
     oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c 'rm -rf {{ item.dest_folder }}/*'
   loop: "{{ masbr_cf_paths }}"
 
+- name: "Detect if there is any data in destination folders"
+  when:
+    - item.src_folder is defined and item.src_folder | length > 0
+    - item.dest_folder is defined and item.dest_folder | length > 0
+    - masbr_restore_overwrite is defined and masbr_restore_overwrite == False
+  shell: >-
+    oc exec {{ masbr_cf_pod_name }} -c {{ masbr_cf_container_name }} -n {{ masbr_cf_namespace }} -- bash -c '[ "$(ls -A {{ item.dest_folder }})" ] && { echo "{{ item.dest_folder }} is not empty!" && exit 1; } || echo "{{ item.dest_folder }} is empty!";'
+  loop: "{{ masbr_cf_paths }}"
+
 
 # Condition 1. src_folder -> dest_folder: copy src_folder/* to dest_folder/*
 #


### PR DESCRIPTION
Customer has requested that we offer the choice to overwrite data when restoring instead of just failing if there is existing data in the directory. This adds a new required environment variable that asks the customer to confirm if they want to overwrite data or fail if we detect any. 

User will be shown this error if they use false and there are directories that have existing data
```
TASK [ibm.mas_devops.suite_app_backup_restore : Detect if there is any data in destination folders] ***
failed: [localhost] (item={'src_folder': 'pv/manage-doclinks/DOCLINKS', 'dest_folder': '/DOCLINKS'}) => {"ansible_loop_var": "item", "changed": true, "cmd": "oc exec fvt28830-masdev-manage-maxinst-557b754965-f49lm -c manage-maxinst-maxinst -n mas-fvt28830-manage -- bash -c '[ \"$(ls -A /DOCLINKS)\" ] && { echo \"/DOCLINKS is not empty!\" && exit 1; } || echo \"/DOCLINKS is empty!\";'", "delta": "0:00:01.225267", "end": "2025-02-10 11:32:20.261525", "item": {"dest_folder": "/DOCLINKS", "src_folder": "pv/manage-doclinks/DOCLINKS"}, "msg": "non-zero return code", "rc": 1, "start": "2025-02-10 11:32:19.036258", "stderr": "command terminated with exit code 1", "stderr_lines": ["command terminated with exit code 1"], "stdout": "/DOCLINKS is not empty!", "stdout_lines": ["/DOCLINKS is not empty!"]}
```

A successful restore will show this if the directories are empty and and overwrite was set to false
```
TASK [ibm.mas_devops.suite_app_backup_restore : Detect if there is any data in destination folders] ***
changed: [localhost] => (item={'src_folder': 'pv/manage-doclinks/DOCLINKS', 'dest_folder': '/DOCLINKS'})

TASK [ibm.mas_devops.suite_app_backup_restore : Copy files from local storage folder to pod folder] ***
changed: [localhost] => (item={'src_folder': 'pv/manage-doclinks/DOCLINKS', 'dest_folder': '/DOCLINKS'})
```


For the true paths it should look like this if there is data in the directory
```
TASK [ibm.mas_devops.suite_app_backup_restore : Erase all existing data found in destination folders] ***
changed: [localhost] => (item={'src_folder': 'pv/manage-doclinks/DOCLINKS', 'dest_folder': '/DOCLINKS'})

TASK [ibm.mas_devops.suite_app_backup_restore : Detect if there is any data in destination folders] ***
skipping: [localhost] => (item={'src_folder': 'pv/manage-doclinks/DOCLINKS', 'dest_folder': '/DOCLINKS'}) 
skipping: [localhost]

TASK [ibm.mas_devops.suite_app_backup_restore : Copy files from local storage folder to pod folder] ***
changed: [localhost] => (item={'src_folder': 'pv/manage-doclinks/DOCLINKS', 'dest_folder': '/DOCLINKS'})
```


