### PR TITLE
[patch] Increase time for LicenseService to be in ready state

### DIFF
--- a/ibm/mas_devops/roles/sls/tasks/install/sls-verify.yml
+++ b/ibm/mas_devops/roles/sls/tasks/install/sls-verify.yml
@@ -30,7 +30,7 @@
         - sls_cr_result.resources[0].status.conditions is defined
         - sls_cr_result.resources[0].status.conditions | selectattr('type', 'equalto', 'Ready') | map(attribute='status') | list | length > 0
         - sls_cr_result.resources[0].status.conditions | selectattr('type', 'equalto', 'Ready')| map(attribute='status') | list | first == "True"
-      retries: 20 # 20 minutes before we give up
+      retries: 30 # 30 minutes before we give up
       delay: 60 # 1 minute
 
     - name: "Wait for LicenseService to be initialized (30s delay)"


### PR DESCRIPTION
## Issue
The api-licensing pod takes a long time to start, causing the SLS pod to fail.

## Description
In fvts390x using fyre cluster, the api-licensing pod takes a long time to start, causing the SLS pod to fail because the LicenseService exceeds its retry limit while waiting to become ready.
