### PR TITLE
Update rotate_ocp_version and add 4.17 as part of OCP version testing

### DIFF
--- a/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
@@ -34,8 +34,8 @@
       Wednesday: 4.14
       Thursday: 4.16
       Friday: 4.15
-      Saturday: 4.14
-      Sunday: 4.17
+      Saturday: 4.17
+      Sunday: 4.16
 
 - name: "Set default OCP version"
   when: ocp_version == "default"

--- a/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
@@ -29,13 +29,13 @@
     ocp_version: "{{ rotate_ocp_version[ansible_date_time['weekday']] ~ ('_openshift' if cluster_type == 'roks' else '') }}"
   vars:
     rotate_ocp_version:
-      Monday: 4.16
+      Monday: 4.17
       Tuesday: 4.15
       Wednesday: 4.14
       Thursday: 4.16
       Friday: 4.15
       Saturday: 4.14
-      Sunday: 4.16
+      Sunday: 4.17
 
 - name: "Set default OCP version"
   when: ocp_version == "default"


### PR DESCRIPTION
Referring story: [https://jsw.ibm.com/browse/MASCORE-5249](url)

Raising PR to update rotate_ocp_version and add 4.17. Currently, 4.16 runs on Monday, Thursday, and Sunday—I've modified it so that Monday and Sunday now run 4.17 instead.
