### PR TITLE
[patch] Adding Manage Foundation support to the docs

### DIFF
--- a/docs/playbooks/oneclick-manage.md
+++ b/docs/playbooks/oneclick-manage.md
@@ -32,11 +32,20 @@ Required environment variables
 
    `export MAS_APPWS_COMPONENTS="base=latest,health=latest"`
 
-   To enable Asset Investment Optimizer, optional feature of health. Set `MANAGE_AIO_FLAG` to `true`. By default this flag is set to `false` . This featue is only avalaible on Manage with health as a addon or on Health as a Standalone install.
+   To disable Asset Investment Optimizer, optional feature of health, set `MAS_APP_SETTINGS_AIO_FLAG` to `false`. By default this flag is set to `true` . This feature is only avalaible on Manage with health as a addon or on Health as a Standalone install. This feature is disabled on 9.1 and later.
 
-   `export MANAGE_AIO_FLAG=true`
+   `export MAS_APP_SETTINGS_AIO_FLAG=true`
 
 
+   **Note**:
+
+   To install Manage Foundation only (available on 9.1 or later), this environment variable needs to be exported:
+   
+   `export IS_FULL_MANAGE=false`
+   
+   Also, `MAS_APPWS_COMPONENTS` needs to be empty:
+   
+   `export MAS_APPWS_COMPONENTS=""`
 
 
 Optional Cloud Pak for Data Installation

--- a/docs/playbooks/oneclick-manage.md
+++ b/docs/playbooks/oneclick-manage.md
@@ -32,14 +32,14 @@ Required environment variables
 
    `export MAS_APPWS_COMPONENTS="base=latest,health=latest"`
 
-   To disable Asset Investment Optimizer, optional feature of health, set `MAS_APP_SETTINGS_AIO_FLAG` to `false`. By default this flag is set to `true` . This feature is only avalaible on Manage with health as a addon or on Health as a Standalone install. This feature is disabled on 9.1 and later.
+   To disable Asset Investment Optimizer, optional feature of health, set `MAS_APP_SETTINGS_AIO_FLAG` to `false`. By default this flag is set to `true` . This feature is only avalaible on Manage with health as a addon or on Health as a Standalone install. This feature is disabled on MAS Core 9.1 and later.
 
    `export MAS_APP_SETTINGS_AIO_FLAG=false`
 
 
    **Note**:
 
-   To install Manage Foundation only (available on 9.1 or later), this environment variable needs to be exported:
+   To install Manage Foundation only (available on MAS Core 9.1 or later), this environment variable needs to be exported:
    
    `export IS_FULL_MANAGE=false`
    

--- a/docs/playbooks/oneclick-manage.md
+++ b/docs/playbooks/oneclick-manage.md
@@ -34,7 +34,7 @@ Required environment variables
 
    To disable Asset Investment Optimizer, optional feature of health, set `MAS_APP_SETTINGS_AIO_FLAG` to `false`. By default this flag is set to `true` . This feature is only avalaible on Manage with health as a addon or on Health as a Standalone install. This feature is disabled on 9.1 and later.
 
-   `export MAS_APP_SETTINGS_AIO_FLAG=true`
+   `export MAS_APP_SETTINGS_AIO_FLAG=false`
 
 
    **Note**:

--- a/ibm/mas_devops/playbooks/oneclick_add_assist.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_assist.yml
@@ -4,6 +4,7 @@
 # Dependencies:
 # - ansible-playbook ibm.mas_devops.oneclick_core
 # - ansible-playbook ibm.mas_devops.oneclick_add_iot
+# - ansible-playbook ibm.mas_devops.oneclick_add_manage (MAS Core 9.1 or later)
 #
 - hosts: localhost
   any_errors_fatal: true

--- a/ibm/mas_devops/playbooks/oneclick_add_iot.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_iot.yml
@@ -3,6 +3,7 @@
 #
 # Dependencies:
 # - ansible-playbook ibm.mas_devops.oneclick_core
+# - ansible-playbook ibm.mas_devops.oneclick_add_manage (MAS Core 9.1 or later)
 #
 - hosts: localhost
   any_errors_fatal: true

--- a/ibm/mas_devops/playbooks/oneclick_add_manage.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_manage.yml
@@ -3,7 +3,7 @@
 #
 # Dependencies:
 # - ansible-playbook ibm.mas_devops.oneclick_core
