### PR TITLE
[patch] Retry CommonService Patch if it faIls

### DIFF
--- a/ibm/mas_devops/roles/cp4d/tasks/prereqs/install-cpfs.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/prereqs/install-cpfs.yml
@@ -121,7 +121,7 @@
     definition:
       spec:
         size: "{{ cpfs_size }}"
-  retries: 5
+  retries: 5 # This can fail transiently if the common service webhook is not yet ready
   delay: 12
 
 - name: "Wait for CommonService instance to be ready in {{ cpd_operators_namespace }}"

--- a/ibm/mas_devops/roles/cp4d/tasks/prereqs/install-cpfs.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/prereqs/install-cpfs.yml
@@ -121,6 +121,8 @@
     definition:
       spec:
         size: "{{ cpfs_size }}"
+  retries: 5
+  delay: 12
 
 - name: "Wait for CommonService instance to be ready in {{ cpd_operators_namespace }}"
   kubernetes.core.k8s_info:

--- a/ibm/mas_devops/roles/suite_app_upgrade/tasks/upgrade.yml
+++ b/ibm/mas_devops/roles/suite_app_upgrade/tasks/upgrade.yml
@@ -2,21 +2,6 @@
 
 # 1. Upgrade Subscription
 # -----------------------------------------------------------------------------
-- name: "Lookup subscription"
-  kubernetes.core.k8s_info:
-    api_version: operators.coreos.com/v1alpha1
-    kind: Subscription
-    namespace: "{{ mas_app_namespace }}"
-    label_selectors:
-      - "operators.coreos.com/{{ mas_app_fqn }}.{{ mas_app_namespace }}"
-  register: suite_app_sub
-
-- name: "Assert subscription exists"
-  assert:
-    that:
-      - suite_app_sub.resources is defined
-      - suite_app_sub.resources | length == 1
-
 - name: "Update subscription"
   kubernetes.core.k8s:
     api_version: operators.coreos.com/v1alpha1


### PR DESCRIPTION
**Description**
Retry the patching of CommonService is it fails, fixing https://jsw.ibm.com/browse/MASCORE-6004

**Testing** 
I re-ran the modified role on an FVT cluster to check that the ansible task was configured correctly.