### PR TITLE
[patch] update routes for aibroker

### DIFF
--- a/ibm/mas_devops/roles/aibroker/tasks/main.yml
+++ b/ibm/mas_devops/roles/aibroker/tasks/main.yml
@@ -4,16 +4,16 @@
 
 # Get cluster domain
 # -----------------------------------------------------------------------------
-- name: "Get cluster domain"
+- name: "Get cluster subdomain"
   kubernetes.core.k8s_info:
     api_version: config.openshift.io/v1
-    kind: DNS
+    kind: Ingress
     name: cluster
-  register: _cluster_dns
+  register: _cluster_subdomain
 
-- name: "Set fact: cluster domain"
+- name: "Set fact: cluster subdomain"
   set_fact:
-    cluster_domain: "{{ _cluster_dns.resources[0].spec.baseDomain }}"
+    cluster_domain: "{{ _cluster_subdomain.resources[0].spec.domain }}"
 
 - name: "Debug: cluster domain"
   debug:


### PR DESCRIPTION
## Issue
https://jsw.ibm.com/browse/MASAIB-1017

## Description
Earlier,it is contains mas instance id and `apps`
When we are looking in DNS like:

aibroker.aibrokerdev.cp.fyre.ibm.com
*.aibroker.aibrokerdev.cp.fyre.ibm.com
*.api.aibroker.aibrokerdev.cp.fyre.ibm.com

We fixed the route to looks like this: aibroker.aibrokerdev.cp.fyre.ibm.com

## Test Results
This is tested on fyre cluster

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
