### PR TITLE
[patch] refactor AI Broker tenant var names

### DIFF
--- a/ibm/mas_devops/roles/aibroker/defaults/main.yml
+++ b/ibm/mas_devops/roles/aibroker/defaults/main.yml
@@ -58,7 +58,7 @@ mas_aibroker_watsonxai_project_id: "{{ lookup('env', 'MAS_AIBROKER_WATSONXAI_PRO
 mas_aibroker_watsonx_action: "{{ lookup('env', 'MAS_AIBROKER_WATSONX_ACTION') | default('install', true) }}"
 mas_aibroker_watsonx_secret: "{{ mas_app_id }}-watsonxcfg"
 
-# S3
+# S3 - Optional shared S3 config. Tenant-level config takes precedence over this.
 mas_aibroker_s3_bucket_prefix: "{{ lookup('env', 'MAS_AIBROKER_S3_BUCKET_PREFIX') | default('', true) }}"
 mas_aibroker_s3_region: "{{ lookup('env', 'MAS_AIBROKER_S3_REGION') | default('', true) }}"
 mas_aibroker_s3_endpoint_url: "{{ lookup('env', 'MAS_AIBROKER_S3_ENDPOINT_URL') | default('', true) }}"

--- a/ibm/mas_devops/roles/aibroker/templates/aibroker/aibrokerapp.yml.j2
+++ b/ibm/mas_devops/roles/aibroker/templates/aibroker/aibrokerapp.yml.j2
@@ -32,6 +32,8 @@ spec:
             port: "{{ mas_aibroker_db_port }}"
             credentials_secret: "{{ mas_aibroker_mariadb_secret }}"
             database_name: "{{ mas_aibroker_db_secret_name }}"
+        
+        # Optional shared S3 config. Tenant-level config takes precedence over this.
         s3:
             bucketPrefix: "{{ mas_aibroker_s3_bucket_prefix }}"
             region: "{{ mas_aibroker_s3_region }}"

--- a/ibm/mas_devops/roles/aibroker_tenant/defaults/main.yml
+++ b/ibm/mas_devops/roles/aibroker_tenant/defaults/main.yml
@@ -33,14 +33,14 @@ mas_aibroker_watsonxai_url: "{{ lookup('env', 'MAS_AIBROKER_WATSONXAI_URL') }}"
 mas_aibroker_watsonxai_project_id: "{{ lookup('env', 'MAS_AIBROKER_WATSONXAI_PROJECT_ID') }}"
 mas_aibroker_watsonx_action: "{{ lookup('env', 'MAS_AIBROKER_WATSONX_ACTION') | default('install', true) }}"
 
-# S3
+# S3 - This config overrides any shared config defined for the AI Broker.
 mas_aibroker_s3_secret: "{{ mas_aibroker_tenant_name }}----s3-secret"
-mas_aibroker_s3_region: "{{ lookup('env', 'MAS_AIBROKER_S3_REGION') | default('', true) }}"
-mas_aibroker_s3_action: "{{ lookup('env', 'MAS_AIBROKER_S3_ACTION') | default('install', true) }}"
-mas_aibroker_s3_endpoint_url: "{{ lookup('env', 'MAS_AIBROKER_S3_ENDPOINT_URL') | default('', true) }}"
-mas_aibroker_s3_bucket_prefix: "{{ lookup('env', 'MAS_AIBROKER_S3_BUCKET_PREFIX') | default('', true) }}"
-mas_aibroker_s3_access_key: "{{ lookup('env', 'MAS_AIBROKER_S3_ACCESS_KEY') }}"
-mas_aibroker_s3_secret_key: "{{ lookup('env', 'MAS_AIBROKER_S3_SECRET_KEY') }}"
+mas_aibroker_s3_region: "{{ lookup('env', 'MAS_AIBROKER_TENANT_S3_REGION') | default('', true) }}"
+mas_aibroker_s3_action: "{{ lookup('env', 'MAS_AIBROKER_TENANT_S3_ACTION') | default('install', true) }}"
+mas_aibroker_s3_endpoint_url: "{{ lookup('env', 'MAS_AIBROKER_TENANT_S3_ENDPOINT_URL') | default('', true) }}"
+mas_aibroker_s3_bucket_prefix: "{{ lookup('env', 'MAS_AIBROKER_TENANT_S3_BUCKET_PREFIX') | default('', true) }}"
+mas_aibroker_s3_access_key: "{{ lookup('env', 'MAS_AIBROKER_TENANT_S3_ACCESS_KEY') }}"
+mas_aibroker_s3_secret_key: "{{ lookup('env', 'MAS_AIBROKER_TENANT_S3_SECRET_KEY') }}"
 
 # SAAS
 mas_aibroker_saas: "{{ lookup('env', 'MAS_AIBROKER_SAAS') | default('false', true) | bool }}"


### PR DESCRIPTION
## Issue
MASAIB-862

## Description
* Put the word "TENANT" in the environment variables for tenant S3 configuration. This avoids clashes with the variables for configuring shared S3 configuration in the AI Broker.
* Add some comments to clarify the distinction between AI Broker-level and tenant-level S3 configuration.

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
