### PR TITLE
[patch] Remove 4.14 from ocp rotation

### DIFF
--- a/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
@@ -33,8 +33,8 @@
       Tuesday: 4.17
       Wednesday: 4.16
       Thursday: 4.15
-      Friday: 4.17
-      Saturday: 4.18
+      Friday: 4.18
+      Saturday: 4.17
       Sunday: 4.16
 
 - name: "Set default OCP version"

--- a/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
@@ -33,7 +33,7 @@
       Tuesday: 4.17
       Wednesday: 4.16
       Thursday: 4.15
-      Friday: 4.14
+      Friday: 4.17
       Saturday: 4.18
       Sunday: 4.16
 


### PR DESCRIPTION
## Issue
https://ibm-watson-iot.slack.com/archives/C031Q7W21FZ/p1753430888295429

The provision failed with error "Unable to apply 4.14.52: the cluster operator image-registry is not available"

https://cloud.ibm.com/docs/openshift?topic=openshift-openshift_changelog_414

## Description
Updated the rotation list for ocp 

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
