### PR TITLE
[major] Avoid usage of an additional variable to install Manage foundation

### DIFF
--- a/docs/playbooks/oneclick-manage.md
+++ b/docs/playbooks/oneclick-manage.md
@@ -41,9 +41,7 @@ Required environment variables
 
    To install Manage Foundation only that is available on MAS Core 9.1 or later, export the following environment variable:
 
-   `export IS_FULL_MANAGE=false`
-
-   Also, the `MAS_APPWS_COMPONENTS` environment variable must be empty:
+   `MAS_APPWS_COMPONENTS` environment variable must be empty:
 
    `export MAS_APPWS_COMPONENTS=""`
 

--- a/ibm/mas_devops/playbooks/oneclick_add_manage.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_manage.yml
@@ -13,8 +13,8 @@
 
   vars:
     # By default we always install Manage base
-    mas_appws_components: "{{ lookup('env', 'MAS_APPWS_COMPONENTS') | default('base=latest', true) | ibm.mas_devops.appws_components }}"
-    
+    mas_appws_components: "{{ lookup('env', 'MAS_APPWS_COMPONENTS') | default('base=latest') | ibm.mas_devops.appws_components }}"
+
     # Application Dependencies
     db2_instance_name: "{{ lookup('env', 'DB2_INSTANCE_NAME') | default('db2w-shared', true) }}"
 

--- a/ibm/mas_devops/playbooks/oneclick_add_manage.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_manage.yml
@@ -4,15 +4,17 @@
 # Dependencies:
 # - ansible-playbook ibm.mas_devops.oneclick_core
 #
-# To install Manage Foundation only that is available on MAS Core 9.1 or later, export the following environment variable:
-# `export IS_FULL_MANAGE=false`
-# Also, the `MAS_APPWS_COMPONENTS` environment variable must be empty:
+# To install Manage Foundation only that is available on MAS Core 9.1 or later
+# Make sure the `MAS_APPWS_COMPONENTS` environment variable must be empty:
 # `export MAS_APPWS_COMPONENTS=""`
 #
 - hosts: localhost
   any_errors_fatal: true
 
   vars:
+    # By default we always install Manage base
+    mas_appws_components: "{{ lookup('env', 'MAS_APPWS_COMPONENTS') | default({'base':'latest'} true) }}"
+    
     # Application Dependencies
     db2_instance_name: "{{ lookup('env', 'DB2_INSTANCE_NAME') | default('db2w-shared', true) }}"
 

--- a/ibm/mas_devops/playbooks/oneclick_add_manage.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_manage.yml
@@ -14,13 +14,23 @@
 
   vars:
     # By default we always install Manage base
-    vars:
+    # mas_appws_components logic:
+    #
+    # This setup distinguishes between unset and empty environment variables.
+    #
+    # ┌────────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────────┐
+    # │ MAS_APPWS_COMPONENTS (env var)                             │ Result after parsing with ibm.mas_devops.appws_components │
+    # ├────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
+    # │ (not set)                                                  │ { base: { version: latest } }                              │
+    # │ "" (empty string)                                          │ Manage Foundation                                                       │
+    # │ "base=latest"                                              │ { base: { version: latest } }                              │
+    # │ "base=latest,health=latest"                                │ { base: ..., health: ... }                                 │
+    # └────────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┘
     mas_appws_components: >-
       {{
         (
-          'base=latest'
-          if 'MAS_APPWS_COMPONENTS' not in lookup('env', '__ENV')
-          else lookup('env', 'MAS_APPWS_COMPONENTS')
+          (lookup('env', 'MAS_APPWS_COMPONENTS', default='__unset__') != '__unset__')
+          | ternary(lookup('env', 'MAS_APPWS_COMPONENTS'), 'base=latest')
         )
         | ibm.mas_devops.appws_components
       }}
@@ -65,6 +75,10 @@
     cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default('4.6.3', true) }}"
 
   pre_tasks:
+    - name: Show raw env var
+      debug:
+        msg: "{{ lookup('env', 'MAS_APPWS_COMPONENTS') }}"
+
     - name: Show Components to be installed
       debug:
         var: mas_appws_components

--- a/ibm/mas_devops/playbooks/oneclick_add_manage.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_manage.yml
@@ -5,15 +5,25 @@
 # - ansible-playbook ibm.mas_devops.oneclick_core
 #
 # To install Manage Foundation only that is available on MAS Core 9.1 or later
-# Make sure the `MAS_APPWS_COMPONENTS` environment variable must be empty:
+# Make sure the `MAS_APPWS_COMPONENTS` environment variable is empty:
 # `export MAS_APPWS_COMPONENTS=""`
