### PR TITLE
Fix cluster removal command to clean up storage properly in roks.yml

### DIFF
--- a/ibm/mas_devops/roles/ocp_deprovision/tasks/providers/roks.yml
+++ b/ibm/mas_devops/roles/ocp_deprovision/tasks/providers/roks.yml
@@ -35,7 +35,7 @@
 - name: "roks : Deprovision ROKS cluster"
   when: cluster_lookup.rc == 0
   shell: |
-    ibmcloud oc cluster rm --cluster {{ cluster_name }} --force-delete-storage -f
+    ibmcloud oc cluster rm --cluster {{ cluster_name }} --force --delete-storage -f
 
 - name: "roks : ROKS cluster does not exist"
   when: cluster_lookup.rc == 1


### PR DESCRIPTION
## Issue
No specific issue ID. This PR addresses a problem where Object Storage (COS) buckets were not being deleted during OpenShift cluster removal on IBM Cloud Classic infrastructure, resulting in continued storage costs.

## Description
This change corrects the usage of the IBM Cloud CLI flags in the cluster deletion command. Previously, the command used: `--force-delete-storage`, which is **not a valid flag**, causing persistent storage resources (like COS buckets) to remain undeleted. The corrected command is: `--force --delete-storage -f`, which ensures the cluster and all associated storage, including Object Storage buckets, are deleted properly. This change was necessary due to observed increases in IBM Cloud storage costs (~$5–6k/month) caused by orphaned storage resources that were not removed during previous deletions.

## Test Results
The updated command was manually executed against a Classic OpenShift cluster, and the associated Object Storage was successfully deleted. No errors were encountered, and the expected cleanup behavior was confirmed.

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
