### PR TITLE
[patch] Set Fyre master nodes to 4cpu 8gb mem

### DIFF
--- a/ibm/mas_devops/roles/ocp_provision/templates/fyre/product_group.json.j2
+++ b/ibm/mas_devops/roles/ocp_provision/templates/fyre/product_group.json.j2
@@ -20,6 +20,15 @@
         }
     },
     "fips":"{{'yes' if ocp_fips_enabled else 'no'}}",
+    "master": {
+        "cpu": "4",
+        "memory": "16"
+    },
+    "api": {
+        "count": "1",
+        "cpu": "4",
+        "memory": "8"
+    },
     "worker":  [
         {
             "count": "{{ fyre_worker_count }}",
@@ -29,5 +38,5 @@
             "additional_disk": {{ fyre_worker_additional_disks | split(',') }}
 {% endif %}
         }
-     ]
+    ]
 }


### PR DESCRIPTION
## Issue
https://jsw.ibm.com/browse/MASCORE-5890

## Description
We're wasting 12 cpu with every cluster due to a default over-speced master node.

## Test Results
N/A

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
