### PR TITLE
Automatically recover elasticsearch in 5.0.0 to 5.1.0 upgrade

### DIFF
--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-ccs.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-ccs.yml
@@ -121,21 +121,102 @@
 # -----------------------------------------------------------------------------
 # Note: We can't fail early when we see Failed status, as the operator will
 # report failed multiple times during initial reconcile.
-- name: "wait-ccs : Wait for ccsStatus 'Completed' (5m interval)"
-  kubernetes.core.k8s_info:
-    api_version: "ccs.cpd.ibm.com/v1beta1"
-    kind: CCS
-    name: "ccs-cr"
-    namespace: "{{ cpd_instance_namespace }}"
-  register: ccs_cr_lookup
-  until:
-    - ccs_cr_lookup.resources is defined
-    - ccs_cr_lookup.resources | length == 1
-    - ccs_cr_lookup.resources[0].status is defined
-    - ccs_cr_lookup.resources[0].status.ccsStatus is defined
-    - ccs_cr_lookup.resources[0].status.ccsStatus == "Completed" #  or ccs_cr_lookup.resources[0].status.wmlStatus == "Failed"
-  retries: 50 # Just over 4 hours
-  delay: 300 # Every 5 minutes
+# We give it an hour to have made it past upgrading elasticsearch if still
+# failing check to see if elasticsearch needs rescuing by deleting and
+# recreating.
+# regardless of if the elasticsearch rescue is performed we wait another 4 hours
+# to let the process complete (in the always section)
+- block:
+  - name: "wait-ccs : Wait for ccsStatus 'Completed' (5m interval)"
+    kubernetes.core.k8s_info:
+      api_version: "ccs.cpd.ibm.com/v1beta1"
+      kind: CCS
+      name: "ccs-cr"
+      namespace: "{{ cpd_instance_namespace }}"
+    register: ccs_cr_lookup
+    until:
+      - ccs_cr_lookup.resources is defined
+      - ccs_cr_lookup.resources | length == 1
+      - ccs_cr_lookup.resources[0].status is defined
+      - ccs_cr_lookup.resources[0].status.ccsStatus is defined
+      - ccs_cr_lookup.resources[0].status.ccsStatus == "Completed"
+    retries: 12 # 1 hour
+    delay: 300 # Every 5 minutes
+
+  rescue:
+  - name: "get the elasticsearch statefulset"
+    kubernetes.core.k8s_info:
+      api_version: apps/v1
+      namespace: "{{ cpd_instance_namespace }}"
+      kind: StatefulSet
+      label_selectors: ["ibm-es-master=True"]
+    register: statefulset_output
+
+  - name: "check if elasticsearch rescue is appropriate"
+    set_fact:
+       recover_elasticsearch: true
+    when:
+      - statefulset_output.resources is defined
+      - statefulset_output.resources | length == 1
+      - statefulset_output.resources[0].status is defined
+      - statefulset_output.resources[0].status.availableReplicas is defined
+      - statefulset_output.resources[0].status.availableReplicas == 0
+
+  - name: "Pause for 5 minutes before removing elasticsearchcluster and associated persistent volumes"
+    pause:
+      minutes: 5
+
+  - name: "reset rescue decision"
+    set_fact:
+       recover_elasticsearch: false
+
+  - name: "confirm elasticsearch rescue is still appropriate"
+    set_fact:
+       recover_elasticsearch: true
+    when:
+      - statefulset_output.resources is defined
+      - statefulset_output.resources | length == 1
+      - statefulset_output.resources[0].status is defined
+      - statefulset_output.resources[0].status.availableReplicas is defined
+      - statefulset_output.resources[0].status.availableReplicas == 0
+
+  - name: "delete the elasticsearch cluster"
+    k8s:
+      api_version: elasticsearch.opencontent.ibm.com/v1
+      kind: ElasticsearchCluster
+      state: absent
+      namespace: "{{ cpd_instance_namespace }}"
+      name: "{{ statefulset_output.resources[0].metadata.ownerReferences[0].name }}"
+    when:
+      - recover_elasticsearch == true
+
+  - name: "Delete the elasticsearch PVCs"
+    k8s:
+      api_version:  v1
+      kind: PersistentVolumeClaim
+      namespace: "{{ cpd_instance_namespace }}"
+      label_selectors: ["app.kubernetes.io/component={{ statefulset_output.resources[0].metadata.name}}"]
+      state: absent
+    when:
+      - recover_elasticsearch == true
+
+  always:
+
+  - name: "wait-ccs : Wait for ccsStatus 'Completed' (5m interval)"
+    kubernetes.core.k8s_info:
+      api_version: "ccs.cpd.ibm.com/v1beta1"
+      kind: CCS
+      name: "ccs-cr"
+      namespace: "{{ cpd_instance_namespace }}"
+    register: ccs_cr_lookup
+    until:
+      - ccs_cr_lookup.resources is defined
+      - ccs_cr_lookup.resources | length == 1
+      - ccs_cr_lookup.resources[0].status is defined
+      - ccs_cr_lookup.resources[0].status.ccsStatus is defined
+      - ccs_cr_lookup.resources[0].status.ccsStatus == "Completed"
+    retries: 50 # Just over 4 hours
+    delay: 300 # Every 5 minutes
 
 - name: "wait-ccs : Check that the CCS ccsStatus is 'Completed'"
   assert:

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-ccs.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-ccs.yml
@@ -152,6 +152,23 @@
       label_selectors: ["ibm-es-master=True"]
     register: statefulset_output
 
