### PR TITLE
[patch] Add extra images for kmodels 1.0.14 as part of aiservice august patch

### DIFF
--- a/ibm/mas_devops/roles/mirror_extras_prepare/vars/kmodels_1.0.14.yml
+++ b/ibm/mas_devops/roles/mirror_extras_prepare/vars/kmodels_1.0.14.yml
@@ -1,0 +1,14 @@
+---
+extra_images:
+  - name: cp/aibroker/controller
+    registry: cp.icr.io/cp
+    tag: 1.0.14
+    digest: sha256:cbd6f839ca854643be40db49541cdfce8ba2bfb47e777da717fb84305210337d
+  - name: cp/aibroker/store
+    registry: cp.icr.io/cp
+    tag: 1.0.9
+    digest: sha256:2fb658cb69342078301c2cb849b1b2dd6f572fa9140a4057941611e14e963a9f
+  - name: cp/aibroker/watcher
+    registry: cp.icr.io/cp
+    tag: 1.0.6
+    digest: sha256:3f53007c095a138f4d4f50a7e3764f5013112ee3e6edee3a07059c1a119f0d45


### PR DESCRIPTION
## Issue
https://jsw.ibm.com/browse/MASAIB-1270

## Description
https://github.com/ibm-mas/ansible-devops/pull/1890
this is related to aibroker august patch

## Test Results
This is tested on fyre cluster


