### PR TITLE
[patch] Add extra fields in watsonx secret in default aibroker tenant namespace 

### DIFF
--- a/docs/playbooks/oneclick-aibroker.md
+++ b/docs/playbooks/oneclick-aibroker.md
@@ -54,6 +54,10 @@ AI Broker supports **AWS** and **Minio** storage providers.
 * `MAS_AIBROKER_WATSONXAI_APIKEY` You WatsonX AI api key
 * `MAS_AIBROKER_WATSONXAI_URL` You WatsonX AI url
 * `MAS_AIBROKER_WATSONXAI_PROJECT_ID` You WatsonX projedt Id
+* `WX_FULL` Indicates on-premises Watsonx installation (set true if you have on-prem installation)
+* `MAS_AIBROKER_WATSONX_INSTANCE_ID` Your Watsonx Instance Id
+* `MAS_AIBROKER_WATSONX_VERSION` Your Watsonx Version
+* `MAS_AIBROKER_WATSONX_USERNAME` Your Watsonx Username
 * `MAS_AIBROKER_DB_HOST` Your database instance host
 * `MAS_AIBROKER_DB_PORT` Your database instance port
 * `MAS_AIBROKER_DB_USER` Your database instance user

--- a/ibm/mas_devops/roles/aibroker_tenant/defaults/main.yml
+++ b/ibm/mas_devops/roles/aibroker_tenant/defaults/main.yml
@@ -37,9 +37,9 @@ mas_aibroker_watsonxai_url: "{{ lookup('env', 'MAS_AIBROKER_WATSONXAI_URL') }}"
 mas_aibroker_watsonxai_project_id: "{{ lookup('env', 'MAS_AIBROKER_WATSONXAI_PROJECT_ID') }}"
 mas_aibroker_watsonx_action: "{{ lookup('env', 'MAS_AIBROKER_WATSONX_ACTION') | default('install', true) }}"
 wx_full: "{{ lookup('env', 'WX_FULL') | default('false', true) }}"
-wx_instance_id: "{{ lookup('env', 'WX_INSTANCE_ID') | default('false', true) }}"
-wx_version: "{{ lookup('env', 'WX_VERSION') | default('false', true) }}"
-wx_username: "{{ lookup('env', 'WX_USERNAME') | default('false', true) }}"
+wx_instance_id: "{{ lookup('env', 'MAS_AIBROKER_WATSONX_INSTANCE_ID') }}"
+wx_version: "{{ lookup('env', 'MAS_AIBROKER_WATSONX_VERSION') }}"
+wx_username: "{{ lookup('env', 'MAS_AIBROKER_WATSONX_USERNAME') }}"
 
 # S3 - This config overrides any shared config defined for the AI Broker.
 mas_aibroker_s3_secret: "{{ mas_aibroker_tenant_name }}----s3-secret"

--- a/ibm/mas_devops/roles/aibroker_tenant/defaults/main.yml
+++ b/ibm/mas_devops/roles/aibroker_tenant/defaults/main.yml
@@ -36,7 +36,7 @@ mas_aibroker_watsonxai_apikey: "{{ lookup('env', 'MAS_AIBROKER_WATSONXAI_APIKEY'
 mas_aibroker_watsonxai_url: "{{ lookup('env', 'MAS_AIBROKER_WATSONXAI_URL') }}"
 mas_aibroker_watsonxai_project_id: "{{ lookup('env', 'MAS_AIBROKER_WATSONXAI_PROJECT_ID') }}"
 mas_aibroker_watsonx_action: "{{ lookup('env', 'MAS_AIBROKER_WATSONX_ACTION') | default('install', true) }}"
-wx_full_on_prem: "{{ lookup('env', 'WX_FULL_ON_PREM') | default('false', true) }}"
+wx_full: "{{ lookup('env', 'WX_FULL') | default('false', true) }}"
 wx_instance_id: "{{ lookup('env', 'WX_INSTANCE_ID') | default('false', true) }}"
 wx_version: "{{ lookup('env', 'WX_VERSION') | default('false', true) }}"
 wx_username: "{{ lookup('env', 'WX_USERNAME') | default('false', true) }}"

--- a/ibm/mas_devops/roles/aibroker_tenant/defaults/main.yml
+++ b/ibm/mas_devops/roles/aibroker_tenant/defaults/main.yml
@@ -36,6 +36,10 @@ mas_aibroker_watsonxai_apikey: "{{ lookup('env', 'MAS_AIBROKER_WATSONXAI_APIKEY'
 mas_aibroker_watsonxai_url: "{{ lookup('env', 'MAS_AIBROKER_WATSONXAI_URL') }}"
 mas_aibroker_watsonxai_project_id: "{{ lookup('env', 'MAS_AIBROKER_WATSONXAI_PROJECT_ID') }}"
 mas_aibroker_watsonx_action: "{{ lookup('env', 'MAS_AIBROKER_WATSONX_ACTION') | default('install', true) }}"
