### PR TITLE
[patch] temp fix for odh issue on roks cluster

### DIFF
--- a/ibm/mas_devops/roles/aiservice_odh/tasks/main.yml
+++ b/ibm/mas_devops/roles/aiservice_odh/tasks/main.yml
@@ -65,3 +65,15 @@
 # 5. Create Istio Auth Rules
 # -----------------------------------------------------------------------------
 - include_tasks: tasks/istio-auth.yml
+
+
+# 6. Install Network policy
+# -----------------------------------------------------------------------------
+# This network policy is added as a temporary workaround to resolve an issue (specifically on the ROKS cluster)
+# where requests from the Kubernetes API to the odh-model-controller-webhook were being blocked.
+# This was causing errors while creating a inference service.
+
+- name: "Install network policy: allow-odh-model-controller"
+  kubernetes.core.k8s:
+    apply: yes
+    definition: "{{ lookup('template', 'templates/odh/allow-odh-model-controller-netpol.yml.j2') }}"

--- a/ibm/mas_devops/roles/aiservice_odh/templates/istio/istio.yml.j2
+++ b/ibm/mas_devops/roles/aiservice_odh/templates/istio/istio.yml.j2
@@ -20,7 +20,7 @@ spec:
       - port:
           number: 8888
         tls:
-          mode: ISTIO_MUTUAL      # can be changed to MUTUAL to use certificate created by aibroker operator, once kmodel is added in operator.
+          mode: ISTIO_MUTUAL
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
@@ -34,4 +34,4 @@ spec:
       - port:
           number: 9000
         tls:
-          mode: ISTIO_MUTUAL     # can be changed to MUTUAL to use certificate created by aibroker operator, once kmodel is added in operator.
+          mode: ISTIO_MUTUAL

--- a/ibm/mas_devops/roles/aiservice_odh/templates/odh/allow-odh-model-controller-netpol.yml.j2
+++ b/ibm/mas_devops/roles/aiservice_odh/templates/odh/allow-odh-model-controller-netpol.yml.j2
@@ -1,0 +1,15 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-odh-model-controller
+  namespace: opendatahub
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: odh-model-controller
+  ingress:
+    - from:
+        - namespaceSelector: {}
+  policyTypes:
+    - Ingress


### PR DESCRIPTION
Add network policy in opendatahub namespace to allow requests from any namespace to odh-model-controller-webhook.

This network policy is added as a temporary workaround to resolve an issue (specifically on the ROKS cluster)
where requests from the Kubernetes API to the odh-model-controller-webhook were being blocked.