### PR TITLE
[patch] Changes for OCP 4.18 AWS IAM ROLE Creation process

### DIFF
--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/rosa/provision_rosa.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/rosa/provision_rosa.yml
@@ -46,9 +46,10 @@
 
 # 4.1 Create Account Roles
 # -----------------------------------------------------------------------------
-- name: "rosa/account-role : Set account role prefix"
+- name: "rosa/account-role : Set major.minor version and prefix"
   set_fact:
-    rosa_account_role_prefix: "ocp{{ ocp_version }}"
+    rosa_major_minor_version: "{{ ocp_version.split('.')[:2] | join('.') }}"
+    rosa_account_role_prefix: "ocp{{ ocp_version.split('.')[:2] | join('') }}"
 
 - name: "rosa/account-role : Check if account roles already exist"
   shell: rosa list account-roles -o json

--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/rosa/provision_rosa.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/rosa/provision_rosa.yml
@@ -46,37 +46,12 @@
 
 # 4.1 Create Account Roles
 # -----------------------------------------------------------------------------
-- name: "rosa/account-role : Set major.minor version and prefix"
+- name: "rosa : Extract major.minor from ocp_version"
   set_fact:
-    rosa_major_minor_version: "{{ ocp_version.split('.')[:2] | join('.') }}"
-    rosa_account_role_prefix: "ocp{{ ocp_version.split('.')[:2] | join('') }}"
+    ocp_major_minor: "{{ ocp_version.split('.')[:2] | join('.') }}"
+    rosa_account_role_prefix: "{{ cluster_name }}-ocp{{ ocp_version.split('.')[:2] | join('') }}"
 
-- name: "rosa/account-role : Check if account roles already exist"
-  shell: rosa list account-roles -o json
-  register: rosa_account_roles
-  failed_when: false
-
-- name: "rosa/account-role : Determine if roles with prefix exist"
-  set_fact:
-    rosa_account_roles_exist: >-
-      {{
-        (rosa_account_roles.stdout | from_json)
-        | selectattr('Name', 'search', rosa_account_role_prefix)
-        | list
-        | length > 0
-      }}
-
-- name: "rosa/account-role : Debug role creation status"
-  debug:
-    msg: >-
-      {{
-        'Account roles already exist with prefix ' ~ rosa_account_role_prefix
-        if rosa_account_roles_exist
-        else 'Creating account roles with prefix ' ~ rosa_account_role_prefix
-      }}
-
-- name: "rosa/account-role : Create account roles"
-  when: not rosa_account_roles_exist
+- name: "rosa : Create account roles"
   shell: >
     rosa create account-roles
     --mode auto

--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/rosa/provision_rosa.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/rosa/provision_rosa.yml
@@ -82,6 +82,7 @@
     --mode auto
     --yes
     --prefix {{ rosa_account_role_prefix }}
+    --version {{ ocp_major_minor }}
 
 
 # 5. Check if the cluster is already provisioned

--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/rosa/provision_rosa.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/rosa/provision_rosa.yml
@@ -44,6 +44,45 @@
     msg: "{{ rosa_whoami_result }}"
 
 
+# 4.1 Create Account Roles
+# -----------------------------------------------------------------------------
+- name: "rosa/account-role : Set account role prefix"
+  set_fact:
+    rosa_account_role_prefix: "ocp{{ ocp_version }}"
+
+- name: "rosa/account-role : Check if account roles already exist"
+  shell: rosa list account-roles -o json
+  register: rosa_account_roles
+  failed_when: false
+
+- name: "rosa/account-role : Determine if roles with prefix exist"
+  set_fact:
+    rosa_account_roles_exist: >-
+      {{
+        (rosa_account_roles.stdout | from_json)
+        | selectattr('Name', 'search', rosa_account_role_prefix)
+        | list
+        | length > 0
+      }}
+
+- name: "rosa/account-role : Debug role creation status"
+  debug:
+    msg: >-
+      {{
+        'Account roles already exist with prefix ' ~ rosa_account_role_prefix
+        if rosa_account_roles_exist
+        else 'Creating account roles with prefix ' ~ rosa_account_role_prefix
+      }}
+
+- name: "rosa/account-role : Create account roles"
+  when: not rosa_account_roles_exist
+  shell: >
+    rosa create account-roles
+    --mode auto
+    --yes
+    --prefix {{ rosa_account_role_prefix }}
+
+
 # 5. Check if the cluster is already provisioned
 # -----------------------------------------------------------------------------
 # State: pending -> installing -> ready


### PR DESCRIPTION
📡**Issue#:** MASR-3736

✅**Description:**✅
This merge request contains the alteration in role name **OCP_PROVISION (ROSA)** to create role for ROSA Cluster being utilised by FVTSAAS and FVTSAAS-TRANSITION.

This edition will seprate the IAM roles utilised for scheduling and operating both FVTSAAS and FVTSAAS-TRANSITION environment. Also in case, in future if we upgradge the version (Major/Minor), It will create the AWS IAM role as per the OCP_VERSION we define in environment pipeline. 

⚒️**Test Result:**🛠️
The changes of this role has been tested on FVTSAAS_TRANSITION on the date 24th MAY, 3:55 PM UTC, Saturday. The Created role can be seen and reviewed in respective AWS Account, region (for EC2 inspection as both environments are deployed in diff region).

**Owner of issue#:** @IanBoden 
**Reviewer:** @whitfiea 