### PR TITLE
[patch] Restrict db2 automatic version selection to Db2 v11

### DIFF
--- a/build/bin/build-collection.sh
+++ b/build/bin/build-collection.sh
@@ -13,8 +13,8 @@ cat $GITHUB_WORKSPACE/ibm/mas_devops/galaxy.yml
 
 
 # Update this when we have new catalog
-MAS_PREVIOUS_CATALOG='v9-250624-amd64'
-MAS_LATEST_CATALOG='v9-250731-amd64'
+MAS_PREVIOUS_CATALOG='v9-250501-amd64'
+MAS_LATEST_CATALOG='v9-250624-amd64'
 
 
 # Update all the placeholders in the playbooks


### PR DESCRIPTION
## Issue
MASCORE-8389

## Description


if we install the db2u with latest changes available into the catalog packages it's by default installing the latest available that is currently v12.x
that is not compatible with the Current mas, 


we need to filter the v12.x version and remove from the list of db2u operators to install the latest patch available into v11.x channel


## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
