### PR TITLE
[patch] Adding retries for application status on application ws config

### DIFF
--- a/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/main.yml
@@ -88,6 +88,12 @@
     namespace: "{{ mas_app_namespace }}"
     kind: "{{ mas_app_kind }}"
   register: app_cr_result
+  retries: 15  # Number of retries before failing
+  delay: 20    # Wait 20 seconds between retries
+  until:
+    - app_cr_result.resources is defined
+    - app_cr_result.resources | length > 0
+    - app_cr_result.resources | json_query('[*].status.conditions[?type==`Ready`][].status') | select('match', 'True') | list | length == 1
 - name: "Check that the application is ready to configure a workspace"
   assert:
     that:


### PR DESCRIPTION
What Changed?
Added retries (15 times) with a delay (20s per retry) to ensure that k8s_info fetches fresh application status.
Previously, the readiness check ran only once, leading to random failures when the application was slow to start.
Now, the playbook waits properly before failing, reducing unnecessary test failures.
Why Was This Changed?
The test was failing intermittently because the application wasn’t always Ready immediately.
Without retries, the playbook failed too soon if the application took extra time to start.
This fix ensures the readiness check waits properly while still failing if the app is truly not Ready