### PR TITLE
Arcgis 11.4 Release

### DIFF
--- a/ibm/mas_devops/roles/arcgis/tasks/main.yml
+++ b/ibm/mas_devops/roles/arcgis/tasks/main.yml
@@ -1,4 +1,18 @@
 ---
+# Create a cluster role for ws-operator to manage scc
+# ------------------------------------------------------------------------------------------------------------------------------
+- name: "Create a custom SecurityContextConstraints"
+  kubernetes.core.k8s:
+    apply: yes
+    template: 'templates/ws-cluster-rbac.yml.j2'
+
+# Create a cluster role for ingress controller
+# ------------------------------------------------------------------------------------------------------------------------------
+- name: "Create a custom SecurityContextConstraints"
+  kubernetes.core.k8s:
+    apply: yes
+    template: 'templates/ingress-cluster-rbac.yml.j2'
+
 # 1. Check for required facts
 # -----------------------------------------------------------------------------
 - name: "Fail if mas_instance_id has not been provided"

--- a/ibm/mas_devops/roles/arcgis/tasks/main.yml
+++ b/ibm/mas_devops/roles/arcgis/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 # Create a cluster role for ws-operator to manage scc
 # ------------------------------------------------------------------------------------------------------------------------------
-- name: "Create a custom SecurityContextConstraints"
+- name: "Create a cluster role for ws-operator to manage scc"
   kubernetes.core.k8s:
     apply: yes
     template: 'templates/ws-cluster-rbac.yml.j2'
 
 # Create a cluster role for ingress controller
 # ------------------------------------------------------------------------------------------------------------------------------
-- name: "Create a custom SecurityContextConstraints"
+- name: "Create a cluster role for ingress controller"
   kubernetes.core.k8s:
     apply: yes
     template: 'templates/ingress-cluster-rbac.yml.j2'

--- a/ibm/mas_devops/roles/arcgis/templates/ingress-cluster-rbac.yml.j2
+++ b/ibm/mas_devops/roles/arcgis/templates/ingress-cluster-rbac.yml.j2
@@ -1,0 +1,26 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: arcgis-ingress-controller
+rules:
+  - apiGroups: [""]
+    resources: ["events", "nodes"]
+    verbs: ["get", "list", "watch", "create", "patch"]
+
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingressclasses"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: arcgis-ingress-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: arcgis-ingress-controller
+subjects:
+  - kind: ServiceAccount
+    name: arcgis-ingress-serviceaccount
+    namespace: mas-{{mas_instance_id}}-arcgis

--- a/ibm/mas_devops/roles/arcgis/templates/ws-cluster-rbac.yml.j2
+++ b/ibm/mas_devops/roles/arcgis/templates/ws-cluster-rbac.yml.j2
@@ -7,11 +7,14 @@ rules:
   - apiGroups: ["security.openshift.io"]
     resources: ["securitycontextconstraints"]
     verbs: ["get", "list", "watch", "create", "delete", "patch", "update"]
+  - apiGroups: ["config.openshift.io"]
+    resources: ["clusterversions"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name:  ws-operator
+  name: ws-operator
 subjects:
   - kind: ServiceAccount
     name: ibm-mas-arcgis-ws-operator

--- a/ibm/mas_devops/roles/arcgis/templates/ws-cluster-rbac.yml.j2
+++ b/ibm/mas_devops/roles/arcgis/templates/ws-cluster-rbac.yml.j2
@@ -1,0 +1,22 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ws-operator
+rules:
+  - apiGroups: ["security.openshift.io"]
+    resources: ["securitycontextconstraints"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name:  ws-operator
+subjects:
+  - kind: ServiceAccount
+    name: ibm-mas-arcgis-ws-operator
+    namespace: mas-{{mas_instance_id}}-arcgis
+roleRef:
+  kind: ClusterRole
+  name: ws-operator
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Issue
Ws operator and Ingress controller of ArcGis failing due to not enough rbac permissions.

## Description
After upgrading ArcGIS to version 11.4, a few cluster-level resources are required by the Workspace Operator. To enable this, certain ClusterRoles and ClusterRoleBindings need to be created for the ArcGIS components.

## Test Results
This changes were tested by successfully deploying the End to End ArcGis application on openshift cluster. Attaching the screenshots for successful deployment of application with its UI and Home page
![image (3)](https://github.com/user-attachments/assets/b13e9f9a-e327-4b10-b10f-000c66c9e64f)
![image (4)](https://github.com/user-attachments/assets/3bbd09cc-4c65-492d-be7e-db5a81d82c60)
![image (5)](https://github.com/user-attachments/assets/b7017f3e-0639-44cf-9874-d85873c6c937)
<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
