### PR TITLE
[patch] Shorten and standardize s3 bucket access point name

### DIFF
--- a/ibm/mas_devops/roles/suite_manage_attachments_config/tasks/common/aws-setup-bucket-permissions.yml
+++ b/ibm/mas_devops/roles/suite_manage_attachments_config/tasks/common/aws-setup-bucket-permissions.yml
@@ -99,7 +99,7 @@
   import_role:
     name: ibm.mas_devops.aws_bucket_access_point
   vars:
-    aws_access_point_name: "{{ aws_bucket_name }}-read-write-access-point"
+    aws_access_point_name: "{{ aws_bucket_name }}-rw-access-point"
     aws_access_point_bucket_name: "{{ aws_bucket_name }}"
     aws_access_point_username: "{{ aws_bucket_read_write_username }}"
     aws_access_point_policy_actions:


### PR DESCRIPTION
## Issue
Access point names have a character limit, and if we're passing a fairly complex bucket name to the role, the read-only access point will be created, whereas the read-write access point will fail. 

Line 88 of this file creates a read-only access point with the name `{{ aws_bucket_name }}-ro-access-point`.

Best practice for the read-write version of this bucket's access point is `{{ aws_bucket_name }}-rw-access-point`.

## Description
Shortens and standardizes the read-write access point name.

## Test Results
No tests. Simple change.

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
