### PR TITLE
[patch] Fix min release for odf-dependencies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @durera @andrercm @sanjayprab @terenceq @whitfiea @alequint @leo-miran
+* @durera @sanjayprab @terenceq @whitfiea @ianBoden @rawa-resul @leo-miran

--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -84,7 +84,7 @@ mirror:
         - name: lvms-operator  # Not used by any of our roles, but used in SNO installations
           channels:
             - name: stable-{{ ocp_release }}
-{% if ocp_release >= "4.16" %}
+{% if ocp_release >= "4.17" %}
         - name: odf-dependencies  # Required by ibm.mas_devops.ocs role
           channels:
             - name: stable-{{ ocp_release }}


### PR DESCRIPTION
## Issue
https://github.com/ibm-mas/ansible-devops/issues/1826

## Description
A previous update introduced a regression in image mirroring support on OCP 4.16, by setting the minimum release for the `odf-dependencies` package to 4.16 instead of 4.17

## Test Results
No testing. Attacking low cost defect fixes that can be handled with a peer review alone this morning.

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