+# Not setting the env var will install Full Manage with base component
 #
 - hosts: localhost
   any_errors_fatal: true
 
   vars:
     # By default we always install Manage base
-    mas_appws_components: "{{ lookup('env', 'MAS_APPWS_COMPONENTS') | default('base=latest') | ibm.mas_devops.appws_components }}"
+    vars:
+    mas_appws_components: >-
+      {{
+        (
+          'base=latest'
+          if 'MAS_APPWS_COMPONENTS' not in lookup('env', '__ENV')
+          else lookup('env', 'MAS_APPWS_COMPONENTS')
+        )
+        | ibm.mas_devops.appws_components
+      }}
 
     # Application Dependencies
     db2_instance_name: "{{ lookup('env', 'DB2_INSTANCE_NAME') | default('db2w-shared', true) }}"

--- a/ibm/mas_devops/playbooks/oneclick_add_manage.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_manage.yml
@@ -13,7 +13,7 @@
 
   vars:
     # By default we always install Manage base
-    mas_appws_components: "{{ lookup('env', 'MAS_APPWS_COMPONENTS') | default({'base':'latest'} true) }}"
+    mas_appws_components: "{{ lookup('env', 'MAS_APPWS_COMPONENTS') | default({'base':'latest'}, true) }}"
     
     # Application Dependencies
     db2_instance_name: "{{ lookup('env', 'DB2_INSTANCE_NAME') | default('db2w-shared', true) }}"

--- a/ibm/mas_devops/playbooks/oneclick_add_manage.yml
+++ b/ibm/mas_devops/playbooks/oneclick_add_manage.yml
@@ -13,7 +13,7 @@
 
   vars:
     # By default we always install Manage base
-    mas_appws_components: "{{ lookup('env', 'MAS_APPWS_COMPONENTS') | default({'base':'latest'}, true) }}"
+    mas_appws_components: "{{ lookup('env', 'MAS_APPWS_COMPONENTS') | default('base=latest', true) | ibm.mas_devops.appws_components }}"
     
     # Application Dependencies
     db2_instance_name: "{{ lookup('env', 'DB2_INSTANCE_NAME') | default('db2w-shared', true) }}"
@@ -55,6 +55,10 @@
     cpd_product_version: "{{ lookup('env', 'CPD_PRODUCT_VERSION') | default('4.6.3', true) }}"
 
   pre_tasks:
+    - name: Show Components to be installed
+      debug:
+        var: mas_appws_components
+
     # For the full set of supported environment variables refer to the playbook documentation
     - name: Check for required environment variables
       assert:

--- a/ibm/mas_devops/roles/suite_app_config/README.md
+++ b/ibm/mas_devops/roles/suite_app_config/README.md
@@ -52,13 +52,6 @@ Note: For Maximo Real estate and facilities, we recommend to use workspace-appli
 - Environment Variable: `MAS_APPWS_BINDINGS_JDBC`
 - Default: `system`
 
-### is_full_manage
-If set to `false`, Manage Foundation will be installed instead of Full Manage (available on MAS Core 9.1 and later).
-
-- Optional
-- Environment Variable: `IS_FULL_MANAGE`
-- Default: `true`
-
 ### mas_appws_components
 Defines the app components and versions to configure in the application workspace. Takes the form of key=value pairs seperated by a comma i.e. To install health within Manage set `base=latest,health=latest`
 

--- a/ibm/mas_devops/roles/suite_app_config/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/defaults/main.yml
@@ -15,7 +15,7 @@ mas_config_dir: "{{ lookup('env', 'MAS_CONFIG_DIR') }}"
 # -----------------------------------------------------------------------------
 mas_app_id: "{{ lookup('env', 'MAS_APP_ID') }}"
 mas_appws_bindings_jdbc: "{{ lookup('env', 'MAS_APPWS_BINDINGS_JDBC') }}"
-mas_appws_components: "{{ lookup('env', 'MAS_APPWS_COMPONENTS') | ibm.mas_devops.appws_components | default('{}', true) }}"
+mas_appws_components: "{{ lookup('env', 'MAS_APPWS_COMPONENTS') | ibm.mas_devops.appws_components | default(mas_appws_components, true) | default('{}', true) }}"
 
 # Only used by Predict currently - will be deprecated in favour of OM3.1 implementation
 mas_appws_settings_deployment_size: "{{ lookup('env', 'MAS_APPWS_SETTINGS_DEPLOYMENT_SIZE') | default('small', true) }}"

