### PR TITLE
[patch] Add --delete-openshift-registry-cos-bucket to roks deprovision

### DIFF
--- a/ibm/mas_devops/roles/ocp_deprovision/tasks/providers/roks.yml
+++ b/ibm/mas_devops/roles/ocp_deprovision/tasks/providers/roks.yml
@@ -35,7 +35,7 @@
 - name: "roks : Deprovision ROKS cluster"
   when: cluster_lookup.rc == 0
   shell: |
-    ibmcloud oc cluster rm --cluster {{ cluster_name }} --delete-storage -f
+    ibmcloud oc cluster rm --cluster {{ cluster_name }} --delete-storage --delete-openshift-registry-cos-bucket -f
 
 - name: "roks : ROKS cluster does not exist"
   when: cluster_lookup.rc == 1


### PR DESCRIPTION
ROKS have changed their cli flags, we now need to set `--delete-openshift-registry-cos-bucket` otherwise some storage is left behind when a cluster is deprovisioned.