-#  
+#
 # To install Manage Foundation only (available on 9.1 or later), this environment variable needs to be exported:
 # export IS_FULL_MANAGE=false
 # and MAS_APPWS_COMPONENTS needs to be empty or unset:

--- a/ibm/mas_devops/playbooks/oneclick_add_manage.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_manage.yml
@@ -3,6 +3,11 @@
 #
 # Dependencies:
 # - ansible-playbook ibm.mas_devops.oneclick_core
+#  
+# To install Manage Foundation only (available on 9.1 or later), this environment variable needs to be exported:
+# export IS_FULL_MANAGE=false
+# and MAS_APPWS_COMPONENTS needs to be empty or unset:
+# export MAS_APPWS_COMPONENTS=""
 #
 - hosts: localhost
   any_errors_fatal: true

--- a/ibm/mas_devops/playbooks/oneclick_add_monitor.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_monitor.yml
@@ -4,6 +4,7 @@
 # Dependencies:
 # - ansible-playbook ibm.mas_devops.oneclick_core
 # - ansible-playbook ibm.mas_devops.oneclick_iot
+# - ansible-playbook ibm.mas_devops.oneclick_add_manage (MAS Core 9.1 or later)
 #
 # Monitor will be configured to use the same db2 instance that IoT is using
 #

--- a/ibm/mas_devops/playbooks/oneclick_add_optimizer.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_optimizer.yml
@@ -3,6 +3,7 @@
 #
 # Dependencies:
 #  - ansible-playbook ibm.mas_devops.oneclick_core
+#  - ansible-playbook ibm.mas_devops.oneclick_add_manage (MAS Core 9.1 or later)
 
 - hosts: localhost
   any_errors_fatal: true

--- a/ibm/mas_devops/playbooks/oneclick_add_visualinspection.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_visualinspection.yml
@@ -3,6 +3,7 @@
 #
 # Dependencies:
 #  - ansible-playbook ibm.mas_devops.oneclick_core
+#  - ansible-playbook ibm.mas_devops.oneclick_add_manage (MAS Core 9.1 or later)
 
 - hosts: localhost
   any_errors_fatal: true

--- a/ibm/mas_devops/roles/suite_app_config/README.md
+++ b/ibm/mas_devops/roles/suite_app_config/README.md
@@ -52,7 +52,7 @@ Set the binding scope for the application workspace's JDBC binding (`system`, `a
 - Default: `system`
 
 ### is_full_manage
-If set to `true`, Manage Foundation will be installed instead of Full Manage (available on MAS 9.1 and later).
+If set to `false`, Manage Foundation will be installed instead of Full Manage (available on MAS 9.1 and later).
 
 - Optional
 - Environment Variable: `IS_FULL_MANAGE`

--- a/ibm/mas_devops/roles/suite_app_config/README.md
+++ b/ibm/mas_devops/roles/suite_app_config/README.md
@@ -52,7 +52,7 @@ Set the binding scope for the application workspace's JDBC binding (`system`, `a
 - Default: `system`
 
 ### is_full_manage
-If set to `false`, Manage Foundation will be installed instead of Full Manage (available on MAS 9.1 and later).
+If set to `false`, Manage Foundation will be installed instead of Full Manage (available on MAS Core 9.1 and later).
 
 - Optional
 - Environment Variable: `IS_FULL_MANAGE`

--- a/ibm/mas_devops/roles/suite_app_config/README.md
+++ b/ibm/mas_devops/roles/suite_app_config/README.md
@@ -51,6 +51,13 @@ Set the binding scope for the application workspace's JDBC binding (`system`, `a
 - Environment Variable: `MAS_APPWS_BINDINGS_JDBC`
 - Default: `system`
 
+### is_full_manage
+If set to `true`, Manage Foundation will be installed instead of Full Manage (available on MAS 9.1 and later).
+
+- Optional
+- Environment Variable: `IS_FULL_MANAGE`
+- Default: `true`
+
 ### mas_appws_components
 Defines the app components and versions to configure in the application workspace. Takes the form of key=value pairs seperated by a comma i.e. To install health within Manage set `base=latest,health=latest`
 


### PR DESCRIPTION
## Description
Adding Manage Foundation support to the docs

## Test Results
The oneclick_add_manage playbook was executed with `IS_FULL_MANAGE=false` and `MAS_APPWS_COMPONENTS` unset and Manage Foundation was successfully installed instead of Full Manage.

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
