### PR TITLE
[patch] revert changes in mref db2configdb.sh.j2

### DIFF
--- a/ibm/mas_devops/roles/suite_db2_setup_for_facilities/templates/db2/scripts/db2configdb.sh.j2
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_facilities/templates/db2/scripts/db2configdb.sh.j2
@@ -12,7 +12,7 @@
 # set parameters used in the script
 
 DB2_DBNAME={{ db2_dbname }}
-DB2_INSTNAME={{ db2_instance_name }}
+DB2_INSTNAME='db2inst1'
 DB2_HOME='/mnt/blumeta0/home/db2inst1/sqllib'
 DB2_USER={{ db2_username }}
 


### PR DESCRIPTION
## Description
This db2configdb.sh.j2 expects to be db2inst1. this was wrongly changed.

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
