### PR TITLE
[patch] changing default MREF db user to tridata

### DIFF
--- a/ibm/mas_devops/roles/suite_db2_setup_for_facilities/README.md
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_facilities/README.md
@@ -40,7 +40,7 @@ The name of the Manage schema where the hack should be targeted in.
 
 - Optional
 - Environment Variable: None
-- Default Value: `tridata`
+- Default Value: `TRIDATA`
 
 ### db2_tablespace_data_size
 The size of the tablespace data in the database.

--- a/ibm/mas_devops/roles/suite_db2_setup_for_facilities/README.md
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_facilities/README.md
@@ -26,7 +26,7 @@ The username that will be used to connect to the database specified by `db2_dbna
 
 - Optional
 - Environment Variable: None
-- Default Value: `db2inst1`
+- Default Value: `tridata`
 
 ### db2_dbname
 The name of the database in the instance to connect to when executing the setup script.

--- a/ibm/mas_devops/roles/suite_db2_setup_for_facilities/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_facilities/defaults/main.yml
@@ -1,7 +1,7 @@
 db2_instance_name: "{{ lookup('env', 'DB2_INSTANCE_NAME') }}"
 db2_namespace: "{{ lookup('env', 'DB2_NAMESPACE') | default('db2u', true) }}"
 db2_dbname: "{{ lookup('env', 'DB2_DBNAME') | default('BLUDB', true) }}"
-db2_schema: "{{ lookup('env', 'DB2_SCHEMA') | default('tridata', true) }}"
+db2_schema: "{{ lookup('env', 'DB2_SCHEMA') | default('TRIDATA', true) }}"
 db2_username: "{{ lookup('env', 'DB2_USERNAME') | default('tridata', true) }}"
 
 # Variables for db2_dbconfig

--- a/ibm/mas_devops/roles/suite_db2_setup_for_facilities/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_facilities/defaults/main.yml
@@ -2,7 +2,7 @@ db2_instance_name: "{{ lookup('env', 'DB2_INSTANCE_NAME') }}"
 db2_namespace: "{{ lookup('env', 'DB2_NAMESPACE') | default('db2u', true) }}"
 db2_dbname: "{{ lookup('env', 'DB2_DBNAME') | default('BLUDB', true) }}"
 db2_schema: "{{ lookup('env', 'DB2_SCHEMA') | default('tridata', true) }}"
-db2_username: "{{ lookup('env', 'DB2_USERNAME') | default('db2inst1', true) }}"
+db2_username: "{{ lookup('env', 'DB2_USERNAME') | default('tridata', true) }}"
 
 # Variables for db2_dbconfig
 db2_config_version: "{{ lookup('env', 'DB2_CONFIG_VERSION') | default('1.0.0', true) }}"


### PR DESCRIPTION
## Description

the default DB user should not be admin user,  changing default to `tridata`.

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
