### PR TITLE
[patch] support custom domain for AI Service

### DIFF
--- a/ibm/mas_devops/roles/aibroker/tasks/main.yml
+++ b/ibm/mas_devops/roles/aibroker/tasks/main.yml
@@ -11,9 +11,17 @@
     name: cluster
   register: _cluster_subdomain
 
-- name: "Set fact: cluster subdomain"
+- name: "Set custom cluster subdomain"
+  set_fact:
+    cluster_domain: "{{ mas_aibroker_cluster_domain }}"
+  when:
+    - mas_aibroker_cluster_domain | length > 0
+
+- name: "Set default cluster subdomain from ingress"
   set_fact:
     cluster_domain: "{{ _cluster_subdomain.resources[0].spec.domain }}"
+  when:
+    - mas_aibroker_cluster_domain | length == 0
 
 - name: "Debug: cluster domain"
   debug:


### PR DESCRIPTION
## Issue
MASAIB-1051

## Description
If a user-supplied cluster domain is available for AI Service then use this, otherwise use the domain from the cluster ingress.

## Test Results
TODO

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
