### PR TITLE
[patch] increasing the default wait and retry for MREF workspace to get ready

### DIFF
--- a/ibm/mas_devops/roles/suite_app_config/vars/facilities.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/facilities.yml
@@ -3,5 +3,6 @@ mas_app_ws_fqn: facilitiesworkspaces.apps.mas.ibm.com
 mas_app_ws_apiversion: apps.mas.ibm.com/v1
 mas_app_ws_kind: FacilitiesWorkspace
 
-mas_app_cfg_delay: "{{ lookup('env', 'MAS_APP_CFG_DELAY') | default(120, true)}}"
-mas_app_cfg_retries: "{{ lookup('env', 'MAS_APP_CFG_RETRIES') | default(30, true)}}"
+# MREF would take 3 - 5 hours.
+mas_app_cfg_delay: "{{ lookup('env', 'MAS_APP_CFG_DELAY') | default(300, true)}}" # ~5 minutes
+mas_app_cfg_retries: "{{ lookup('env', 'MAS_APP_CFG_RETRIES') | default(60, true)}}" # ~5 hours


### PR DESCRIPTION
## Description

MREF workspace takes 3-5 hours depending upon the size of the app, cluster and performace of db. So increasing the max wait time to 5 hours to allow FacilitiesWorkspace to get activated.

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
