### PR TITLE
[patch] Inject Db2uCluster CR as owner in the enforce settings configmap

### DIFF
--- a/ibm/mas_devops/roles/suite_db2_setup_for_facilities/tasks/apply-db2-config-version.yml
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_facilities/tasks/apply-db2-config-version.yml
@@ -49,6 +49,10 @@
     spec: |
       {{db2_configs[db2_config_version]}}
 
+- name: Set db2_instance_uid variable required to set ownershipreference in the -enforce-config configmap
+  set_fact:
+    db2_instance_uid: "{{ _db2_instance_engn_svc.resources[0].metadata.uid }}"
+
 - name: Create k8s configmaps for DB2 config version
   kubernetes.core.k8s:
     state: present

--- a/ibm/mas_devops/roles/suite_db2_setup_for_facilities/templates/db2_enforce_config.yaml.j2
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_facilities/templates/db2_enforce_config.yaml.j2
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{db2_instance_name | lower}}-enforce-mref-config"
+  ownerReferences:
+    - apiVersion: db2u.databases.ibm.com/v1
+      kind: Db2uCluster
+      name: "{{ db2_instance_name | lower }}"
+      uid: "{{ db2_instance_uid }}"  
 data:
   version: "{{ db2_config_version }}"
 


### PR DESCRIPTION
## Issue
MASCORE-7585

## Description
run the following scenario:

- Install and configure facilities db2 instance using the ansible role suite-db2-setup-facilities: Success
- Remove the db2 instance by deleting the corresponding Db2uCluster CR. 
  - verified that the <db-instance-name>-enforce-mref-config is still present in the system
- Run again the ansible role  suite-db2-setup-facilities. It fails: 
```
TASK [ibm.mas_devops.suite_db2_setup_for_facilities : Check DB2 cfg is take effect] *************************************************************************************************************************************************
FAILED - RETRYING: [localhost]: Check DB2 cfg is take effect (20 retries left).
FAILED - RETRYING: [localhost]: Check DB2 cfg is take effect (19 retries left).
FAILED - RETRYING: [localhost]: Check DB2 cfg is take effect (18 retries left).
FAILED - RETRYING: [localhost]: Check DB2 cfg is take effect (17 retries left).
FAILED - RETRYING: [localhost]: Check DB2 cfg is take effect (16 retries left).
FAILED - RETRYING: [localhost]: Check DB2 cfg is take effect (15 retries left).
FAILED - RETRYING: [localhost]: Check DB2 cfg is take effect (14 retries left).
FAILED - RETRYING: [localhost]: Check DB2 cfg is take effect (13 retries left).
FAILED - RETRYING: [localhost]: Check DB2 cfg is take effect (12 retries left).
FAILED - RETRYING: [localhost]: Check DB2 cfg is take effect (11 retries left).
FAILED - RETRYING: [localhost]: Check DB2 cfg is take effect (10 retries left).
FAILED - RETRYING: [localhost]: Check DB2 cfg is take effect (9 retries left).
FAILED - RETRYING: [localhost]: Check DB2 cfg is take effect (8 retries left).
FAILED - RETRYING: [localhost]: Check DB2 cfg is take effect (7 retries left).
FAILED - RETRYING: [localhost]: Check DB2 cfg is take effect (6 retries left).
FAILED - RETRYING: [localhost]: Check DB2 cfg is take effect (5 retries left).
FAILED - RETRYING: [localhost]: Check DB2 cfg is take effect (4 retries left).
FAILED - RETRYING: [localhost]: Check DB2 cfg is take effect (3 retries left).
FAILED - RETRYING: [localhost]: Check DB2 cfg is take effect (2 retries left).
FAILED - RETRYING: [localhost]: Check DB2 cfg is take effect (1 retries left).
fatal: [localhost]: FAILED! => {"attempts": 20, "changed": true, "cmd": "oc exec -n db2u c-db2-facilities-db2u-0 -- su -lc 'db2 get db cfg for MREFDB | grep \"(STRING_UNITS) = CODEUNITS32\"' db2inst1\n", "delta": "0:00:02.175554", "end": "2025-06-13 10:13:04.313298", "msg": "non-zero return code", "rc": 1, "start": "2025-06-13 10:13:02.137744", "stderr": "Defaulted container \"db2u\" out of: db2u, init-labels (init), init-kernel (init)\ncommand terminated with exit code 1", "stderr_lines": ["Defaulted container \"db2u\" out of: db2u, init-labels (init), init-kernel (init)", "command terminated with exit code 1"], "stdout": "", "stdout_lines": []}

NO MORE HOSTS LEFT ******************************************************************************************************************************************************************************************************************

PLAY RECAP **************************************************************************************************************************************************************************************************************************
localhost                  : ok=95   changed=8    unreachable=0    failed=1    skipped=8    rescued=0    ignored=1
```
- Manually remove the configmap <db-instance-name>-enforce-mref-config
- attempt again running the role suite_db2_setup_for_facilities. This time it correctly completes.

