### PR TITLE
[patch] Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Issue
+<!-- Provide the ID numbers of issues related to this change. Please do not provide direct links to IBM-internal systems. If there are no issues related to this change, why are you working on it? -->
+
+## Description
+<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->
+
+## Test Results
+<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->
+
+<hr/>
+
+### :warning: Notes for Reviewers
+* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
+* Ensure all sections in the PR template are appropriately completed.


### PR DESCRIPTION
Add a basic pull request template derived from the one shared in the IBM-internal Playbook.

* PRs are being delivered with little consistency. A quick look at the PR history will show PRs with an entirely empty description, or at least no standardization on how they are filled in.
* I have deliberately modified the IBM-internal template shared in the playbook to reference issue (work item) **ID numbers** rather than providing links to issues; such links will only work within the IBM network and this is a public GitHub repository.
* I have removed the Backporting section as it does not appear relevant to the repository.
