### PR TITLE
[patch] Bug fix for DSC template in odh role

### DIFF
--- a/ibm/mas_devops/roles/aiservice_odh/templates/odh/data-science-cluster.yml.j2
+++ b/ibm/mas_devops/roles/aiservice_odh/templates/odh/data-science-cluster.yml.j2
@@ -15,6 +15,7 @@ spec:
     kserve:
       managementState: Managed
       serving:
+        name: knative-serving
         ingressGateway:
           certificate:
             type: SelfSigned
@@ -24,4 +25,3 @@ spec:
 {% else %}
         managementState: Managed
 {% endif %}
-        name: knative-serving


### PR DESCRIPTION
## Issue
ODH role was failing while creating DSC CR. Root cause is while rendering template, parent key was changed for `name: knative-serving`. 

## Description
Fix for ODH role,

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
