### PR TITLE
[patch] always lookup current ibm-mas subscription on upgrade

### DIFF
--- a/ibm/mas_devops/roles/suite_upgrade/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_upgrade/tasks/main.yml
@@ -16,7 +16,6 @@
 # Default mas_channel based on the current version of the
 # installed MAS core if not provided by the user specifically
 - name: "Get subscription for ibm-mas"
-  when: mas_channel is not defined or mas_channel == ""
   kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
     kind: Subscription


### PR DESCRIPTION
## Always lookup current ibm-mas subscription during upgrade

When running the oneclick_upgrade playbook and explicitly specifying the [mas_channel](https://github.com/ibm-mas/ansible-devops/tree/master/ibm/mas_devops/roles/suite_upgrade#mas_channel) the upgrade role will fail. This happens because information from the current ibm-mas subscription is always required now.

As part of addressing label selectors with:

- https://github.com/ibm-mas/ansible-devops/pull/1586
- https://github.com/ibm-mas/ansible-devops/pull/1589

The current ibm-mas subscription is always required. For example here:

https://github.com/ibm-mas/ansible-devops/blob/master/ibm/mas_devops/roles/suite_upgrade/tasks/upgrade.yml#L8

The subscription needs to be looked up even if the new mas_channel to upgrade two is explicitly provided. 

