### PR TITLE
[patch] Enable TLS verification for istio DestinationRule used by Kmodel

### DIFF
--- a/ibm/mas_devops/roles/kmodels/templates/istio/istio.yml.j2
+++ b/ibm/mas_devops/roles/kmodels/templates/istio/istio.yml.j2
@@ -34,4 +34,4 @@ spec:
       - port:
           number: 9000
         tls:
-          mode: ISTIO_MUTUAL.     # can be changed to MUTUAL to use certificate created by aibroker operator, once kmodel is added in operator.
+          mode: ISTIO_MUTUAL     # can be changed to MUTUAL to use certificate created by aibroker operator, once kmodel is added in operator.

--- a/ibm/mas_devops/roles/kmodels/templates/istio/istio.yml.j2
+++ b/ibm/mas_devops/roles/kmodels/templates/istio/istio.yml.j2
@@ -20,7 +20,7 @@ spec:
       - port:
           number: 8888
         tls:
-          mode: DISABLE
+          mode: ISTIO_MUTUAL      # can be changed to MUTUAL to use certificate created by aibroker operator, once kmodel is added in operator.
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
@@ -34,4 +34,4 @@ spec:
       - port:
           number: 9000
         tls:
-          mode: DISABLE
+          mode: ISTIO_MUTUAL.     # can be changed to MUTUAL to use certificate created by aibroker operator, once kmodel is added in operator.


### PR DESCRIPTION
## Issue
[MASAIB-1108](https://jsw.ibm.com/browse/MASAIB-1108)

## Description
Enable TLS verification for Istio

## Test Results
WIP

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
