### PR TITLE
[patch] Add OCP 4.18 into rotation

### DIFF
--- a/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
@@ -29,12 +29,12 @@
     ocp_version: "{{ rotate_ocp_version[ansible_date_time['weekday']] ~ ('_openshift' if cluster_type == 'roks' else '') }}"
   vars:
     rotate_ocp_version:
-      Monday: 4.17
-      Tuesday: 4.15
-      Wednesday: 4.14
-      Thursday: 4.16
-      Friday: 4.15
-      Saturday: 4.17
+      Monday: 4.18
+      Tuesday: 4.17
+      Wednesday: 4.16
+      Thursday: 4.15
+      Friday: 4.14
+      Saturday: 4.18
       Sunday: 4.16
 
 - name: "Set default OCP version"

--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/fyre/provision_fyre.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/fyre/provision_fyre.yml
@@ -55,11 +55,7 @@
     force_basic_auth: yes
     validate_certs: false
   register: _cluster_exist
-  failed_when: _cluster_exist.status == 403
-
-- name: "fyre : Debug cluster lookup"
-  debug:
-    var: _cluster_exist
+  failed_when: _cluster_exist.status in [403, 401]  # Forbidden, Unauthorized
 
 
 # 4. Deploy the OCP+ cluster


### PR DESCRIPTION
- Improves error handling when provisioning FYRE clusters with an invalid/expired API key
- Adds OCP 4.18 into the `rotate` policy for `ocp_provision` role