### PR TITLE
[patch] Fix ClusterPolicy creation for nvidia_gpu role

### DIFF
--- a/ibm/mas_devops/roles/nvidia_gpu/tasks/main.yml
+++ b/ibm/mas_devops/roles/nvidia_gpu/tasks/main.yml
@@ -87,13 +87,13 @@
     # 4.3 Create GPU Cluster Policy
     # -----------------------------------------------------------------------------
     - name: "Create Cluster Policy instance using latest driver"
-      when: gpu_driver_version is not defined
+      when: gpu_driver_version is not defined or not gpu_driver_version
       kubernetes.core.k8s:
         apply: yes
         definition: "{{ lookup('template', 'templates/clusterpolicy-v2.yml.j2') }}"
 
     - name: "Create Cluster Policy instance using custom driver"
-      when: gpu_driver_version is defined
+      when: gpu_driver_version is defined and gpu_driver_version
       kubernetes.core.k8s:
         apply: yes
         definition: "{{ lookup('template', 'templates/clusterpolicy-customversion.yml.j2') }}"


### PR DESCRIPTION
Fix for issue #1651 

gpu_driver_version is technically defined as Null so Ansible role attempt to create Cluster Policy with custom driver
```
oc get clusterpolicy gpu-cluster-policy -o yaml|yq .spec.driver|egrep "version|repository"
repository: nvcr.io/nvidia
version: ""
```

This empty version will cause the Daemonset to have incorrect image:
`Failed to apply default image tag "nvcr.io/nvidia/driver:-rhcos4.16": couldn't parse image name "nvcr.io/nvidia/driver:-rhcos4.16": invalid reference format`

Workaround in the issue should work but for the intended purposes of this role and to use the "latest" driver available, added small fix in PR to validate if gpu_driver_version is not empty

Tested on my local configuration as I was attempting to install MVI:
```
TASK [ibm.mas_devops.nvidia_gpu : Create Cluster Policy instance using latest driver] ******************************************************************************************************************************
changed: [localhost] => changed=true 
  method: apply
  result:
    apiVersion: nvidia.com/v1
    kind: ClusterPolicy
...

TASK [ibm.mas_devops.nvidia_gpu : Create Cluster Policy instance using custom driver] ******************************************************************************************************************************
skipping: [localhost] => changed=false 
  false_condition: gpu_driver_version is defined and gpu_driver_version
  skip_reason: Conditional result was False

...

PLAY RECAP *********************************************************************************************************************************************************************************************************
localhost                  : ok=24   changed=1    unreachable=0    failed=0    skipped=7    rescued=0    ignored=0   
```