Clearly the fact that the Db2uCluster CR and the <db-instance-name>-enforce-mref-config configmap, both created by the suite_db2_setup_for_facilities, have a different life cycle is a problem.

The fix to the role  suite_db2_setup_for_facilities injects the Db2uCluster CR as owner in  the <db-instance-name>-enforce-mref-config  configmap when this is created.  In this way when the Db2uCluster CR  is deleted also the owned configmap is removed.

## Test Results
With the fix, the cycle run the role suite_db2_setup_for_facilities, delete Db2uCluster CR, run again the role suite_db2_setup_for_facilities works without any problem.

The fix have been tested using the following playbook:

```
---
- hosts: localhost
  any_errors_fatal: true

  vars:
    # Application Installation
    mas_app_id: "{{ lookup('env', 'MAS_APP_ID') | default('facilities', true) }}"

    mas_app_channel: "{{ lookup('env', 'MAS_APP_CHANNEL') | default('9.1.x', true) }}"

    # Application Configuration
    mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') | default('masdev', true) }}"
    configure_external_db: "{{ lookup('env', 'CONFIGURE_EXTERNAL_DB') | default('False', true) | bool }}"
    mas_config_scope: "{{ lookup('env', 'MAS_CONFIG_SCOPE') | default('wsapp', true) }}"
    mas_appws_bindings_jdbc: "{{ lookup('env', 'MAS_APPWS_BINDINGS_JDBC') | default('workspace-application', true) }}"
    db2_instance_name: "{{ lookup('env', 'DB2_INSTANCE_NAME') | default('db2-facilities',true) }}"

    # Check if SSL is enabled
    ssl_enabled: "{{ lookup('env', 'SSL_ENABLED') | default('True', true) | bool }}"

  pre_tasks:
    # For the full set of supported environment variables refer to the playbook documentation
    - name: Check for required environment variables
      assert:
        that:
          - lookup('env', 'IBM_ENTITLEMENT_KEY') != ""
          - lookup('env', 'MAS_INSTANCE_ID') != ""
          - lookup('env', 'MAS_CONFIG_DIR') != ""
        fail_msg: "One or more required environment variables are not defined"

  roles:

    # Db2 Install and Setup
    - name: ibm.mas_devops.suite_db2_setup_for_facilities
      when: configure_external_db == false 
```

with the following environment variables:

```
export MAS_INSTANCE_ID=drenigma
export MAS_CONFIG_DIR=~/masconfig

export ARTIFACTORY_USERNAME=###############
export ARTIFACTORY_TOKEN=###############
export IBM_ENTITLEMENT_KEY=###############
export MAS_ENTITLEMENT_USERNAME=###############
export MAS_ICR_CPOPEN=###############
export MAS_ICR_CP=###############
export MAS_CHANNEL=9.1.x-stable
export MAS_APP_CHANNEL=9.1.x-stable
export MAS_CATALOG_VERSION=v9-master-amd64

export DB2_DBNAME=MREFDB
export MAS_APP_ID=facilities
export DB2_LDAP_USERNAME=mrefdata
export DB2_LDAP_PASSWORD=###############
export DB2_SCHEMA=FACILITIES
export DB2_USERNAME=${DB2_LDAP_USERNAME}
```

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
