### PR TITLE
[patch] Remove unnecessary HTTP PATCH call from suite_dns role

### DIFF
--- a/ibm/mas_devops/plugins/modules/cis_dns_entries.py
+++ b/ibm/mas_devops/plugins/modules/cis_dns_entries.py
@@ -236,10 +236,6 @@ def main():
                 if(response.status_code == 200):
                     changed = True
                     # DNS record created successfully
-
-            response = requests.request("PATCH", url, headers=headers, data=payload)
-            if(response.status_code == 200):
-                changed = True
         
         if delete_wildcards:
             for entry in existingDNSEntries:


### PR DESCRIPTION
According to [CIS API Docs](https://cloud.ibm.com/apidocs/cis#create-dns-record-e2ec84) the `dns_records` APIs do not support `PATCH`. To check I tested this myself against both the `/dns_record` and `/dns_record/{id}` APIs:
```
HTTP 405 {"trace": "xxx", "errors": [{"code": null, "message": "405 Method Not Allowed"}]}
```
As far as I can tell, all this PATCH call is doing is increasing our chances of hitting the CIS API's aggressive rate limits, especially as it is issued around 54 times (once for each entry in the [dnsentries.yml.js template](https://github.com/ibm-mas/ansible-devops/blob/master/ibm/mas_devops/roles/suite_dns/templates/dnsentries.yml.j2)) every time the suite_dns role is run.