### PR TITLE
[patch] rename dns entry pmscheduleragent to maintenanceagent for facilties

### DIFF
--- a/ibm/mas_devops/roles/suite_certs/templates/dnsentries.yml.j2
+++ b/ibm/mas_devops/roles/suite_certs/templates/dnsentries.yml.j2
@@ -34,7 +34,7 @@ nowildcard:
   -  incomingmailagent.{{ mas_workspace_id }}.facilities
   -  objectmigrationagent.{{ mas_workspace_id }}.facilities
   -  objectpublishagent.{{ mas_workspace_id }}.facilities
-  -  pmscheduleragent.{{ mas_workspace_id }}.facilities
+  -  maintenanceagent.{{ mas_workspace_id }}.facilities
   -  reportqueueagent.{{ mas_workspace_id }}.facilities
   -  reservesmtpagent.{{ mas_workspace_id }}.facilities
   -  snmpagent.{{ mas_workspace_id }}.facilities


### PR DESCRIPTION
## Description

pmscheduleragent in renamed to maintenanceagent in MREF.

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
