### PR TITLE
[major] AI Service entitlement in tenant CR

### DIFF
--- a/ibm/mas_devops/roles/aibroker_tenant/defaults/main.yml
+++ b/ibm/mas_devops/roles/aibroker_tenant/defaults/main.yml
@@ -19,6 +19,9 @@ mas_aibroker_path_ca_crt: './certs'
 mas_aibroker_tenant_name: "{{ lookup('env', 'MAS_AIBROKER_TENANT_NAME') | default('user', true) }}"
 tenant_action: "{{ lookup('env', 'TENANT_ACTION') | default('install', true) }}"
 tenantNamespace: 'aibroker-{{ mas_aibroker_tenant_name }}'
+tenant_entitlement_type: "{{ lookup('env', 'MAS_AIBROKER_TENANT_ENTITLEMENT_TYPE') }}"
+tenant_entitlement_start_date: "{{ lookup('env', 'MAS_AIBROKER_TENANT_ENTITLEMENT_START_DATE') }}"
+tenant_entitlement_end_date: "{{ lookup('env', 'MAS_AIBROKER_TENANT_ENTITLEMENT_END_DATE') }}"
 
 # API Key
 mas_aibroker_apikey_action: "{{ lookup('env', 'MAS_AIBROKER_APIKEY_ACTION') | default('install', true) }}"

--- a/ibm/mas_devops/roles/aibroker_tenant/templates/aibroker/aibrokerworkspace.yml.j2
+++ b/ibm/mas_devops/roles/aibroker_tenant/templates/aibroker/aibrokerworkspace.yml.j2
@@ -33,3 +33,7 @@ spec:
             tenant_id: "{{ tenantNamespace }}"
             subscription_id: "{{ mas_aibroker_sls_subscription_id }}"
             instance_id: "{{ mas_instance_id }}"
+        entitlement:
+            type: {{ tenant_entitlement_type }}
+            startDate: {{ tenant_entitlement_start_date }}
+            endDate: {{ tenant_entitlement_end_date }}

--- a/ibm/mas_devops/roles/aibroker_tenant/templates/aibroker/aibrokerworkspace.yml.j2
+++ b/ibm/mas_devops/roles/aibroker_tenant/templates/aibroker/aibrokerworkspace.yml.j2
@@ -33,7 +33,7 @@ spec:
             tenant_id: "{{ tenantNamespace }}"
             subscription_id: "{{ mas_aibroker_sls_subscription_id }}"
             instance_id: "{{ mas_instance_id }}"
-        entitlement:
-            type: {{ tenant_entitlement_type }}
-            startDate: {{ tenant_entitlement_start_date }}
-            endDate: {{ tenant_entitlement_end_date }}
+            entitlement:
+                type: {{ tenant_entitlement_type }}
+                startDate: {{ tenant_entitlement_start_date }}
+                endDate: {{ tenant_entitlement_end_date }}


### PR DESCRIPTION
## Issue
MASAIB-882

## Description
Set the tenant's AI Service entitlement info in the AI Broker Workspace CR. These new fields are required, except for the `type` which defaults to `standard`.

## Test Results
Deployed the CR with the new build of the AI Broker's workspace operator and observed that the tenant was configured correctly. No errors observed. Confirmed that entitlement info was picked up correctly by the operator.

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
