### PR TITLE
[minor] ability to set operator log level

### DIFF
--- a/ibm/mas_devops/roles/aibroker/defaults/main.yml
+++ b/ibm/mas_devops/roles/aibroker/defaults/main.yml
@@ -8,6 +8,9 @@ mas_config_dir: "{{ lookup('env', 'MAS_CONFIG_DIR') }}"
 # -----------------------------------------------------------------------------
 custom_labels: "{{ lookup('env', 'CUSTOM_LABELS') | default(None, true) | string | ibm.mas_devops.string2dict() }}"
 
+# Operator loggging: 0 for errors, 1 for warnings, 2 for info, 3 to 7 for debug.
+mas_aibroker_operator_log_level: "{{ lookup('env', 'MAS_AIBROKER_OPERATOR_LOG_LEVEL') | default('2', true) }}"
+
 # Source container registry
 # -----------------------------------------------------------------------------
 # mas_icr_cp: "{{ lookup('env', 'MAS_ICR_CP') | default('cp.icr.io/cp', true) }}"

--- a/ibm/mas_devops/roles/aibroker/defaults/main.yml
+++ b/ibm/mas_devops/roles/aibroker/defaults/main.yml
@@ -8,7 +8,7 @@ mas_config_dir: "{{ lookup('env', 'MAS_CONFIG_DIR') }}"
 # -----------------------------------------------------------------------------
 custom_labels: "{{ lookup('env', 'CUSTOM_LABELS') | default(None, true) | string | ibm.mas_devops.string2dict() }}"
 
-# Operator loggging: 0 for errors, 1 for warnings, 2 for info, 3 to 7 for debug.
+# Operator logging: 0 for errors, 1 for warnings, 2 for info, 3 to 7 for debug.
 mas_aibroker_operator_log_level: "{{ lookup('env', 'MAS_AIBROKER_OPERATOR_LOG_LEVEL') | default('2', true) }}"
 
 # Source container registry

--- a/ibm/mas_devops/roles/aibroker/templates/aibroker/aibrokerapp.yml.j2
+++ b/ibm/mas_devops/roles/aibroker/templates/aibroker/aibrokerapp.yml.j2
@@ -4,6 +4,8 @@ kind: AiBrokerApp
 metadata:
     name: "{{ mas_instance_id }}"
     namespace: "{{ aibroker_namespace }}"
+    annotations:
+        ansible.sdk.operatorframework.io/verbosity: "{{ mas_aibroker_operator_log_level }}"
     labels:
         mas.ibm.com/applicationId: aibroker
         mas.ibm.com/instanceId: "{{ mas_instance_id }}"

--- a/ibm/mas_devops/roles/aibroker_tenant/defaults/main.yml
+++ b/ibm/mas_devops/roles/aibroker_tenant/defaults/main.yml
@@ -9,7 +9,7 @@ mas_icr_cpopen: "{{ lookup('env', 'MAS_ICR_CPOPEN') | default('icr.io/cpopen', t
 # Custom labels for resources
 custom_labels: "{{ lookup('env', 'CUSTOM_LABELS') | default(None, true) | string | ibm.mas_devops.string2dict() }}"
 
-# Operator loggging: 0 for errors, 1 for warnings, 2 for info, 3 to 7 for debug.
+# Operator logging: 0 for errors, 1 for warnings, 2 for info, 3 to 7 for debug.
 mas_aibroker_operator_log_level: "{{ lookup('env', 'MAS_AIBROKER_OPERATOR_LOG_LEVEL') | default('2', true) }}"
 
 aibroker_name: "aibroker"

--- a/ibm/mas_devops/roles/aibroker_tenant/defaults/main.yml
+++ b/ibm/mas_devops/roles/aibroker_tenant/defaults/main.yml
@@ -9,6 +9,9 @@ mas_icr_cpopen: "{{ lookup('env', 'MAS_ICR_CPOPEN') | default('icr.io/cpopen', t
 # Custom labels for resources
 custom_labels: "{{ lookup('env', 'CUSTOM_LABELS') | default(None, true) | string | ibm.mas_devops.string2dict() }}"
 
+# Operator loggging: 0 for errors, 1 for warnings, 2 for info, 3 to 7 for debug.
+mas_aibroker_operator_log_level: "{{ lookup('env', 'MAS_AIBROKER_OPERATOR_LOG_LEVEL') | default('2', true) }}"
+
 aibroker_name: "aibroker"
 aibroker_namespace: "{{ lookup('env', 'MAS_AIBROKER_NAMESPACE') | default('mas-{}-aibroker'.format(mas_instance_id), true) }}"
 aibroker_channel: "{{ lookup('env', 'MAS_AIBROKER_CHANNEL') }}"

--- a/ibm/mas_devops/roles/aibroker_tenant/templates/aibroker/aibrokerworkspace.yml.j2
+++ b/ibm/mas_devops/roles/aibroker_tenant/templates/aibroker/aibrokerworkspace.yml.j2
@@ -4,6 +4,8 @@ kind: AiBrokerWorkspace
 metadata:
     name: "{{ tenantNamespace }}"
     namespace: "{{ aibroker_namespace }}"
+    annotations:
+        ansible.sdk.operatorframework.io/verbosity: "{{ mas_aibroker_operator_log_level }}"
     labels:
         mas.ibm.com/applicationId: aibroker
         mas.ibm.com/instanceId: "{{ mas_instance_id }}"


### PR DESCRIPTION
## Issue
MASAIB-768

## Description
Add the ability to set the AI Broker operator log level (applies to both app and workspace operators). See https://sdk.operatorframework.io/docs/building-operators/ansible/reference/advanced_options/#ansible-verbosity

## Test Results
Set level to 7 and saw debug logs in the operator output.

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