+wx_full_on_prem: "{{ lookup('env', 'WX_FULL_ON_PREM') | default('false', true) }}"
+wx_instance_id: "{{ lookup('env', 'WX_INSTANCE_ID') | default('false', true) }}"
+wx_version: "{{ lookup('env', 'WX_VERSION') | default('false', true) }}"
+wx_username: "{{ lookup('env', 'WX_USERNAME') | default('false', true) }}"
 
 # S3 - This config overrides any shared config defined for the AI Broker.
 mas_aibroker_s3_secret: "{{ mas_aibroker_tenant_name }}----s3-secret"

--- a/ibm/mas_devops/roles/aibroker_tenant/templates/watsonx/secret.yml.j2
+++ b/ibm/mas_devops/roles/aibroker_tenant/templates/watsonx/secret.yml.j2
@@ -15,3 +15,8 @@ data:
   wx_apikey: {{ mas_aibroker_watsonxai_apikey | b64encode }}
   wx_project_id: {{ mas_aibroker_watsonxai_project_id | b64encode }}
   wx_url: {{ mas_aibroker_watsonxai_url | b64encode }}
+{% if wx_full_on_prem is 'true' and wx_instance_id is defined and wx_version is defined and wx_username is defined %}
+  wx_instance_id: {{ wx_instance_id | b64encode }}
+  wx_version: {{ wx_version | b64encode }}
+  wx_username: {{ wx_username | b64encode }}
+{% endif %}

--- a/ibm/mas_devops/roles/aibroker_tenant/templates/watsonx/secret.yml.j2
+++ b/ibm/mas_devops/roles/aibroker_tenant/templates/watsonx/secret.yml.j2
@@ -15,7 +15,7 @@ data:
   wx_apikey: {{ mas_aibroker_watsonxai_apikey | b64encode }}
   wx_project_id: {{ mas_aibroker_watsonxai_project_id | b64encode }}
   wx_url: {{ mas_aibroker_watsonxai_url | b64encode }}
-{% if wx_full_on_prem is 'true' and wx_instance_id is defined and wx_version is defined and wx_username is defined %}
+{% if wx_full is 'true' and wx_instance_id is defined and wx_version is defined and wx_username is defined %}
   wx_instance_id: {{ wx_instance_id | b64encode }}
   wx_version: {{ wx_version | b64encode }}
   wx_username: {{ wx_username | b64encode }}

--- a/ibm/mas_devops/roles/aibroker_tenant/templates/watsonx/secret.yml.j2
+++ b/ibm/mas_devops/roles/aibroker_tenant/templates/watsonx/secret.yml.j2
@@ -15,7 +15,7 @@ data:
   wx_apikey: {{ mas_aibroker_watsonxai_apikey | b64encode }}
   wx_project_id: {{ mas_aibroker_watsonxai_project_id | b64encode }}
   wx_url: {{ mas_aibroker_watsonxai_url | b64encode }}
-{% if wx_full is 'true' and wx_instance_id is defined and wx_version is defined and wx_username is defined %}
+{% if wx_full == 'true' and wx_instance_id is defined and wx_version is defined and wx_username is defined %}
   wx_instance_id: {{ wx_instance_id | b64encode }}
   wx_version: {{ wx_version | b64encode }}
   wx_username: {{ wx_username | b64encode }}


### PR DESCRIPTION
## Issue
<!-- Provide the ID numbers of issues related to this change. Please do not provide direct links to IBM-internal systems. If there are no issues related to this change, why are you working on it? -->
https://jsw.ibm.com/browse/MASAIB-1131
## Description
<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->
add 3 new variables to secret:
wx_instance_id
wx_version
wx_username
when specify variable WX_FULL as true and these 3 env defined
WX_FULL is true if customer have on prem watsonx installed.
## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->
when WX_FULL is false
<img width="1444" height="924" alt="Screenshot 2025-07-18 at 7 49 09 PM" src="https://github.com/user-attachments/assets/d8d7706b-68d4-43de-96ff-dbe26209f895" />
when WX_FULL is true
<img width="1439" height="926" alt="Screenshot 2025-07-18 at 7 54 08 PM" src="https://github.com/user-attachments/assets/8843edfa-5f0c-4345-b500-a881d9625bad" />

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
