### PR TITLE
[doc] Fix Kafka version in role README.md

### DIFF
--- a/ibm/mas_devops/roles/kafka/README.md
+++ b/ibm/mas_devops/roles/kafka/README.md
@@ -37,7 +37,7 @@ The version of Kafka to deploy by the operator. Before changing the kafka_versio
 by the [amq-streams operator version](https://access.redhat.com/documentation/en-us/red_hat_amq_streams) or [strimzi operator version](https://strimzi.io/downloads/).
 
 - Environment Variable: `KAFKA_VERSION`
-- Default Value: `3.5.0` for AMQ Streams and `3.7.0` for Strimzi.
+- Default Value: `3.8.0` for AMQ Streams and `3.9.0` for Strimzi.
 
 ### kafka_namespace
 The namespace where the operator and Kafka cluster will be deployed.


### PR DESCRIPTION
The kafka version defaults were updated https://github.com/ibm-mas/ansible-devops/blob/master/ibm/mas_devops/roles/kafka/defaults/main.yaml#L7 but not the docs. Updating the docs