### PR TITLE
[patch] Fix mongo upgrade flag applying to updates

### DIFF
--- a/ibm/mas_devops/roles/mongodb/tasks/providers/community/validate-upgrade.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/community/validate-upgrade.yml
@@ -63,7 +63,7 @@
 # This would validate that we only upgrade to v7.0 if 'target_mongodb_version' matches v7.0 minor version and 'mongodb_v7_upgrade: true'
 - name: "Assert that the Mongo v7 upgrade has been triggered"
   when:
-    - existing_mongo_minor_version is version_compare('7.0', '<=')
+    - existing_mongo_minor_version is version_compare('7.0', '<')
     - target_mongodb_version | regex_search('(?<=)(.*)(?=...)') == '7.0'
   assert:
     that: mongodb_v7_upgrade


### PR DESCRIPTION
## Description
The `mongodb_v7_upgrade` flag is incorrectly being required for updates as well as upgrades.

## Test Results
No testing done, simple and obvious logic change that can be peer reviewed.

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
