### PR TITLE
[patch] Always B64 encode AI service's JDBC cert

### DIFF
--- a/ibm/mas_devops/playbooks/aiservice.yml
+++ b/ibm/mas_devops/playbooks/aiservice.yml
@@ -88,10 +88,9 @@
     - role: ibm.mas_devops.minio
       when: install_minio == true
 
-    - role: ibm.mas_devops.odh
+    - role: ibm.mas_devops.aiservice_odh
 
-    - role: ibm.mas_devops.kmodels
-
+    - role: ibm.mas_devops.aiservice_kmodels
     # 2. AI Service
     # -------------------------------------------------------------------------
     - role: ibm.mas_devops.aiservice

--- a/ibm/mas_devops/roles/aiservice_tenant/templates/aiservice/aiserviceworkspace.yml.j2
+++ b/ibm/mas_devops/roles/aiservice_tenant/templates/aiservice/aiserviceworkspace.yml.j2
@@ -23,21 +23,11 @@ spec:
         dro:
             url: "{{ drocfg.url }}"
             secretName: "{{ aiservice_dro_token_secret }}"
-# TODO: remove this condition before patch release - as it is temporary fix.
-{% if aiservice_channel == '9.1.x' %}
-            ca: "{{ drocfg.ca }}"
-{% else %}
             ca: "{{ drocfg.ca | b64encode  }}"
-{% endif %}
         sls:
             url: "{{ slscfg.url }}"
             secretName: "{{ aiservice_sls_secret }}"
-# TODO: remove this condition before patch release - as it is temporary fix.
-{% if aiservice_channel == '9.1.x' %}
-            ca: "{{ slscfg.ca }}"
-{% else %}
             ca: "{{ slscfg.ca | b64encode  }}"
-{% endif %}
         rsl:
             url: {{ rsl_url }}
             orgId: {{ rsl_org_id }}


### PR DESCRIPTION
remove condition from aiserviceworkspace regarding of encoding of ca cert

## Issue
<!-- Provide the ID numbers of issues related to this change. Please do not provide direct links to IBM-internal systems. If there are no issues related to this change, why are you working on it? -->

## Description
<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
