### PR TITLE
[patch] Remove spec.name from Grafana v5 dashboards

### DIFF
--- a/ibm/mas_devops/roles/kafka/templates/redhat/dashboards-v5/kafka-exporter.yml.j2
+++ b/ibm/mas_devops/roles/kafka/templates/redhat/dashboards-v5/kafka-exporter.yml.j2
@@ -5,7 +5,6 @@ metadata:
   name: "kafka-jmxexported-metrics"
   namespace: "{{ kafka_namespace }}"
 spec:
-  name: "{{ kafka_namespace }}-kafka-jmxexported-metrics"
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:

--- a/ibm/mas_devops/roles/kafka/templates/redhat/dashboards-v5/kafka-zookeeper.yml.j2
+++ b/ibm/mas_devops/roles/kafka/templates/redhat/dashboards-v5/kafka-zookeeper.yml.j2
@@ -5,7 +5,6 @@ metadata:
   name: "zookeeper-metrics"
   namespace: "{{ kafka_namespace }}"
 spec:
-  name: "{{ kafka_namespace }}-zookeeper-metrics"
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:

--- a/ibm/mas_devops/roles/kafka/templates/redhat/dashboards-v5/kafka.yml.j2
+++ b/ibm/mas_devops/roles/kafka/templates/redhat/dashboards-v5/kafka.yml.j2
@@ -5,7 +5,6 @@ metadata:
   name: "kafka-metrics"
   namespace: "{{ kafka_namespace }}"
 spec:
-  name: "{{ kafka_namespace }}-kafka-metrics"
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:

--- a/ibm/mas_devops/roles/mongodb/templates/community/dashboards/mongodb-overview-v5.yml.j2
+++ b/ibm/mas_devops/roles/mongodb/templates/community/dashboards/mongodb-overview-v5.yml.j2
@@ -5,7 +5,6 @@ metadata:
   name: "mongodb-overview"
   namespace: "{{ mongodb_namespace }}"
 spec:
-  name: "{{ mongodb_namespace }}-mongodb-overview"
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:


### PR DESCRIPTION
```
apiVersion: grafana.integreatly.org/v1beta1
kind: GrafanaDashboard
```

This CRD [does not support spec.name](https://grafana.github.io/grafana-operator/docs/api/#grafanadashboardspec). Observed when Kafka installation failed.

I did not modify the associated v4 dashboards, as I assume spec.name was supported at some point in the past.