### PR TITLE
[patch] Add support for nfd image for OCP 4.17

### DIFF
--- a/ibm/mas_devops/roles/nvidia_gpu/tasks/main.yml
+++ b/ibm/mas_devops/roles/nvidia_gpu/tasks/main.yml
@@ -1,21 +1,7 @@
 ---
-# Install and configure the Node Feature Discovery Operator
+# 1. Install and configure the Node Feature Discovery Operator
 # -----------------------------------------------------------------------------
 - include_tasks: tasks/nfd_setup.yml
-
-# 1. Look up OCP version in Cluster
-# -----------------------------------------------------------------------------
-- name: "Look up cluster ocp version"
-  kubernetes.core.k8s_info:
-    api_version: config.openshift.io/v1
-    name: "version"
-    kind: ClusterVersion
-  register: ocp_version_lookup
-
-- name: "Set ocp version number"
-  when: ocp_version_lookup.resources[0] is defined
-  set_fact:
-    ocp_version_num: "{{ ocp_version_lookup.resources[0].status.desired.version }}"
 
 # 2. Lookup the packagemanifest for gpu-operator-certified
 # -----------------------------------------------------------------------------
@@ -46,7 +32,6 @@
 - name: "Debug information"
   debug:
     msg:
-      - "OCP Release Version ................ {{ ocp_version_num }}"
       - "GPU Namespace ...................... {{ gpu_namespace }}"
       - "GPU Channel   ...................... {{ gpu_channel }}"
 

--- a/ibm/mas_devops/roles/nvidia_gpu/tasks/nfd_setup.yml
+++ b/ibm/mas_devops/roles/nvidia_gpu/tasks/nfd_setup.yml
@@ -1,4 +1,18 @@
 ---
+# 0. Look up OCP version in Cluster
+# -----------------------------------------------------------------------------
+- name: "Look up cluster ocp version"
+  kubernetes.core.k8s_info:
+    api_version: config.openshift.io/v1
+    name: "version"
+    kind: ClusterVersion
+  register: ocp_version_lookup
+
+- name: "Set ocp version number"
+  when: ocp_version_lookup.resources[0] is defined
+  set_fact:
+    ocp_version_num: "{{ ocp_version_lookup.resources[0].status.desired.version }}"
+
 # 1. Lookup the packagemanifest for gpu-operator-certified
 # -----------------------------------------------------------------------------
 - name: Get nfd package manifest
@@ -28,6 +42,7 @@
 - name: "Debug information"
   debug:
     msg:
+      - "OCP Release Version ................ {{ ocp_version_num }}"
       - "NFD Namespace ...................... {{ nfd_namespace }}"
       - "NFD Channel   ...................... {{ nfd_channel }}"
 
@@ -87,6 +102,8 @@
       kubernetes.core.k8s:
         apply: yes
         definition: "{{ lookup('template', 'templates/nfd-instance.yml.j2') }}"
+      vars:
+        ocp_version: "{{ ocp_version_num }}"
 
     # 4.4. Make sure NFD daemonsets have been created and all pods are ready
     # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/nvidia_gpu/templates/nfd-instance.yml.j2
+++ b/ibm/mas_devops/roles/nvidia_gpu/templates/nfd-instance.yml.j2
@@ -16,8 +16,13 @@ spec:
       #      - nodename: ["special-.*-node-.*"]
   instance: ''
   operand:
+{% if ocp_version < "4.17.0" %}
     image: >-
-      registry.redhat.io/openshift4/ose-node-feature-discovery@sha256:042325bfcca24584f6b72f5f38a47cc77b34301bccb29e3e6a7cc77aeab45e6e
+      'registry.redhat.io/openshift4/ose-node-feature-discovery@sha256:042325bfcca24584f6b72f5f38a47cc77b34301bccb29e3e6a7cc77aeab45e6e'
+{% else %}
+    image: >-
+      'registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9@sha256:45192fef5a1250ee573975ced1e897662116d5a30a1f8f4baa4497f64933fba3'
+{% endif %}
     imagePullPolicy: Always
     namespace: "{{nfd_namespace}}"
   workerConfig:


### PR DESCRIPTION
NFD supports different images based on the ocp version. When ocp is version 4.17 and above, the image is expected to be http://registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9@sha256:45192fef5a1250ee573975ced1e897662116d5a30a1f8f4baa4497f64933fba3 and when it is below 4.17, the image should be registry.redhat.io/openshift4/ose-node-feature-discovery@sha256:cc09665d75447c53a86a5acb5926f9b9fb59294533e04bfa432001d2b41efebc
Related to jira issue: [MASCORE-6014](https://jsw.ibm.com/browse/MASCORE-6014)