### PR TITLE
[patch] removed validation check for rsl

### DIFF
--- a/ibm/mas_devops/roles/aiservice_tenant/tasks/config_rsl/main.yml
+++ b/ibm/mas_devops/roles/aiservice_tenant/tasks/config_rsl/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Check if all RSL config values are present"
   ansible.builtin.set_fact:
-    rsl_config_valid: "{{ rsl_url | length > 0 and rsl_org_id | length > 0 and rsl_token | length > 0 and rsl_ca_crt | length > 0 }}"
+    rsl_config_valid: "{{ rsl_url | length > 0 and rsl_org_id | length > 0 and rsl_token | length > 0 }}"
 
 - name: "Unset RSL Secret name"
   ansible.builtin.set_fact:


### PR DESCRIPTION
## Issue
<!-- Provide the ID numbers of issues related to this change. Please do not provide direct links to IBM-internal systems. If there are no issues related to this change, why are you working on it? -->
i removed the check for creating rsl-secret which is needed for fmea models. This certificate param should be only required when RSL API uses self signed certificate. So i removed length check on certificate while creating rsl secret.

## Description
<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
