### PR TITLE
Add ability to set maxUnavailable for machine configs

### DIFF
--- a/ibm/mas_devops/common_tasks/wait-machine-config-update.yml
+++ b/ibm/mas_devops/common_tasks/wait-machine-config-update.yml
@@ -1,5 +1,28 @@
 ---
-# 1. Wait for node pools to start updating
+# 1. Set maxUnavailable
+# A typical airgap test environment will consist of 3 master nodes and 11 worker nodes
+# the test will require the machine config pool to be updated twice (once as part of the
+# airgpa set and a second time to simulate an airgap environment)
+# by setting MACHINE_CONFIG_MULTIUPDATE we change the worker pool to update 3 nodes at
+# a time significantly reducing the setup time. This does not modify the master machine
+# config pool as with only 3 master nodes trying to update multiple master nodes can
+# cause deadlocks due to trying to drain 2 in parallel and the third not being able to
+# contain all the pods
+# -----------------------------------------------------------------------------
+- name: Set worker maxUnavailable
+  kubernetes.core.k8s_json_patch:
+    api_version: machineconfiguration.openshift.io/v1
+    kind: MachineConfigPool
+    name: worker
+    patch:
+      - op: add
+        path: /spec/maxUnavailable
+        value: 3
+  when:
+    - machine_config_multiupdate is defined
+    - machine_config_multiupdate
+
+# 2. Wait for node pools to start updating
 # -----------------------------------------------------------------------------
 - name: Wait for node pools to start updating
   kubernetes.core.k8s_info:
@@ -18,7 +41,7 @@
     - "worker"
     - "master"
 
-# 2. Wait for node pools to finish updating
+# 3. Wait for node pools to finish updating
 # -----------------------------------------------------------------------------
 - name: Wait for node pools to finish updating
   kubernetes.core.k8s_info:

--- a/ibm/mas_devops/roles/ocp_idms/README.md
+++ b/ibm/mas_devops/roles/ocp_idms/README.md
@@ -132,6 +132,14 @@ An optional prefix to apply to the catalog sources names for the 3 Red Hat catal
 - Environment Variable: `REDHAT_CATALOGS_PREFIX`
 - Default: None
 
+### machine_config_multiupdate
+An optional value that if present will set the max unavailable nodes for the worker Machine Config Pool. 
+This is only recommended to be set during setup of an environment where nodes will be lightly loaded and
+draining multiple worker nodes in parallel is possible
+
+- Optional
+- Environment Variable: `MACHINE_CONFIG_MULTIUPDATE`
+- Default: false
 
 Example Playbook
 -------------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/ocp_idms/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_idms/defaults/main.yml
@@ -38,3 +38,5 @@ idms_suffix_redhat: "{% if registry_prefix_redhat | length > 0 %}-{{ registry_pr
 # Optional Red Hat CatalogSource Name Prefix
 # -----------------------------------------------------------------------------
 redhat_catalogs_prefix: "{{ lookup('env', 'REDHAT_CATALOGS_PREFIX') | default('', true) }}"
+
+machine_config_multiupdate: "{{ lookup('env','MACHINE_CONFIG_MULTIUPDATE') | default('False',true) | bool}}"

--- a/ibm/mas_devops/roles/ocp_login/tasks/login-fyre.yml
+++ b/ibm/mas_devops/roles/ocp_login/tasks/login-fyre.yml
@@ -37,6 +37,10 @@
     login_server: "https://{{ api_host }}:6443"
   shell: |
     oc login -u kubeadmin -p {{ login_password }} --server={{ login_server }} --insecure-skip-tls-verify=true
+  register: login_result
+  retries: 10
+  delay: 30 # seconds
+  until: login_result.rc == 0
 
 # 6. For IPv6 testing, lookup network
 - name: Lookup network for IPv6 testing

--- a/ibm/mas_devops/roles/ocp_simulate_disconnected_network/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_simulate_disconnected_network/defaults/main.yml
@@ -3,3 +3,4 @@ airgap_network_exclusions: "quay.io registry.redhat.io registry.connect.redhat.c
 
 registry_private_ca_file: "{{ lookup('env', 'REGISTRY_PRIVATE_CA_FILE') }}"
 registry_private_ca_crt: "{{ lookup('file', registry_private_ca_file) }}"
+machine_config_multiupdate: "{{ lookup('env','MACHINE_CONFIG_MULTIUPDATE') | default('False',true) | bool}}"


### PR DESCRIPTION
## Issue
<!-- Provide the ID numbers of issues related to this change. Please do not provide direct links to IBM-internal systems. If there are no issues related to this change, why are you working on it? -->

Airgap testing is unreliable - no specific issue created

## Description
<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->

Airgap tests were hitting two problems:

1. fyre login sometimes failing the first time - the roks login task would retry so copied the settings from there
2. setup frequently taking more than 2 hours and the pipeline timing it out - by updating worker nodes in parallel the time has roughly halved

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

Tested by ongoing daily runs, will take time to see how much this improves stability but initial testing shows promise

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
