### PR TITLE
[patch] Increase retries for rhm-data-service readiness check in DRO

### DIFF
--- a/ibm/mas_devops/roles/dro/tasks/install-dro/main.yml
+++ b/ibm/mas_devops/roles/dro/tasks/install-dro/main.yml
@@ -237,7 +237,7 @@
     - rds_sts.resources[0].status is defined
     - rds_sts.resources[0].status.readyReplicas is defined
     - rds_sts.resources[0].status.readyReplicas == 3
-  retries: 30
+  retries: 40
   delay: 20 # seconds
 
 - name: "Wait for the ibm-data-reporter-operator-controller-manager to be ready"


### PR DESCRIPTION
## Issue
While checking regression in amd64 for power catalog, UDS pod is failing in mas personal fvt pipelines because rhm-data-service is taking longer time to be in ready state.

![image (42)](https://github.com/user-attachments/assets/3f82980f-194c-4020-8dc1-581cd292d2d6)


