### PR TITLE
[patch] reformat ca cert while passed from env vars for AIBroker role

### DIFF
--- a/ibm/mas_devops/roles/aibroker/tasks/config_db2/main.yml
+++ b/ibm/mas_devops/roles/aibroker/tasks/config_db2/main.yml
@@ -25,7 +25,7 @@
       password: "{{ lookup('env', 'MAS_AIBROKER_DB2_PASSWORD') }}"
       url: "{{ lookup('env', 'MAS_AIBROKER_DB2_JDBC_URL') }}"
       sslenabled: "{{ lookup('env', 'MAS_AIBROKER_DB2_SSL_ENABLED') | default('True', true) | bool }}"
-      ca: "{{ lookup('env', 'MAS_AIBROKER_DB2_CA_CERT') }}"
+      ca: "{{ lookup('env', 'MAS_AIBROKER_DB2_CA_CERT') | regex_replace('BEGIN CERTIFICATE', 'BEGIN_CERTIFICATE') | regex_replace('END CERTIFICATE', 'END_CERTIFICATE') | regex_replace('\\s+', '\n') | replace('BEGIN_CERTIFICATE', 'BEGIN CERTIFICATE')| replace('END_CERTIFICATE', 'END CERTIFICATE') }}"
   when: not jdbc_config_file_result.stat.exists
 
 - name: "Validate JDBC configuration"

--- a/ibm/mas_devops/roles/aibroker/tasks/config_sls/main.yml
+++ b/ibm/mas_devops/roles/aibroker/tasks/config_sls/main.yml
@@ -21,7 +21,7 @@
       secret_name: "{{ lookup('env', 'MAS_AIBROKER_SLS_SECRET_NAME') }}"
       registration_key: "{{ lookup('env', 'MAS_AIBROKER_SLS_REGISTRATION_KEY') }}"
       url: "{{ lookup('env', 'MAS_AIBROKER_SLS_URL') }}"
-      ca: "{{ lookup('env', 'MAS_AIBROKER_SLS_CA_CERT') }}"
+      ca: "{{ lookup('env', 'MAS_AIBROKER_SLS_CA_CERT') | regex_replace('BEGIN CERTIFICATE', 'BEGIN_CERTIFICATE') | regex_replace('END CERTIFICATE', 'END_CERTIFICATE') | regex_replace('\\s+', '\n') | replace('BEGIN_CERTIFICATE', 'BEGIN CERTIFICATE')| replace('END_CERTIFICATE', 'END CERTIFICATE') }}"
   when: not sls_file_result.stat.exists
 
 - name: "Validate SLS configuration"

--- a/ibm/mas_devops/roles/aibroker_tenant/tasks/config_sls/main.yml
+++ b/ibm/mas_devops/roles/aibroker_tenant/tasks/config_sls/main.yml
@@ -21,7 +21,7 @@
       secret_name: "{{ lookup('env', 'MAS_AIBROKER_SLS_SECRET_NAME') }}"
       registration_key: "{{ lookup('env', 'MAS_AIBROKER_SLS_REGISTRATION_KEY') }}"
       url: "{{ lookup('env', 'MAS_AIBROKER_SLS_URL') }}"
-      ca: "{{ lookup('env', 'MAS_AIBROKER_SLS_CA_CERT') }}"
+      ca: "{{ lookup('env', 'MAS_AIBROKER_SLS_CA_CERT') | regex_replace('BEGIN CERTIFICATE', 'BEGIN_CERTIFICATE') | regex_replace('END CERTIFICATE', 'END_CERTIFICATE') | regex_replace('\\s+', '\n') | replace('BEGIN_CERTIFICATE', 'BEGIN CERTIFICATE')| replace('END_CERTIFICATE', 'END CERTIFICATE') }}"
   when: not sls_file_result.stat.exists
 
 - name: "Validate SLS configuration"


### PR DESCRIPTION
## Issue
<!-- Provide the ID numbers of issues related to this change. Please do not provide direct links to IBM-internal systems. If there are no issues related to this change, why are you working on it? -->

MASAIB-761
## Description
<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->
Reformat ca cert for db2 and sls when we pass certs as env vars.
## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->
<img width="1485" alt="Screenshot 2025-06-23 at 10 50 24 AM" src="https://github.com/user-attachments/assets/b35a28f0-9260-401e-9e54-194caf273eee" />
<img width="1481" alt="Screenshot 2025-06-23 at 10 50 39 AM" src="https://github.com/user-attachments/assets/910af48a-2d14-4d65-875d-480870eacb6d" />

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
