### PR TITLE
[patch] Adding ODF dependencies for mirroring in OCP

### DIFF
--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -84,4 +84,9 @@ mirror:
         - name: lvms-operator  # Not used by any of our roles, but used in SNO installations
           channels:
             - name: stable-{{ ocp_release }}
+{% if ocp_release >= "4.16" %}
+        - name: odf-dependencies  # Required by ibm.mas_devops.ocs role
+          channels:
+            - name: stable-{{ ocp_release }}
+{% endif %}
 {% endif %}


### PR DESCRIPTION
Adding ODF dependencies for mirroring in OCP
-----------------------------------------------
Updated https://github.com/ibm-mas/ansible-devops/blob/master/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2#L87 , to add the ODF dependencies for redhat-operator catalogs

Tested same in a fyre airgap test cluster and found ODF gets installed successfully.