+  # We are aiming to catch this exception caused by a change in how ElasticSearch is managed by Cloud Pak for Data
+  # whereby in CPD 5.1 it starts to explicitly control the version of ElasticSearch, and sets it to an older version
+  # that the version it naturally would have been set to already, resulting in an unsupported downgrade.
+  #
+  # [2025-05-02T10:00:35,693][ERROR][o.o.b.OpenSearchUncaughtExceptionHandler] [elasticsea-0ac3-ib-6fb9-es-server-esnodes-0] uncaught exception in thread [main]
+  # org.opensearch.bootstrap.StartupException: java.lang.IllegalArgumentException: Could not load codec 'Lucene912'. Did you forget to add lucene-backward-codecs.jar?
+  #         at org.opensearch.bootstrap.OpenSearch.init(OpenSearch.java:185) ~[opensearch-2.17.0.jar:2.17.0]
+  #         at org.opensearch.bootstrap.OpenSearch.execute(OpenSearch.java:172) ~[opensearch-2.17.0.jar:2.17.0]
+  #         at org.opensearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:104) ~[opensearch-2.17.0.jar:2.17.0]
+  #         at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138) ~[opensearch-cli-2.17.0.jar:2.17.0]
+  #         at org.opensearch.cli.Command.main(Command.java:101) ~[opensearch-cli-2.17.0.jar:2.17.0]
+  #         at org.opensearch.bootstrap.OpenSearch.main(OpenSearch.java:138) ~[opensearch-2.17.0.jar:2.17.0]
+  #         at org.opensearch.bootstrap.OpenSearch.main(OpenSearch.java:104) ~[opensearch-2.17.0.jar:2.17.0]
+  # Caused by: java.lang.IllegalArgumentException: Could not load codec 'Lucene912'. Did you forget to add lucene-backward-codecs.jar?
+  #
+  # When this happens, the only solution we are aware of is to delete the ElasticSearch instance and allow it to be recreated fresh, 
+  # the alternative is to not upgrade Cloud Pak for Data until after it catches up with the version of ElasticSearch already in use.
   - name: "check if elasticsearch rescue is appropriate"
     set_fact:
        recover_elasticsearch: true


### PR DESCRIPTION
## Issue
<!-- Provide the ID numbers of issues related to this change. Please do not provide direct links to IBM-internal systems. If there are no issues related to this change, why are you working on it? -->

MASCORE-6233

## Description
<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->

Upgrading from CPD 5.0.0 to CPD 5.1.0 can cause a downgrade of elasticsearch from 2.18 to 2.17 which isn't supported. If we detect this problem we need to purge the elasticsearch cluster (delete statefulset and PVCs)

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

Watched an update and checked it went through the correct steps and ended up with a working CPD 5.1.0

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
