### PR TITLE
[patch] setting default kafka version for redhat amq-streams to 3.8.0

### DIFF
--- a/ibm/mas_devops/roles/kafka/defaults/main.yaml
+++ b/ibm/mas_devops/roles/kafka/defaults/main.yaml
@@ -11,7 +11,7 @@ kafka_defaults:
     operator_name: "strimzi-kafka-operator"
     alias_name: "Strimzi"
   redhat:
-    version: "3.9.0"
+    version: "3.8.0"
     namespace: "amq-streams"
     operator_name: "amq-streams"
     alias_name: "Red Hat AMQ Streams"


### PR DESCRIPTION
3.9.0 is not yet supported by amq-streams

The amq-streams-cluster-operator-v2.8.0-0-844df77dc5-8rtjz_strimzi-cluster-operator is reporting this error:

```
2025-02-10 19:39:39 WARN  AbstractOperator:556 - Reconciliation #223(timer) Kafka(kafka/maskafka): Failed to reconcile
io.strimzi.operator.cluster.model.KafkaVersion$UnsupportedKafkaVersionException: Unsupported Kafka.spec.kafka.version: 3.9.0. Supported versions are: [3.7.0, 3.8.0]
```