### PR TITLE
[patch] ensure default CIS cert is excluded when searching for existing edge certs

### DIFF
--- a/ibm/mas_devops/roles/suite_dns/README.md
+++ b/ibm/mas_devops/roles/suite_dns/README.md
@@ -210,8 +210,10 @@ Location to output the edge-routes-{mas_instance_id}.txt
 - Default: `.` (which will set the directory file in ibm/mas_devops)
 
 ### saas_mode
-If true, saas_edge_certificate_routes.yml.j2 template will be used instead of edge_certificate_routes.yml.j2
-This template omits routes that will not be present in SaaS envs to reduce the hostname count to under 50 so only a single edge route certificate is required
+If true:
+ - saas_edge_certificate_routes.yml.j2 template will be used instead of edge_certificate_routes.yml.j2
+   This template omits routes that will not be present in SaaS envs to reduce the hostname count to under 50 so only a single edge route certificate is required
+ - Ensures that the default edge certificates configured by CIS are excluded from checks, even when the CIS domain includes the MAS instance ID.
 
 - Optional
 - Environment Variable: `SAAS_MODE`

--- a/ibm/mas_devops/roles/suite_dns/defaults/main.yaml
+++ b/ibm/mas_devops/roles/suite_dns/defaults/main.yaml
@@ -65,9 +65,10 @@ delete_wildcards: "{{ lookup('env', 'DELETE_WILDCARDS') | default('false', true)
 # Override and delete any existing edge certificates in cis instance
 override_edge_certs: "{{ lookup('env', 'OVERRIDE_EDGE_CERTS') | default('true', true) | bool }}"
 
-# If true, saas_edge_certificate_routes.yml.j2 template will be used instead of edge_certificate_routes.yml.j2
-# This template omits routes that will not be present in SaaS envs to reduce the hostname count to under 50
-# so only a single edge route certificate is required
+# If true:
+#  - saas_edge_certificate_routes.yml.j2 template will be used instead of edge_certificate_routes.yml.j2
+#    This template omits routes that will not be present in SaaS envs to reduce the hostname count to under 50 so only a single edge route certificate is required
+#  - Ensures that the default edge certificates configured by CIS are excluded from checks, even when the CIS domain includes the MAS instance ID.
 saas_mode:  "{{ lookup('env', 'SAAS_MODE') | default('false', true) | bool }}"
 
 cis_apiservice:

--- a/ibm/mas_devops/roles/suite_dns/defaults/main.yaml
+++ b/ibm/mas_devops/roles/suite_dns/defaults/main.yaml
@@ -69,7 +69,7 @@ override_edge_certs: "{{ lookup('env', 'OVERRIDE_EDGE_CERTS') | default('true', 
 #  - saas_edge_certificate_routes.yml.j2 template will be used instead of edge_certificate_routes.yml.j2
 #    This template omits routes that will not be present in SaaS envs to reduce the hostname count to under 50 so only a single edge route certificate is required
 #  - Ensures that the default edge certificates configured by CIS are excluded from checks, even when the CIS domain includes the MAS instance ID.
-saas_mode:  "{{ lookup('env', 'SAAS_MODE') | default('false', true) | bool }}"
+saas_mode: "{{ lookup('env', 'SAAS_MODE') | default('false', true) | bool }}"
 
 cis_apiservice:
   group_name: acme.cis.ibm.com

--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
@@ -46,37 +46,29 @@
     ibmcloud cis certificates {{ _cis_domain_id }} -i {{ cis_service_name }} -o json
   register: _cis_certificates
 
-- name: "cis : Verify if is there a dedicated certificate already"
+- name: "cis : exclude certs not for {{ mas_instance_id }}"
   set_fact:
-    hasDedicated: "{{ _cis_certificates.stdout | from_json | selectattr('hosts', 'search', mas_instance_id) | map(attribute='id') | list | length > 0 }}"
-  when:
-    - not saas_mode
-
-- name: "cis : Lookup the dedicated certificate id"
-  set_fact:
-    dedicatedId: "{{ _cis_certificates.stdout | from_json | selectattr('hosts', 'search', mas_instance_id) | map(attribute='id') | first }}"
-  when:
-    - hasDedicated
-    - not saas_mode
-
+    dedicated_list: "{{ _cis_certificates.stdout | from_json | selectattr('hosts','search',mas_instance_id) }}"
 
 # In SaaS, the default edge cert created by CIS already includes mas_instance_id in its hostname,
 # so we add an additional check to ensure this default cert is excluded from our search for the dedicated cert.
 # Specifically, we look for type: "advanced" (certs ordered by this role will always have this - the default cert has type: "universal").
 # This specialised check is gated behind the saas_mode flag to protect against unintentionally impacting other existing users of this role
