### PR TITLE
[patch] mongodb backup of monitor database is not required

### DIFF
--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/backup-restore/backup-database.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/backup-restore/backup-database.yml
@@ -41,7 +41,7 @@
       when: mas_app_id is not defined or mas_app_id | length == 0
       set_fact:
         # Backup all databases if not specified mas_app_id
-        mongodb_db_filter: "^(mas|iot)(_|-){{ mas_instance_id }}(_|-)"
+        mongodb_db_filter: "^(mas|iot)(_|-){{ mas_instance_id }}(_|-)(?!.*monitor$)"
 
     - name: "Set fact: database name filter for {{ mas_app_id }}"
       when: mas_app_id is defined and mas_app_id | length > 0
@@ -50,7 +50,6 @@
           set_fact:
             mongodb_db_all_filters:
               iot: "iot_{{ mas_instance_id }}_"
-              monitor: "iot_{{ mas_instance_id }}_|mas_{{ mas_instance_id }}_monitor"
               visualinspection: "mas-{{ mas_instance_id }}-(visualinspection|edgeman)"
               optimizer: "mas_{{ mas_instance_id }}_optimizer"
 


### PR DESCRIPTION
## MongoDB backup of Monitor database is not required

Within the Monitor database in MongoDB `mas_{{ instanceId }}_monitor` is a single collection named `sessions`. Documents in the `sessions` collection are for temporary storage of Monitor UI session data. There is no need to back them up as any Monitor UI session can be re-established. 