### PR TITLE
[patch] Using the new is_full_manage property to differentiate the installation of Full Manage and Manage Foundation

### DIFF
--- a/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/main.yml
@@ -2,6 +2,7 @@
 # Manage pre-configuration: pod templates
 - name: "Run Manage specific pre-configuration: Pod Templates"
   include_tasks: "tasks/manage/pre-config/setup-pod-templates.yml"
+  when: is_full_manage
 
 # Manage pre-configuration: components
 - name: "Run Manage specific pre-configuration: Load components"

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/manage.yml
@@ -3,11 +3,11 @@
 mas_appws_spec:
   bindings: "{{ mas_app_bindings }}"
   podTemplates: "{{ ((ibm_mas_manage_manageworkspace_pod_templates is defined) and (ibm_mas_manage_manageworkspace_pod_templates | length != 0)) | ternary(ibm_mas_manage_manageworkspace_pod_templates, []) }}"
-  components: "{{ ((mas_app_components_manage is defined) and (mas_app_components_manage | length != 0)) | ternary(mas_app_components_manage, {'base':{'version':'latest'}}) }}"
+  components: "{{ ((mas_app_components_manage is defined) and (mas_app_components_manage | length != 0)) | ternary(mas_app_components_manage, default_component) }}"
   settings:
     deployment:
       persistentVolumes: "{{ mas_app_settings_persistent_volumes }}"
-      serverBundles: "{{ mas_app_settings_server_bundles[mas_app_settings_server_bundles_size]['serverBundles'] }}"
+      serverBundles: "{{ is_full_manage | ternary(mas_app_settings_server_bundles[mas_app_settings_server_bundles_size]['serverBundles'], []) }}"
       defaultJMS: "{{ mas_app_settings_default_jms }}"
       serverTimezone: "{{ mas_app_settings_server_timezone }}"
     languages:

--- a/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
@@ -87,6 +87,16 @@ server_bundles_jms_add_server_config_content: "{{ lookup('file', '{{ role_path }
 # these settings will define the bundle servers spec
 mas_app_settings_server_bundles_size: "{{ lookup('env', 'MAS_APP_SETTINGS_SERVER_BUNDLES_SIZE') | default('dev', true)  }}"
 mas_app_settings_server_bundles:
+  foundation:
+    serverBundleEarFilename: maximo-foundation
+    serverBundles:
+      - bundleType: foundation
+        isDefault: true
+        isMobileTarget: true
+        isUserSyncTarget: true
+        name: foundation
+        replica: 1
+        routeSubDomain: foundation
   dev:
     serverBundleEarFilename: maximo-all
     serverBundles:

--- a/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
@@ -86,17 +86,11 @@ server_bundles_jms_add_server_config_content: "{{ lookup('file', '{{ role_path }
 
 # these settings will define the bundle servers spec
 mas_app_settings_server_bundles_size: "{{ lookup('env', 'MAS_APP_SETTINGS_SERVER_BUNDLES_SIZE') | default('dev', true)  }}"
+# This is to specify if manage installation is full or foundation
+is_full_manage: "{{ lookup('env', 'IS_FULL_MANAGE') | default(true, true)  }}"
+# If this is not full manage (foundation), there is no default base component
+default_component: "{{ is_full_manage | ternary({'base':{'version':'latest'}}, {})  }}"
 mas_app_settings_server_bundles:
-  foundation:
-    serverBundleEarFilename: maximo-foundation
-    serverBundles:
-      - bundleType: foundation
-        isDefault: true
-        isMobileTarget: true
-        isUserSyncTarget: true
-        name: foundation
-        replica: 1
-        routeSubDomain: foundation
   dev:
     serverBundleEarFilename: maximo-all
     serverBundles:

--- a/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
@@ -87,7 +87,7 @@ server_bundles_jms_add_server_config_content: "{{ lookup('file', '{{ role_path }
 # these settings will define the bundle servers spec
 mas_app_settings_server_bundles_size: "{{ lookup('env', 'MAS_APP_SETTINGS_SERVER_BUNDLES_SIZE') | default('dev', true)  }}"
 # This is to specify if manage installation is full or foundation
-is_full_manage: "{{ lookup('env', 'IS_FULL_MANAGE') | default(true, true)  }}"
+is_full_manage: "{{ lookup('env', 'IS_FULL_MANAGE') | lower in ['true', '1', 'yes']  }}"
 # If this is not full manage (foundation), there is no default base component
 default_component: "{{ is_full_manage | ternary({'base':{'version':'latest'}}, {})  }}"
 mas_app_settings_server_bundles:


### PR DESCRIPTION
Using the new is_full_manage property to differentiate the installation of Full Manage and Manage Foundation
This new property will be set by the cli (WIP) and, if not set, it will default to true, which doesn't change current behavior of Manage installation.

The cli will set is_full_manage to false only when the user selected MAS channel is 9.1+ and they also selected to not install Manage. This is the only scenario where Manage Foundation needs to be installed instead of Full Manage.
