### PR TITLE
[patch] fix suite-dns edge certs logic & remove redundant HTTP call

### DIFF
--- a/ibm/mas_devops/plugins/modules/cis_dns_entries.py
+++ b/ibm/mas_devops/plugins/modules/cis_dns_entries.py
@@ -246,20 +246,12 @@ def main():
                     if(response.status_code == 200):
                         changed = True
         if cis_waf:
-
             url = f"https://api.cis.cloud.ibm.com/v1/{crn}/zones/{zoneId}/settings/waf"	
             payload="{\n \"value\": \"on\" \n}"
             response = requests.request("PATCH", url, headers=headers, data=payload)
             if(response.status_code == 200):
                 changed = True
         
-        if (edgeCertRoutes) and len(edgeCertRoutes) > 0:
-            url = f"https://api.cis.cloud.ibm.com/v2/{crn}/zones/{zoneId}/ssl/certificate_packs/order"
-            payload = "{\n \"certificate_authority\": \"digicert\",\n \"validation_method\": \"txt\",\n \"validity_days\": 365,\n \"type\": \"advanced\",\n  \"hosts\": ["+ ",".join(["'"+str(i)+"'" for i in edgeCertRoutes]) +"],:}" 
-            response = requests.request("POST", url, headers=headers, data=payload)
-            if(response.status_code == 200):
-                
-                changed = True
     except requests.exceptions.RequestException as e:  # This is the correct syntax
         module.fail_json(msg = f"Error calling : {url}")
 

--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
@@ -78,6 +78,6 @@
 - name: "cis : Order certificate if there no dedicated yet"
   ansible.builtin.shell: |
     ibmcloud cis certificate-order {{ _cis_domain_id }} --hostnames {{ item|join(',') }} -i {{ cis_service_name }}
-  loop: "{{ edge_cert_routes | batch(50) | list }}"
+  loop: "{{ edge_cert_routes | batch(100) | list }}"
   when:
     - not hasDedicated or _deleted_certificate is defined


### PR DESCRIPTION
## Issue
MASCORE-6361

## Description

[cis_edge_certificate.yml](https://github.com/ibm-mas/ansible-devops/blob/dadb1ecd65d2bad89cefb8845271133133bc1293/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml#L80)
```yaml
- name: "cis : Order certificate if there no dedicated yet"
  ansible.builtin.shell: |
    ibmcloud cis certificate-order {{ _cis_domain_id }} --hostnames {{ item|join(',') }} -i {{ cis_service_name }}
  loop: "{{ edge_cert_routes | batch(50) | list }}"
  when:
    - not hasDedicated or _deleted_certificate is defined
```
orders 1 certificate per 50 hosts (due to `batch(50`) from the template [edge_certificate_routes.yml.j2](https://github.com/ibm-mas/ansible-devops/blob/master/ibm/mas_devops/roles/suite_dns/templates/edge_certificate_routes.yml.j2)

Since the reportdb entry was added, there are now 51 host names in that template. This means:
1. we now order 2 edge certs per MAS instance instead of 1, putting additional unnecessary strain on the 50/certs per week limit imposed by Lets Encrypt. SRE are hitting this limit regularly in prod for the maximo.com domain, fixing this will help (but likely not totally solve) this problem.
2. the cleanup logic assumes there is only a single edge cert, meaning 1 of the certs is left behind if the role is ever rerun with override_edge_certs: true

This problematic behaviour aligns with what we see in the fvt-cis instance used by fvtsaas:
![image](https://github.com/user-attachments/assets/a9b15c00-a130-4718-8934-ae846b14674a)

This PR resolves this problem by increasing the number of host names in each certificate to the maximum permitted value of 100 (see [here](https://letsencrypt.org/docs/rate-limits/#new-orders-per-account)).


Also [this](https://github.com/ibm-mas/ansible-devops/blob/dadb1ecd65d2bad89cefb8845271133133bc1293/ibm/mas_devops/plugins/modules/cis_dns_entries.py#L256) code in the Python module called by the suite-dns role:
```python
        if (edgeCertRoutes) and len(edgeCertRoutes) > 0:
            url = f"https://api.cis.cloud.ibm.com/v2/{crn}/zones/{zoneId}/ssl/certificate_packs/order"
            payload = "{\n \"certificate_authority\": \"digicert\",\n \"validation_method\": \"txt\",\n \"validity_days\": 365,\n \"type\": \"advanced\",\n  \"hosts\": ["+ ",".join(["'"+str(i)+"'" for i in edgeCertRoutes]) +"],:}" 
            response = requests.request("POST", url, headers=headers, data=payload)
            if(response.status_code == 200):
                changed = True
```
is entirely redundant: it is attempting to POST invalid JSON, e.g.:
```json
{
 "certificate_authority": "digicert",
 "validation_method": "txt",
 "validity_days": 365,
 "type": "advanced",
  "hosts": ['test1.com','test2.com'],:}
400
{"trace": "37aa491a-3040-4d54-8daf-5c0ff7b1da3f", "errors": [{"code": "CIS-FRT-00005", "message": "property null is not of type \"object\""}]}
```
and so should be removed (especially as it is using up one of our 100/req minute rate limit quota enforcved by the CIS HTTP API).

## Test Results
TODO

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
