### PR TITLE
[patch] add retries to MREF db2 oc commands

### DIFF
--- a/ibm/mas_devops/roles/suite_db2_setup_for_facilities/tasks/db2/preparedb.yml
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_facilities/tasks/db2/preparedb.yml
@@ -39,29 +39,47 @@
   ansible.builtin.shell: |
     oc exec -n {{ db2_namespace }} -ti {{ db2_pod_name }} -- sudo chmod 777 /tmp/prepare_db_files/create-tablespaces.sql /tmp/prepare_db_files/create-schema.sql /tmp/prepare_db_files/db2configdb.sh
   register: shell_status
+  until: shell_status.rc == 0
+  retries: 5
+  delay: 60 # seconds
 
 - name: Disable HA for maintanance
   ansible.builtin.shell: |
     oc exec -n {{ db2_namespace }} -ti {{ db2_pod_name }} -- sudo wvcli system disable -m "Disable HA before Db2 maintenance"
   register: shell_status
+  until: shell_status.rc == 0
+  retries: 5
+  delay: 60 # seconds
 
 - name: Executing db2configdb.sh
   ansible.builtin.shell: |
     oc exec -n {{ db2_namespace }} -ti {{ db2_pod_name }} -- su - db2inst1 -c "sh /tmp/prepare_db_files/db2configdb.sh "
   register: shell_status
+  until: shell_status.rc == 0
+  retries: 5
+  delay: 60 # seconds
 
 - name: Executing create-tablespaces.sql
   ansible.builtin.shell: |
     oc exec -n {{ db2_namespace }} -ti {{ db2_pod_name }} -- su - db2inst1 -c "db2 -tvf /tmp/prepare_db_files/create-tablespaces.sql "
   register: shell_status
+  until: shell_status.rc == 0
+  retries: 5
+  delay: 60 # seconds
 
 - name: Executing create-schema.sql
   when: db2_schema is defined
   ansible.builtin.shell: |
     oc exec -n {{ db2_namespace }} -ti {{ db2_pod_name }} -- su - db2inst1 -c "db2 -tvf /tmp/prepare_db_files/create-schema.sql "
   register: shell_status
+  until: shell_status.rc == 0
+  retries: 5
+  delay: 60 # seconds
 
 - name: Enable HA after maintenance
   ansible.builtin.shell: |
     oc exec -n {{ db2_namespace }} -ti {{ db2_pod_name }} -- sudo wvcli system enable -m "Enable HA after Db2 maintenance"
   register: shell_status
+  until: shell_status.rc == 0
+  retries: 5
+  delay: 60 # seconds

--- a/ibm/mas_devops/roles/suite_db2_setup_for_facilities/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_facilities/tasks/main.yml
@@ -70,23 +70,11 @@
       - "Db2 database name ...................... {{ db2_dbname }}"
       - "Db2 Schema name ........................ {{ db2_schema }}"
 
-# 4. Determine if the schema has been created
-# -----------------------------------------------------------------------------
-- name: Checking if schema is already created
-  kubernetes.core.k8s_exec:
-    namespace: "{{ db2_namespace }}"
-    pod: "{{ db2_pod_name }}"
-    container: db2u
-    command: su - db2inst1 -c "db2 connect to {{ db2_dbname }} >/dev/null && db2 'select schemaname from syscat.schemata' | grep '{{ db2_schema }}' | tr -d ' ' " > /tmp/ts_numd.txt
-  register: db2_output
-  retries: 10
-  delay: 60
 
-# 5. Execute DB2 config enforcement
+# 4. Execute DB2 config enforcement
 # -----------------------------------------------------------------------------
-- include_tasks: tasks/apply-db2-dbconfig.yml
-  when: ( db2_output.stdout_lines | length ) == 0
+- name: apply Real Estate and Facilities configurations for db2
+  include_tasks: tasks/apply-db2-dbconfig.yml
 
 - name: run prepare DB scripts
   include_tasks: db2/preparedb.yml
-  when: ( db2_output.stdout_lines | length ) == 0


### PR DESCRIPTION
## Issue
It was reported a bug in the fvt pipelines regarding oc commands that were not retrying. Therefore, it was added `retries` and `delay` in all `oc exec` tasks.
 
## Description
- Removal of the schema check, since the db2 role was integrated with the configuration steps.
- Adding retries in the `oc exec` functions.

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
