### PR TITLE
[patch] increase retries for db2 facilities

### DIFF
--- a/ibm/mas_devops/roles/suite_db2_setup_for_facilities/tasks/apply-db2-config-settings.yml
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_facilities/tasks/apply-db2-config-settings.yml
@@ -41,5 +41,5 @@
     oc exec -n {{db2_namespace}} {{db2_pod_name}} -- su -lc 'db2 get db cfg for {{ db2_dbname }} | grep "(STRING_UNITS) = CODEUNITS32"' db2inst1
   register: check_cmds_status
   until: check_cmds_status.rc == 0
-  retries: 5
+  retries: 20
   delay: 30 # seconds

--- a/ibm/mas_devops/roles/suite_db2_setup_for_facilities/tasks/apply-db2-config-version.yml
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_facilities/tasks/apply-db2-config-version.yml
@@ -32,7 +32,7 @@
   register: _db2_instance_engn_svc
   until:
     - _db2_instance_engn_svc.resources[0] is defined
-  retries: 15 # approx 5 minutes before we give up
+  retries: 30 # approx 5 minutes before we give up
   delay: 20 # seconds
 
 - name: Update DB2 configmaps

--- a/ibm/mas_devops/roles/suite_db2_setup_for_facilities/tasks/db2/preparedb.yml
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_facilities/tasks/db2/preparedb.yml
@@ -40,7 +40,7 @@
     oc exec -n {{ db2_namespace }} -ti {{ db2_pod_name }} -- sudo chmod 777 /tmp/prepare_db_files/create-tablespaces.sql /tmp/prepare_db_files/create-schema.sql /tmp/prepare_db_files/db2configdb.sh
   register: shell_status
   until: shell_status.rc == 0
-  retries: 5
+  retries: 10
   delay: 60 # seconds
 
 - name: Disable HA for maintanance
@@ -48,7 +48,7 @@
     oc exec -n {{ db2_namespace }} -ti {{ db2_pod_name }} -- sudo wvcli system disable -m "Disable HA before Db2 maintenance"
   register: shell_status
   until: shell_status.rc == 0
-  retries: 5
+  retries: 10
   delay: 60 # seconds
 
 - name: Executing db2configdb.sh
@@ -56,7 +56,7 @@
     oc exec -n {{ db2_namespace }} -ti {{ db2_pod_name }} -- su - db2inst1 -c "sh /tmp/prepare_db_files/db2configdb.sh "
   register: shell_status
   until: shell_status.rc == 0
-  retries: 5
+  retries: 10
   delay: 60 # seconds
 
 - name: Executing create-tablespaces.sql
@@ -64,7 +64,7 @@
     oc exec -n {{ db2_namespace }} -ti {{ db2_pod_name }} -- su - db2inst1 -c "db2 -tvf /tmp/prepare_db_files/create-tablespaces.sql "
   register: shell_status
   until: shell_status.rc == 0
-  retries: 5
+  retries: 10
   delay: 60 # seconds
 
 - name: Executing create-schema.sql
@@ -73,7 +73,7 @@
     oc exec -n {{ db2_namespace }} -ti {{ db2_pod_name }} -- su - db2inst1 -c "db2 -tvf /tmp/prepare_db_files/create-schema.sql "
   register: shell_status
   until: shell_status.rc == 0
-  retries: 5
+  retries: 10
   delay: 60 # seconds
 
 - name: Enable HA after maintenance
@@ -81,5 +81,5 @@
     oc exec -n {{ db2_namespace }} -ti {{ db2_pod_name }} -- sudo wvcli system enable -m "Enable HA after Db2 maintenance"
   register: shell_status
   until: shell_status.rc == 0
-  retries: 5
+  retries: 10
   delay: 60 # seconds

--- a/ibm/mas_devops/roles/suite_db2_setup_for_facilities/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_facilities/tasks/main.yml
@@ -41,7 +41,7 @@
     oc exec -n {{db2_namespace}} {{db2_pod_name}} -- su -lc 'db2set' db2inst1
   register: check_props_status
   until: check_props_status.rc == 0
-  retries: 5
+  retries: 20
   delay: 30
 
 - name: Verifying properties


### PR DESCRIPTION
## Issue
MASCORE-7202

## Description
FVT tests are failing during `suite-db2-setup-for-facilities`. One of the possible reasons is not enough wait time, therefore those were increased to avoid the error.

## Test Results

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
