### PR TITLE
[patch] Increase wait time for application readiness check before wor…

### DIFF
--- a/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
@@ -94,7 +94,7 @@
     - app_cr_result.resources is defined
     - app_cr_result.resources | length > 0
     - app_cr_result.resources | json_query('[*].status.conditions[?type==`Ready`][].status') | select('match', 'True') | list | length == 1
-  failed_when: app_cr_result.failed
+  
 
 - name: "Check that the application is ready to configure a workspace"
   assert:

--- a/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
@@ -94,7 +94,7 @@
     - app_cr_result.resources is defined
     - app_cr_result.resources | length > 0
     - app_cr_result.resources | json_query('[*].status.conditions[?type==`Ready`][].status') | select('match', 'True') | list | length == 1
-  failed_when: app_cr_result is failed
+  failed_when: app_cr_result.failed
 
 - name: "Check that the application is ready to configure a workspace"
   assert:

--- a/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
@@ -81,23 +81,23 @@
 #
 # If the application is not in ready state we can fail fast rather than waiting
 # for the workspace to be Ready -- because it never will!
-- name: "Lookup application information"
-  kubernetes.core.k8s_info:
-    api_version: "{{ mas_app_api_version }}"
-    name: "{{ mas_instance_id }}"
-    namespace: "{{ mas_app_namespace }}"
-    kind: "{{ mas_app_kind }}"
-  register: app_cr_result
-
 - name: "Wait for application to be Ready before configuring workspace"
-  retries: 15  # Adjust retries as needed
+  retries: 15  # Number of retries before failing
   delay: 20    # Wait 20 seconds between retries
-  until:
-    - app_cr_result.resources is defined
-    - app_cr_result.resources | length > 0
-    - app_cr_result.resources | json_query('[*].status.conditions[?type==`Ready`][].status') | select('match', 'True') | list | length == 1
   register: app_ready
+  until:
+    - app_ready.resources is defined
+    - app_ready.resources | length > 0
+    - app_ready.resources | json_query('[*].status.conditions[?type==`Ready`][].status') | select('match', 'True') | list | length == 1
   failed_when: app_ready is failed
+  block:
+    - name: "Lookup application information (fetch latest status)"
+      kubernetes.core.k8s_info:
+        api_version: "{{ mas_app_api_version }}"
+        name: "{{ mas_instance_id }}"
+        namespace: "{{ mas_app_namespace }}"
+        kind: "{{ mas_app_kind }}"
+      register: app_ready
 
 - name: "Check that the application is ready to configure a workspace"
   assert:

--- a/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
@@ -81,23 +81,20 @@
 #
 # If the application is not in ready state we can fail fast rather than waiting
 # for the workspace to be Ready -- because it never will!
-- name: "Wait for application to be Ready before configuring workspace"
+- name: "Lookup application information and wait for Ready status"
+  kubernetes.core.k8s_info:
+    api_version: "{{ mas_app_api_version }}"
+    name: "{{ mas_instance_id }}"
+    namespace: "{{ mas_app_namespace }}"
+    kind: "{{ mas_app_kind }}"
+  register: app_ready
   retries: 15  # Number of retries before failing
   delay: 20    # Wait 20 seconds between retries
-  register: app_ready
   until:
     - app_ready.resources is defined
     - app_ready.resources | length > 0
     - app_ready.resources | json_query('[*].status.conditions[?type==`Ready`][].status') | select('match', 'True') | list | length == 1
   failed_when: app_ready is failed
-  block:
-    - name: "Lookup application information (fetch latest status)"
-      kubernetes.core.k8s_info:
-        api_version: "{{ mas_app_api_version }}"
-        name: "{{ mas_instance_id }}"
-        namespace: "{{ mas_app_namespace }}"
-        kind: "{{ mas_app_kind }}"
-      register: app_ready
 
 - name: "Check that the application is ready to configure a workspace"
   assert:

--- a/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
@@ -88,6 +88,17 @@
     namespace: "{{ mas_app_namespace }}"
     kind: "{{ mas_app_kind }}"
   register: app_cr_result
+
+- name: "Wait for application to be Ready before configuring workspace"
+  retries: 15  # Adjust retries as needed
+  delay: 20    # Wait 20 seconds between retries
+  until:
+    - app_cr_result.resources is defined
+    - app_cr_result.resources | length > 0
+    - app_cr_result.resources | json_query('[*].status.conditions[?type==`Ready`][].status') | select('match', 'True') | list | length == 1
+  register: app_ready
+  failed_when: app_ready is failed
+
 - name: "Check that the application is ready to configure a workspace"
   assert:
     that:

--- a/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
@@ -93,8 +93,7 @@
   until:
     - app_cr_result.resources is defined
     - app_cr_result.resources | length > 0
-    - app_cr_result.resources | json_query('[*].status.conditions[?type==`Ready`][].status') | select('match', 'True') | list | length == 1
-  
+    - app_cr_result.resources | json_query('[*].status.conditions[?type==`Ready`][].status') | select('match', 'True') | list | length == 1  
 
 - name: "Check that the application is ready to configure a workspace"
   assert:

--- a/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
@@ -87,14 +87,14 @@
     name: "{{ mas_instance_id }}"
     namespace: "{{ mas_app_namespace }}"
     kind: "{{ mas_app_kind }}"
-  register: app_ready
+  register: app_cr_result
   retries: 15  # Number of retries before failing
   delay: 20    # Wait 20 seconds between retries
   until:
-    - app_ready.resources is defined
-    - app_ready.resources | length > 0
-    - app_ready.resources | json_query('[*].status.conditions[?type==`Ready`][].status') | select('match', 'True') | list | length == 1
-  failed_when: app_ready is failed
+    - app_cr_result.resources is defined
+    - app_cr_result.resources | length > 0
+    - app_cr_result.resources | json_query('[*].status.conditions[?type==`Ready`][].status') | select('match', 'True') | list | length == 1
+  failed_when: app_cr_result is failed
 
 - name: "Check that the application is ready to configure a workspace"
   assert:


### PR DESCRIPTION
Added retry logic (15 attempts with 20s delay) before asserting application readiness Ensured `app_cr_result.resources` is defined and has at least one resource before checking status Prevents unnecessary failures due to delayed application startup in OpenShift Keeps `assert` after waiting to strictly validate application readiness because getting issue on 