### PR TITLE
[patch] Fix efs-setup in ocp_efs role to get securitygroup for cluster 4.17 

### DIFF
--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -44,7 +44,7 @@ mirror:
       packages:
         - name: grafana-operator  #  Required by ibm.mas_devops.grafana role
           channels:
-{% if ocp_release != "4.16" %}
+{% if ocp_release < "4.16" %}
             - name: v4
 {% endif %}
             - name: v5

--- a/ibm/mas_devops/roles/ocp_efs/tasks/efs-setup.yml
+++ b/ibm/mas_devops/roles/ocp_efs/tasks/efs-setup.yml
@@ -30,8 +30,29 @@
 
 # 3. Get Security Group of the cluster
 # -----------------------------------------------------------------------------
+- name: "Look up cluster ocp version"
+  kubernetes.core.k8s_info:
+    api_version: config.openshift.io/v1
+    name: "version"
+    kind: ClusterVersion
+  register: ocp_version_lookup
+
+- name: "Set ocp version number"
+  when: ocp_version_lookup.resources[0] is defined
+  set_fact:
+    ocp_version_num: "{{ ocp_version_lookup.resources[0].status.desired.version }}"
+
+- name: "Debug information"
+  debug:
+    msg: "OCP Release Version ................ {{ ocp_version_num }}"
+
 - name: "efs-setup : Get Security Group of the EC2 Instance"
-  shell: aws ec2 describe-security-groups --filters Name=vpc-id,Values={{ vpcid }} Name=tag:Name,Values='*worker*' --query "SecurityGroups[*].{ID:GroupId}[0]"
+  shell: >
+    {% if ocp_version_num is version('4.17', '<') %}
+    aws ec2 describe-security-groups --filters Name=vpc-id,Values={{ vpcid }} Name=tag:Name,Values='*worker*' --query "SecurityGroups[*].{ID:GroupId}[0]"
+    {% else %}
+    aws ec2 describe-security-groups --filters Name=vpc-id,Values={{ vpcid }} Name=tag:Name,Values='*node*' --query "SecurityGroups[*].{ID:GroupId}[0]"
+    {% endif %}
   register: security_group
 
 - name: "efs-setup : Get Security Group Id from Output"


### PR DESCRIPTION
This Fix is a pre-requisite for  https://jsw.ibm.com/browse/MASCORE-5250 and https://jsw.ibm.com/browse/MASCORE-5245

The current task at ibm/mas_devops/roles/ocp_efs/tasks/efs-setup.yml will filter security group based on the tag "worker", which will fail for OCP version 4.17

```
- name: "efs-setup : Get Security Group of the EC2 Instance"
  shell: aws ec2 describe-security-groups --filters Name=vpc-id,Values={{ vpcid }} Name=tag:Name,Values='*worker*' --query "SecurityGroups[*].{ID:GroupId}[0]"
  register: security_group
``` 

We need to add a condition on above task so that for version below ocp 4.17 above shell script can be continued and for version 4.17.0 & above use another condition for filtering as below:

```
- name: "efs-setup : Get Security Group of the EC2 Instance"
  shell: >
    {% if ocp_version_num is version('4.17', '<') %}
    aws ec2 describe-security-groups --filters Name=vpc-id,Values={{ vpcid }} Name=tag:Name,Values='*worker*' --query "SecurityGroups[*].{ID:GroupId}[0]"
    {% else %}
    aws ec2 describe-security-groups --filters Name=vpc-id,Values={{ vpcid }} Name=tag:Name,Values='*node*' --query "SecurityGroups[*].{ID:GroupId}[0]"
    {% endif %}
  register: security_group
``` 

So for adding above condition, we need to define a variable to set OCP version number that is fetched from provisioned cluster as below.

```
- name: "Look up cluster ocp version"
  kubernetes.core.k8s_info:
    api_version: config.openshift.io/v1
    name: "version"
    kind: ClusterVersion
  register: ocp_version_lookup

- name: "Set ocp version number"
  when: ocp_version_lookup.resources[0] is defined
  set_fact:
    ocp_version_num: "{{ ocp_version_lookup.resources[0].status.desired.version }}"

- name: "Debug information"
  debug:
    msg: "OCP Release Version ................ {{ ocp_version_num }}"
``` 

This is tested in a cluster of versio 4.17 for saas-trans , adding a snap for reference:

<img width="1421" alt="Screenshot 2025-03-22 at 5 13 08 PM" src="https://github.com/user-attachments/assets/1e27c896-4de6-4de6-bdae-8d03d9c72c20" />

In addition to this, as part of https://jsw.ibm.com/browse/MASCORE-5245 modified ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2 as below:

```
    # community-operators
    - catalog: registry.redhat.io/redhat/community-operator-index:v{{ ocp_release }}
      packages:
        - name: grafana-operator  #  Required by ibm.mas_devops.grafana role
          channels:
{% if ocp_release < "4.16" %}
            - name: v4
{% endif %}
            - name: v5
        - name: opentelemetry-operator  # Required by ibm.mas_devops.opentelemetry role
          channels:
            - name: alpha
        - name: strimzi-kafka-operator  #  Required by ibm.mas_devops.kafka role
          channels:
            - name: stable
``` 

This will not include v4 if either 4.16 or 4.17
