### PR TITLE
[patch] fix db2u facilties install

### DIFF
--- a/ibm/mas_devops/roles/db2/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/db2/tasks/install/main.yml
@@ -371,19 +371,8 @@
     namespace: "{{db2_namespace}}"
     state: absent
 
-# 16. Delete db2 pod on intial setup only, to workaround db2 issue
-# that was causing TLS connection issues when the pod was first started
-# -----------------------------------------------------------------------------
-# - name: Delete db2u pod on initial setup
-#   kubernetes.core.k8s:
-#     api_version: v1
-#     kind: Pod
-#     name: "c-{{db2_instance_name | lower}}-db2u-0"
-#     namespace: "{{db2_namespace}}"
-#     state: absent
-#   when: initial_db2_cluster_lookup.resources | length == 0
 
-# 17. create an LDAP user if db2_ldap_username specified
+# 16. create an LDAP user if db2_ldap_username specified
 # -----------------------------------------------------------------------------
 - name: Create LDAP user if username and password is provided
   include_tasks: tasks/install/create_ldap_user.yml
@@ -399,7 +388,7 @@
       - "{{db2_ldap_username}}"
       - "{{db2_rotate_password}}"
 
-# 18. Rotate db2 ldap password
+# 17. Rotate db2 ldap password
 # -----------------------------------------------------------------------------
 - name: Rotate Db2 LDAP password if db2_rotate_password is True and username is provided
   include_tasks: tasks/install/rotate_ldap_user_password.yml
@@ -408,7 +397,7 @@
     - db2_ldap_username != ""
     - db2_rotate_password == true
 
-# 19. Wait for the statefulset to be ready
+# 18. Wait for the statefulset to be ready
 # -----------------------------------------------------------------------------
 - name: "Wait for Db2 Stateful set to be ready"
   kubernetes.core.k8s_info:
@@ -427,7 +416,7 @@
   retries: 20 # approx 10 minutes before we give up
   delay: 30 # seconds
 
-# 20. Generate a JdbcCfg for MAS configuration
+# 19. Generate a JdbcCfg for MAS configuration
 # -----------------------------------------------------------------------------
 - include_tasks: tasks/install/suite_jdbccfg.yml
   when:


### PR DESCRIPTION
## Issue
without this change facilities db2 setup failing with db2u latest version: `v110509.0.5`

Below steps we did to validate the changes:
1. Manually delete the db2u pod
2. Wait for new pod to come up and ready
3. wait for jdbccfg to reconcile, it was working fine after recreating the pod

It means somewhere in the previous or current db2u version issue: `that was causing TLS connection issues when the pod was first started` have been resolved

so removing the code:
```
# 16. Delete db2 pod on intial setup only, to workaround db2 issue
# that was causing TLS connection issues when the pod was first startedà
# Comment out becuase the database could end-up in an inconsistent state
# -----------------------------------------------------------------------------
- name: Delete db2u pod on initial setup
  kubernetes.core.k8s:
    api_version: v1
    kind: Pod
    name: "c-{{db2_instance_name | lower}}-db2u-0"
    namespace: "{{db2_namespace}}"
    state: absent
  when: initial_db2_cluster_lookup.resources | length == 0
```




## Description
<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->

## Test Results
Tested on pfvt:
https://dashboard.masdev.wiotp.sl.hursley.ibm.com/tests/pfvtdb2u

<img width="1060" height="885" alt="image" src="https://github.com/user-attachments/assets/8fee487c-36af-4543-bde5-e93dcfba56fd" />


<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
