### PR TITLE
[patch] add new instance label

### DIFF
--- a/ibm/mas_devops/roles/aibroker/templates/aibroker/aibrokerapp.yml.j2
+++ b/ibm/mas_devops/roles/aibroker/templates/aibroker/aibrokerapp.yml.j2
@@ -7,6 +7,7 @@ metadata:
     labels:
         mas.ibm.com/applicationId: aibroker
         mas.ibm.com/instanceId: "{{ mas_instance_id }}"
+        app.kubernetes.io/instance="{{ mas_instance_id }}"
 spec:
     settings:
         icr:

--- a/ibm/mas_devops/roles/aibroker/templates/aibroker/aibrokerapp.yml.j2
+++ b/ibm/mas_devops/roles/aibroker/templates/aibroker/aibrokerapp.yml.j2
@@ -7,7 +7,7 @@ metadata:
     labels:
         mas.ibm.com/applicationId: aibroker
         mas.ibm.com/instanceId: "{{ mas_instance_id }}"
-        app.kubernetes.io/instance="{{ mas_instance_id }}"
+        app.kubernetes.io/instance: "{{ mas_instance_id }}"
 spec:
     settings:
         icr:


### PR DESCRIPTION
## Issue
https://jsw.ibm.com/browse/MASAIB-768

## Description
Ensure the AI Broker operator has the label `app.kubernetes.io/instance`. This uniquely identifies the operator instance if for example multiple instances are running in the cluster. This is intended to be a replacement for the `mas.ibm.com/instanceId` label as the AI Service is designed to be independent from MAS.

## Test Results
N/A

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
