### PR TITLE
[major] Removal of CPD related dependencies from Assist playbook

### DIFF
--- a/ibm/mas_devops/playbooks/oneclick_add_assist.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_assist.yml
@@ -1,6 +1,4 @@
 ---
-# Add Assist application to an existing MAS Core+IoT installation
-#
 # Dependencies:
 # - ansible-playbook ibm.mas_devops.oneclick_core
 # - ansible-playbook ibm.mas_devops.oneclick_add_manage (MAS Core 9.1 or later)

--- a/ibm/mas_devops/playbooks/oneclick_add_assist.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_assist.yml
@@ -8,8 +8,6 @@
   vars:
     # Application Dependencies
     cos_type: ibm
-   # cpd_service_name: wd
-   # cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default('4.8.0', true) }}"
 
     # Application Installation
     mas_app_id: assist
@@ -18,9 +16,6 @@
     mas_app_spec:
       bindings:
         objectstorage: system
-    #mas_appws_spec:
-     # bindings:
-      #  watsondiscovery: application
 
     # Application Configuration
     mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') | default('masdev', true) }}"
@@ -37,8 +32,6 @@
 
   roles:
     - ibm.mas_devops.cos
-    #- ibm.mas_devops.cp4d
-    #- ibm.mas_devops.cp4d_service
     - ibm.mas_devops.suite_config
     - ibm.mas_devops.suite_app_install
     - ibm.mas_devops.suite_app_config

--- a/ibm/mas_devops/playbooks/oneclick_add_assist.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_assist.yml
@@ -10,8 +10,8 @@
   vars:
     # Application Dependencies
     cos_type: ibm
-    cpd_service_name: wd
-    cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default('4.8.0', true) }}"
+   # cpd_service_name: wd
+   # cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default('4.8.0', true) }}"
 
     # Application Installation
     mas_app_id: assist
@@ -20,9 +20,9 @@
     mas_app_spec:
       bindings:
         objectstorage: system
-    mas_appws_spec:
-      bindings:
-        watsondiscovery: application
+    #mas_appws_spec:
+     # bindings:
+      #  watsondiscovery: application
 
     # Application Configuration
     mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') | default('masdev', true) }}"
@@ -40,7 +40,7 @@
   roles:
     - ibm.mas_devops.cos
     - ibm.mas_devops.cp4d
-    - ibm.mas_devops.cp4d_service
-    - ibm.mas_devops.suite_config
+    #- ibm.mas_devops.cp4d_service
+    #- ibm.mas_devops.suite_config
     - ibm.mas_devops.suite_app_install
     - ibm.mas_devops.suite_app_config

--- a/ibm/mas_devops/playbooks/oneclick_add_assist.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_assist.yml
@@ -39,8 +39,8 @@
 
   roles:
     - ibm.mas_devops.cos
-    - ibm.mas_devops.cp4d
+    #- ibm.mas_devops.cp4d
     #- ibm.mas_devops.cp4d_service
-    #- ibm.mas_devops.suite_config
+    - ibm.mas_devops.suite_config
     - ibm.mas_devops.suite_app_install
     - ibm.mas_devops.suite_app_config

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/assist.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/assist.yml
@@ -1,5 +1,5 @@
 ---
 # Default application spec for Assist
-mas_appws_spec:
-  bindings:
-    watsondiscovery: application
+#mas_appws_spec:
+ # bindings:
+  #  watsondiscovery: application

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/assist.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/assist.yml
@@ -1,5 +1,1 @@
----
-# Default application spec for Assist
-#mas_appws_spec:
- # bindings:
-  #  watsondiscovery: application
+


### PR DESCRIPTION
## Issue
Removal of all CPD-related components and dependencies.

[ASSIST-517](https://jsw.ibm.com/browse/ASSIST-517) 
The Salesforce customer Case ID: TS019208936 

## Description
As per the customer's request to proceed with the installation of Assist without CPD, we have updated the Ansible playbook accordingly. The following changes were made:

Removed all CPD-related components and dependencies.
Removed Watson Discovery bindings.
Validated the playbook to ensure Assist installs correctly without CPD.
The updated playbook was tested successfully, and Assist is now installable as requested.

## Test Results
Successfully installed Assist after removing all CPD and Watson-related bindings and variables. The deployment completed without issues, and the application is functioning as expected.

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
