### PR TITLE
[patch] add instance label to AI workspace CR

### DIFF
--- a/ibm/mas_devops/roles/aibroker_tenant/templates/aibroker/aibrokerworkspace.yml.j2
+++ b/ibm/mas_devops/roles/aibroker_tenant/templates/aibroker/aibrokerworkspace.yml.j2
@@ -7,6 +7,7 @@ metadata:
     labels:
         mas.ibm.com/applicationId: aibroker
         mas.ibm.com/instanceId: "{{ mas_instance_id }}"
+        app.kubernetes.io/instance: "{{ mas_instance_id }}"
 {% if custom_labels is defined and custom_labels.items() %}
 {% for key, value in custom_labels.items() %}
         "{{ key }}": "{{ value }}"


### PR DESCRIPTION
## Issue
MASAIB-768

## Description
Ensure the AI Broker operator has the label `app.kubernetes.io/instance`. This uniquely identifies the operator instance if for example multiple instances are running in the cluster. This is intended to be a replacement for the `mas.ibm.com/instanceId` label as the AI Service is designed to be independent from MAS.

## Test Results
N/A

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
