### PR TITLE
[patch] fix JDBC secret creation for aibroker role

### DIFF
--- a/ibm/mas_devops/roles/aibroker/tasks/config_db2/main.yml
+++ b/ibm/mas_devops/roles/aibroker/tasks/config_db2/main.yml
@@ -9,8 +9,10 @@
     jdbc_file_cfg: "{{ lookup('file', '{{ mas_config_dir }}/jdbc-{{ mas_app_id }}-db2u.yml') | from_yaml_all }}"
   ansible.builtin.set_fact:
     jdbccfg:
-      username: "{{ jdbc_file_cfg[0].data.username }}"
-      password: "{{ jdbc_file_cfg[0].data.password }}"
+      # read from Secret
+      username: "{{ jdbc_file_cfg[0].data.username | b64decode }}"
+      password: "{{ jdbc_file_cfg[0].data.password | b64decode  }}"
+      # read from JdbcCfg
       url: "{{ jdbc_file_cfg[1].spec.config.url }}"
       sslenabled: "{{ jdbc_file_cfg[1].spec.config.sslEnabled | default('True', true) | bool }}"
       ca: "{{ jdbc_file_cfg[1].spec.certificates | map(attribute='crt') | join(',') | replace(',','\n') }}"

--- a/ibm/mas_devops/roles/aibroker/tasks/config_db2/main.yml
+++ b/ibm/mas_devops/roles/aibroker/tasks/config_db2/main.yml
@@ -11,9 +11,9 @@
     jdbccfg:
       username: "{{ jdbc_file_cfg[0].data.username }}"
       password: "{{ jdbc_file_cfg[0].data.password }}"
-      url: "{{ jdbc_file_cfg[1].spec.config.url | b64encode }}"
-      sslenabled: "{{ jdbc_file_cfg[1].spec.config.sslEnabled | b64encode }}"
-      ca: "{{ jdbc_file_cfg[1].spec.certificates | map(attribute='crt') | join(',') | replace(',','\n') | b64encode }}"
+      url: "{{ jdbc_file_cfg[1].spec.config.url }}"
+      sslenabled: "{{ jdbc_file_cfg[1].spec.config.sslEnabled | default('True', true) | bool }}"
+      ca: "{{ jdbc_file_cfg[1].spec.certificates | map(attribute='crt') | join(',') | replace(',','\n') }}"
   when: jdbc_config_file_result.stat.exists
 
 - name: Read JDBC config from environment
@@ -40,11 +40,6 @@
   when: jdbccfg.url | length == 0
   ansible.builtin.fail:
     msg: "jdbccfg.url must not be empty"
-
-- name: "Validate JDBC configuration"
-  when: jdbccfg.sslenabled | length == 0
-  ansible.builtin.fail:
-    msg: "jdbccfg.sslenabled must not be empty"
 
 - name: "Validate JDBC configuration"
   when: jdbccfg.ca | length == 0

--- a/ibm/mas_devops/roles/aibroker/templates/jdbc/jdbc-admin-credentials.yml.j2
+++ b/ibm/mas_devops/roles/aibroker/templates/jdbc/jdbc-admin-credentials.yml.j2
@@ -5,9 +5,9 @@ metadata:
   name: "{{ mas_aibroker_jdbc_secret }}"
   namespace: mas-{{ mas_instance_id }}-aibroker
 data:
-  username: "{{ jdbccfg.username }}"
-  password: "{{ jdbccfg.password }}"
-  url: "{{ jdbccfg.url }}"
-  sslenabled: "{{ jdbccfg.sslenabled }}"
-  certificate: "{{ jdbccfg.ca }}"
+  username: "{{ jdbccfg.username | b64encode }}"
+  password: "{{ jdbccfg.password | b64encode }}"
+  url: "{{ jdbccfg.url | b64encode }}"
+  sslenabled: "{{ jdbccfg.sslenabled | b64encode }}"
+  certificate: "{{ jdbccfg.ca | b64encode }}"
 type: Opaque


### PR DESCRIPTION
## Issue
MASAIB-1028

## Description
* Ensure that the "SSL Enabled" option has a default boolean value when read from file or environment. We can then eliminate the validation step that checks the length of the boolean, which throws an error for obvious reasons.
* Base64 encode all values directly in the secret, rather than selectively encoding some of them in task, which is confusing. This involves decoding two secret values first, and adding a comment to make it clear where specific values are being read from.

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
