### PR TITLE
[patch] add check while applying dro pvc

### DIFF
--- a/ibm/mas_devops/roles/dro/tasks/install-dro/main.yml
+++ b/ibm/mas_devops/roles/dro/tasks/install-dro/main.yml
@@ -37,6 +37,12 @@
       - "User Provided DRO Storage Class Name ..................... {{ dro_storage_class }}"
   when: dro_storage_class is defined and (dro_storage_class | length > 0)
 
+- name: Lookup previous DRO PVC
+  kubernetes.core.k8s_info:
+    namespace: "{{ dro_namespace }}"
+    kind: PersistentVolumeClaim
+  register: dro_installed_pvc
+
 - name: Determine Storage Class
   include_tasks: tasks/install-dro/determine-storage-classes.yml
   when: dro_storage_class is not defined or dro_storage_class == ""
@@ -44,6 +50,7 @@
 - name: Create DRO PVC
   kubernetes.core.k8s:
     definition: "{{ lookup('template', 'templates/dro-pvc.yml.j2') }}"
+  when: dro_installed_pvc.resources is defined and dro_installed_pvc.resources | length == 0
 
 # 5. Create Marketplace Pull Secret
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Issue
#1752 

## Description
Retrieve old PVC deployments and added a conditional check around the task that deploys DRO PVC. If it already exists, it's going to skip.

## Test Results
Step:
- Run DRO role in already installed instance and verified if the task was going to be skipped.
<img width="1901" height="1042" alt="image" src="https://github.com/user-attachments/assets/29440b98-78c2-4a9e-8b35-d25ea7abb901" />

- Uninstalled DRO by setting `DRO_ACTION=uninstall` and running the role.
- Installed the DRO again to verify if the default functionality was not affected.
<img width="1900" height="990" alt="image" src="https://github.com/user-attachments/assets/1b077e7a-4a3d-4bec-a1a1-39e5127115d4" />

- Uninstalled and installed with `DRO_STORAGE_CLASS=ocs-storgacluster-ceph-rbd`
- Unset `DRO_STORAGE_CLASS` and run the role again.
<img width="1900" height="960" alt="image" src="https://github.com/user-attachments/assets/d1c472b1-3062-49d8-b3c9-817e43051e1c" />


<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
