### PR TITLE
[patch] Enable mTLS verification for DestinationRule used by ODH

### DIFF
--- a/ibm/mas_devops/roles/aiservice_kmodels/templates/istio/istio.yml.j2
+++ b/ibm/mas_devops/roles/aiservice_kmodels/templates/istio/istio.yml.j2
@@ -20,7 +20,7 @@ spec:
       - port:
           number: 8888
         tls:
-          mode: DISABLE
+          mode: ISTIO_MUTUAL      # can be changed to MUTUAL to use certificate created by aibroker operator, once kmodel is added in operator.
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
@@ -34,4 +34,4 @@ spec:
       - port:
           number: 9000
         tls:
-          mode: DISABLE
+          mode: ISTIO_MUTUAL     # can be changed to MUTUAL to use certificate created by aibroker operator, once kmodel is added in operator.


### PR DESCRIPTION
## Issue
[MASAIB-1108](https://jsw.ibm.com/browse/MASAIB-1108)

## Description
Enable mTLS verification for DestinationRule used by opendatahub.

## Test Results
Successfully tested deployment with this change.
<img width="1462" height="796" alt="Screenshot 2025-07-28 at 4 43 55 PM" src="https://github.com/user-attachments/assets/0e37b54e-1156-4dab-b58b-c29a31b7faf4" />
<img width="1434" height="743" alt="Screenshot 2025-07-28 at 4 43 06 PM" src="https://github.com/user-attachments/assets/a30eb629-fed7-49ef-be05-ae605ff15f36" />
<img width="1163" height="729" alt="Screenshot 2025-07-28 at 4 42 46 PM" src="https://github.com/user-attachments/assets/e2514bdf-7937-4a17-97d5-43dead44f691" />
<img width="1350" height="581" alt="Screenshot 2025-07-28 at 2 43 08 PM" src="https://github.com/user-attachments/assets/c29e7b36-6953-4c51-a7bf-fae2444eab63" />
<img width="1354" height="882" alt="Screenshot 2025-07-28 at 2 44 00 PM" src="https://github.com/user-attachments/assets/252330ba-ef5d-46e8-9830-70e650f468aa" />
<img width="1328" height="757" alt="Screenshot 2025-07-28 at 2 42 57 PM" src="https://github.com/user-attachments/assets/d36eb6b1-4000-4586-a455-827cc5126907" />
<img width="1349" height="875" alt="Screenshot 2025-07-28 at 2 42 45 PM" src="https://github.com/user-attachments/assets/d1566bb2-0500-413a-a84a-ba529cd3d31e" />

Must gather logs: [must-gather-20250728-091618.tgz](https://github.com/user-attachments/files/21468614/must-gather-20250728-091618.tgz)

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