--- a/ibm/mas_devops/roles/suite_app_config/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/defaults/main.yml
@@ -15,7 +15,7 @@ mas_config_dir: "{{ lookup('env', 'MAS_CONFIG_DIR') }}"
 # -----------------------------------------------------------------------------
 mas_app_id: "{{ lookup('env', 'MAS_APP_ID') }}"
 mas_appws_bindings_jdbc: "{{ lookup('env', 'MAS_APPWS_BINDINGS_JDBC') }}"
-mas_appws_components: "{{ lookup('env', 'MAS_APPWS_COMPONENTS') | ibm.mas_devops.appws_components | default(mas_appws_components, true) | default('{}', true) }}"
+mas_appws_components: "{{ lookup('env', 'MAS_APPWS_COMPONENTS') | ibm.mas_devops.appws_components | default('{}', true) }}"
 
 # Only used by Predict currently - will be deprecated in favour of OM3.1 implementation
 mas_appws_settings_deployment_size: "{{ lookup('env', 'MAS_APPWS_SETTINGS_DEPLOYMENT_SIZE') | default('small', true) }}"

--- a/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Show Components to be installed
+  debug:
+    var: mas_appws_components
+
 # Manage pre-configuration: pod templates
 - name: "Run Manage specific pre-configuration: Pod Templates"
   include_tasks: "tasks/manage/pre-config/setup-pod-templates.yml"

--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/manage.yml
@@ -3,7 +3,7 @@
 mas_appws_spec:
   bindings: "{{ mas_app_bindings }}"
   podTemplates: "{{ ((ibm_mas_manage_manageworkspace_pod_templates is defined) and (ibm_mas_manage_manageworkspace_pod_templates | length != 0)) | ternary(ibm_mas_manage_manageworkspace_pod_templates, []) }}"
-  components: "{{ ((mas_app_components_manage is defined) and (mas_app_components_manage | length != 0)) | ternary(mas_app_components_manage, default_component) }}"
+  components: "{{ ((mas_app_components_manage is defined) and (mas_app_components_manage | length != 0)) | ternary(mas_app_components_manage, {}) }}"
   settings:
     deployment:
       persistentVolumes: "{{ mas_app_settings_persistent_volumes }}"

--- a/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
@@ -86,9 +86,7 @@ server_bundles_jms_add_server_config_content: "{{ lookup('file', '{{ role_path }
 # these settings will define the bundle servers spec
 mas_app_settings_server_bundles_size: "{{ lookup('env', 'MAS_APP_SETTINGS_SERVER_BUNDLES_SIZE') | default('dev', true)  }}"
 # This is to specify if manage installation is full or foundation
-is_full_manage: "{{ (lookup('env', 'IS_FULL_MANAGE', default='true') | lower) in ['true', '1', 'yes'] }}"
-# If this is not full manage (foundation), there is no default base component
-default_component: "{{ is_full_manage | ternary({'base':{'version':'latest'}}, {})  }}"
+is_full_manage: "{{ (mas_app_components_manage is defined) and (mas_app_components_manage | length > 0) }}"
 mas_app_settings_server_bundles:
   dev:
     serverBundleEarFilename: maximo-all

--- a/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
@@ -86,7 +86,7 @@ server_bundles_jms_add_server_config_content: "{{ lookup('file', '{{ role_path }
 # these settings will define the bundle servers spec
 mas_app_settings_server_bundles_size: "{{ lookup('env', 'MAS_APP_SETTINGS_SERVER_BUNDLES_SIZE') | default('dev', true)  }}"
 # This is to specify if manage installation is full or foundation
-is_full_manage: "{{ (mas_app_components_manage is defined) and (mas_app_components_manage | length > 0) }}"
+is_full_manage: "{{ (mas_appws_components is defined) and (mas_appws_components | length > 0) }}"
 mas_app_settings_server_bundles:
   dev:
     serverBundleEarFilename: maximo-all


### PR DESCRIPTION
## Issue
MASCORE-7612

## Description
We are removing the need of setting an specific IS_FULL_MANAGE variable when installing Manage Foundation.
This change will ensure that by default foundation is always installed if no components is set for Manage installation.

To keep compatibility with current behavior we are also change Manage oneclick playbook to always install Manage base e the env var is not set. The way to install foundation explicitly using the playbook is by setting the env var as:

export MAS_APPWS_COMPONENTS=""


## Test Results
I ran all sort of possible tests for this playbook including:
* Install foundation only with
export MAS_APPWS_COMPONENTS=""
* installing Manage full without set the env var;
* Installing Manage full explicitly setting the MAS_APPWS_COMPONENTS env var;


<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