-- name: "cis : Verify if is there a dedicated certificate already (SaaS)"
+- name: "cis : exclude universal certs (SaaS)"
   set_fact:
-    hasDedicated: "{{ _cis_certificates.stdout | from_json | selectattr('hosts', 'search', mas_instance_id) | selectattr('type', 'equalto', 'advanced') | map(attribute='id') | list | length > 0}}"
+    dedicated_list: "{{ dedicated_list | selectattr('type', 'equalto', 'advanced') }}"
   when:
     - saas_mode
 
-- name: "cis : Lookup the dedicated certificate id (SaaS)"
+- name: "cis : Verify if is there a dedicated certificate already"
   set_fact:
-    dedicatedId: "{{ _cis_certificates.stdout | from_json | selectattr('hosts', 'search', mas_instance_id) | selectattr('type', 'equalto', 'advanced') | map(attribute='id') | first }}"
+    hasDedicated: "{{ dedicated_list | length > 0 }}"
+
+- name: "cis : Lookup the dedicated certificate id"
+  set_fact:
+    dedicatedId: "{{ dedicated_list[0].id }}"
   when:
     - hasDedicated
-    - saas_mode
-
 
 - name: Debug dedicated certificates
   debug:

--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
@@ -53,10 +53,10 @@
     - not saas_mode
 
 - name: "cis : Lookup the dedicated certificate id"
-  when: hasDedicated
   set_fact:
     dedicatedId: "{{ _cis_certificates.stdout | from_json | selectattr('hosts', 'search', mas_instance_id) | map(attribute='id') | first }}"
   when:
+    - hasDedicated
     - not saas_mode
 
 

--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
@@ -49,11 +49,34 @@
 - name: "cis : Verify if is there a dedicated certificate already"
   set_fact:
     hasDedicated: "{{ _cis_certificates.stdout | from_json | selectattr('hosts', 'search', mas_instance_id) | map(attribute='id') | list | length > 0 }}"
+  when:
+    - not saas_mode
 
 - name: "cis : Lookup the dedicated certificate id"
   when: hasDedicated
   set_fact:
     dedicatedId: "{{ _cis_certificates.stdout | from_json | selectattr('hosts', 'search', mas_instance_id) | map(attribute='id') | first }}"
+  when:
+    - not saas_mode
+
+
+# In SaaS, the default edge cert created by CIS already includes mas_instance_id in its hostname,
+# so we add an additional check to ensure this default cert is excluded from our search for the dedicated cert.
+# Specifically, we look for type: "advanced" (certs ordered by this role will always have this - the default cert has type: "universal").
+# This specialised check is gated behind the saas_mode flag to protect against unintentionally impacting other existing users of this role
+- name: "cis : Verify if is there a dedicated certificate already (SaaS)"
+  set_fact:
+    hasDedicated: "{{ _cis_certificates.stdout | from_json | selectattr('hosts', 'search', mas_instance_id) | selectattr('type', 'equalto', 'advanced') | map(attribute='id') | list | length > 0}}"
+  when:
+    - saas_mode
+
+- name: "cis : Lookup the dedicated certificate id (SaaS)"
+  set_fact:
+    dedicatedId: "{{ _cis_certificates.stdout | from_json | selectattr('hosts', 'search', mas_instance_id) | selectattr('type', 'equalto', 'advanced') | map(attribute='id') | first }}"
+  when:
+    - hasDedicated
+    - saas_mode
+
 
 - name: Debug dedicated certificates
   debug:


### PR DESCRIPTION
## Issue
MASCORE-6647

## Description

When a CIS instance domain includes the MAS instance ID (i.e. the CIS is likely dedicated for use by a single MAS instance),  the default "universal" edge cert provided by CIS will include the MAS instance ID in its hostnames already.

This breaks the current logic in suite-dns as it is "tricked" into thinking the universal edge cert is the "dedicated" certificate provisioned by suite-dns in a previous run. 

The universal cert only covers routes down one subdomain level, but MAS routes use lower levels. This means that, when `override_edge_certs: false` is used, a dedicated edge cert will not be ordered for the MAS instance and TLS won't work correctly for many of its routes.

This PR establishes a tactical fix for this problem by also checking that the certificate type is "advanced" (edge certs ordered by suite-dns will always have this type). This prevents it from being "tricked" into thinking the universal cert is the dedicated cert. 

The additional check is gated behind the `saas_mode: true` flag to ensure this change does not have any unintended consequences for other existing users of the role.



## Test Results

Changes have been verified in isolation for edge cases, and have been tested in the Staging environment for both a newly provisioned and existing instance.  Please see internal Jira issue (MASCORE-6647) for testing results.


<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
