### PR TITLE
[patch] Add missing storage variables to kmodels role

### DIFF
--- a/docs/playbooks/aiservice.md
+++ b/docs/playbooks/aiservice.md
@@ -31,7 +31,7 @@ This playbook can be ran against any OCP cluster regardless of its type; whether
     - IBM Suite License Service (~10 Minutes) **optional**
     - IBM Data Reporter Operator (~10 Minutes) **optional**
     - IBM Db2 **optional**
-    - Minio (~5 minutes) **optional**
+    - Minio (~5 minutes) **optional** please see this [warning](#warning)
 - Install ODH:
     - Install Red Hat OpenShift Serverless Operator
     - Install Red Hat OpenShift Service Mesh Operator
@@ -113,6 +113,10 @@ Optional environment variables
 * `USE_AWS_DB2` A flag indicating whether to use an AWS-hosted DB2 instance (default value is: false)
 * `AISERVICE_CLUSTER_DOMAIN` Provide custom domain (default value is: empty)
 * `AISERVICE_IS_EXTERNAL_ROUTE` A flag indicating to enable external route (default value is: false)
+
+# warning
+
+**Please notice that minio deployment role is just for testing purpose. User should use own minio (secure) deployment or use AWS S3.**
 
 
 Usage

--- a/docs/playbooks/aiservice.md
+++ b/docs/playbooks/aiservice.md
@@ -31,7 +31,7 @@ This playbook can be ran against any OCP cluster regardless of its type; whether
     - IBM Suite License Service (~10 Minutes) **optional**
     - IBM Data Reporter Operator (~10 Minutes) **optional**
     - IBM Db2 **optional**
-    - Minio (~5 minutes) **optional** please see this [warning](#warning)
+    - Minio (~5 minutes) **optional**
 - Install ODH:
     - Install Red Hat OpenShift Serverless Operator
     - Install Red Hat OpenShift Service Mesh Operator
@@ -113,11 +113,6 @@ Optional environment variables
 * `USE_AWS_DB2` A flag indicating whether to use an AWS-hosted DB2 instance (default value is: false)
 * `AISERVICE_CLUSTER_DOMAIN` Provide custom domain (default value is: empty)
 * `AISERVICE_IS_EXTERNAL_ROUTE` A flag indicating to enable external route (default value is: false)
-
-# warning
-
-**Please notice that minio deployment role is just for testing purpose. User should use own minio (secure) deployment or use AWS S3.**
-
 
 Usage
 -------------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/aiservice_kmodels/defaults/main.yml
+++ b/ibm/mas_devops/roles/aiservice_kmodels/defaults/main.yml
@@ -63,5 +63,5 @@ aiservice_provision_tenant: "{{ lookup('env', 'AISERVICE_PROVISION_TENANT') | de
 # S3
 aiservice_storage_ssl: "{{ lookup('env', 'AISERVICE_STORAGE_SSL') | default('true', true) }}"
 
-# kmodels custom version: 
+# kmodels custom version
 kmodels_extras_version: "{{ lookup('env', 'KMODELS_VERSION') }}"

--- a/ibm/mas_devops/roles/aiservice_kmodels/defaults/main.yml
+++ b/ibm/mas_devops/roles/aiservice_kmodels/defaults/main.yml
@@ -64,7 +64,7 @@ aiservice_provision_tenant: "{{ lookup('env', 'AISERVICE_PROVISION_TENANT') | de
 kmodels_extras_version: "{{ lookup('env', 'KMODELS_VERSION') }}"
 
 # Storage vars
-aiservice_storage_provider: "{{ lookup('env', 'AISERVICE_STORAGE_PROVIDER') | default('aws', true) }}"
+aiservice_storage_provider: "{{ lookup('env', 'AISERVICE_STORAGE_PROVIDER') | default('', true) }}"
 aiservice_storage_accesskey: "{{ lookup('env', 'AISERVICE_STORAGE_ACCESSKEY') | default('', true) }}"
 aiservice_storage_secretkey: "{{ lookup('env', 'AISERVICE_STORAGE_SECRETKEY') | default('', true) }}"
 aiservice_storage_host: "{{ lookup('env', 'AISERVICE_STORAGE_HOST') | default('', true) }}"

--- a/ibm/mas_devops/roles/aiservice_kmodels/defaults/main.yml
+++ b/ibm/mas_devops/roles/aiservice_kmodels/defaults/main.yml
@@ -60,9 +60,6 @@ aiservice_storage_templates_bucket: "{{ lookup('env', 'AISERVICE_STORAGE_TEMPLAT
 aiservice_saas: "{{ lookup('env', 'AISERVICE_SAAS') | default('false', true) | bool }}"
 aiservice_provision_tenant: "{{ lookup('env', 'AISERVICE_PROVISION_TENANT') | default('provision-tenant', true) }}"
 
-# S3
-aiservice_storage_ssl: "{{ lookup('env', 'AISERVICE_STORAGE_SSL') | default('true', true) }}"
-
 # kmodels custom version
 kmodels_extras_version: "{{ lookup('env', 'KMODELS_VERSION') }}"
 
@@ -74,4 +71,3 @@ aiservice_storage_host: "{{ lookup('env', 'AISERVICE_STORAGE_HOST') | default(''
 aiservice_storage_port: "{{ lookup('env', 'AISERVICE_STORAGE_PORT') | default('', true) }}"
 aiservice_storage_ssl: "{{ lookup('env', 'AISERVICE_STORAGE_SSL') | default('true', true) }}"
 aiservice_storage_region: "{{ lookup('env', 'AISERVICE_STORAGE_REGION') | default('', true) }}"
-aiservice_storage_pipelines_bucket: "{{ lookup('env', 'AISERVICE_STORAGE_PIPELINES_BUCKET') }}"

--- a/ibm/mas_devops/roles/aiservice_kmodels/defaults/main.yml
+++ b/ibm/mas_devops/roles/aiservice_kmodels/defaults/main.yml
@@ -62,3 +62,6 @@ aiservice_provision_tenant: "{{ lookup('env', 'AISERVICE_PROVISION_TENANT') | de
 
 # S3
 aiservice_storage_ssl: "{{ lookup('env', 'AISERVICE_STORAGE_SSL') | default('true', true) }}"
+
+# kmodels custom version: 
+kmodels_extras_version: "{{ lookup('env', 'KMODELS_VERSION') }}"

--- a/ibm/mas_devops/roles/aiservice_kmodels/defaults/main.yml
+++ b/ibm/mas_devops/roles/aiservice_kmodels/defaults/main.yml
@@ -65,3 +65,13 @@ aiservice_storage_ssl: "{{ lookup('env', 'AISERVICE_STORAGE_SSL') | default('tru
 
 # kmodels custom version
 kmodels_extras_version: "{{ lookup('env', 'KMODELS_VERSION') }}"
+
+# Storage vars
+aiservice_storage_provider: "{{ lookup('env', 'AISERVICE_STORAGE_PROVIDER') | default('aws', true) }}"
+aiservice_storage_accesskey: "{{ lookup('env', 'AISERVICE_STORAGE_ACCESSKEY') | default('', true) }}"
+aiservice_storage_secretkey: "{{ lookup('env', 'AISERVICE_STORAGE_SECRETKEY') | default('', true) }}"
+aiservice_storage_host: "{{ lookup('env', 'AISERVICE_STORAGE_HOST') | default('', true) }}"
+aiservice_storage_port: "{{ lookup('env', 'AISERVICE_STORAGE_PORT') | default('', true) }}"
+aiservice_storage_ssl: "{{ lookup('env', 'AISERVICE_STORAGE_SSL') | default('true', true) }}"
+aiservice_storage_region: "{{ lookup('env', 'AISERVICE_STORAGE_REGION') | default('', true) }}"
+aiservice_storage_pipelines_bucket: "{{ lookup('env', 'AISERVICE_STORAGE_PIPELINES_BUCKET') }}"


### PR DESCRIPTION
This PR is for give warning to customer to not use minio role included in this automation. Instead customer can use own minio secure instance or AWS S3. 

Also added variable to specify custom version of kmodels components

## Issue
<!-- Provide the ID numbers of issues related to this change. Please do not provide direct links to IBM-internal systems. If there are no issues related to this change, why are you working on it? -->

## Description
<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
