### PR TITLE
[minor] Add ibm.com/kyverno namespace label support

### DIFF
--- a/ibm/mas_devops/plugins/action/update_ibm_entitlement.py
+++ b/ibm/mas_devops/plugins/action/update_ibm_entitlement.py
@@ -24,6 +24,7 @@ class ActionModule(ActionBase):
           icr_password: "{{ icr_password }}"
           artifactory_username: "{{ artifactory_username }}"
           artifactory_password: "{{ artifactory_token }}"
+          kyverno_labels: true|false
         register: secret
     """
     def run(self, tmp=None, task_vars=None):
@@ -35,6 +36,7 @@ class ActionModule(ActionBase):
         artifactoryUsername = self._task.args.get('artifactory_username', None)
         artifactoryPassword = self._task.args.get('artifactory_password', None)
         secretName = self._task.args.get('secret_name', None)
+        kyvernoLabels = self._task.args.get('kyverno_labels', None)
 
         if namespace is None:
             raise AnsibleError(f"Error: namespace argument was not provided")
@@ -44,7 +46,7 @@ class ActionModule(ActionBase):
         api_key = self._task.args.get('api_key', None)
 
         dynClient = get_api_client(api_key=api_key, host=host)
-        createNamespace(dynClient, namespace)
+        createNamespace(dynClient, namespace, kyvernoLabels)
         secret = updateIBMEntitlementKey(dynClient, namespace, icrUsername, icrPassword, artifactoryUsername, artifactoryPassword, secretName)
 
         return dict(

--- a/ibm/mas_devops/plugins/action/update_ibm_entitlement.py
+++ b/ibm/mas_devops/plugins/action/update_ibm_entitlement.py
@@ -24,7 +24,7 @@ class ActionModule(ActionBase):
           icr_password: "{{ icr_password }}"
           artifactory_username: "{{ artifactory_username }}"
           artifactory_password: "{{ artifactory_token }}"
-          kyverno_labels: true|false
+          namespace_kyverno_label: "audit"
         register: secret
     """
     def run(self, tmp=None, task_vars=None):
@@ -36,7 +36,7 @@ class ActionModule(ActionBase):
         artifactoryUsername = self._task.args.get('artifactory_username', None)
         artifactoryPassword = self._task.args.get('artifactory_password', None)
         secretName = self._task.args.get('secret_name', None)
-        kyvernoLabels = self._task.args.get('kyverno_labels', None)
+        namespaceKyvernoLabel = self._task.args.get('namespace_kyverno_label', None)
 
         if namespace is None:
             raise AnsibleError(f"Error: namespace argument was not provided")
@@ -46,7 +46,7 @@ class ActionModule(ActionBase):
         api_key = self._task.args.get('api_key', None)
 
         dynClient = get_api_client(api_key=api_key, host=host)
-        createNamespace(dynClient, namespace, kyvernoLabels)
+        createNamespace(dynClient, namespace, namespaceKyvernoLabel)
         secret = updateIBMEntitlementKey(dynClient, namespace, icrUsername, icrPassword, artifactoryUsername, artifactoryPassword, secretName)
 
         return dict(

--- a/ibm/mas_devops/roles/aiservice/tasks/aiservice/main.yml
+++ b/ibm/mas_devops/roles/aiservice/tasks/aiservice/main.yml
@@ -25,6 +25,7 @@
     icr_password: "{{ mas_entitlement_key }}"
     artifactory_username: "{{ artifactory_username }}"
     artifactory_password: "{{ artifactory_token }}"
+    kyverno_labels: true
 
 - name: "Create ibm-aiservice Subscription"
   ibm.mas_devops.apply_subscription:

--- a/ibm/mas_devops/roles/aiservice/tasks/aiservice/main.yml
+++ b/ibm/mas_devops/roles/aiservice/tasks/aiservice/main.yml
@@ -25,7 +25,7 @@
     icr_password: "{{ mas_entitlement_key }}"
     artifactory_username: "{{ artifactory_username }}"
     artifactory_password: "{{ artifactory_token }}"
-    kyverno_labels: true
+    namespace_kyverno_label: "audit"
 
 - name: "Create ibm-aiservice Subscription"
   ibm.mas_devops.apply_subscription:

--- a/ibm/mas_devops/roles/aiservice_tenant/tasks/namespace/install/main.yml
+++ b/ibm/mas_devops/roles/aiservice_tenant/tasks/namespace/install/main.yml
@@ -11,5 +11,7 @@
     name: "{{ tenantNamespace }}"
     api_version: v1
     kind: Namespace
+    labels:
+      ibm.com/kyverno: "audit"
   when:
     - namespace_info.resources | length == 0

--- a/ibm/mas_devops/roles/db2/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/db2/tasks/install/main.yml
@@ -372,7 +372,6 @@
     state: absent
 
 
-
 ## 16. create an LDAP user if db2_ldap_username specified
 # -----------------------------------------------------------------------------
 - name: Create LDAP user if username and password is provided

--- a/ibm/mas_devops/roles/db2/templates/db2u_namespace.yaml
+++ b/ibm/mas_devops/roles/db2/templates/db2u_namespace.yaml
@@ -3,5 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: "{{ db2_namespace }}"
-  labels: 
+  labels:
     ibm.com/kyverno: audit

--- a/ibm/mas_devops/roles/db2/templates/db2u_namespace.yaml
+++ b/ibm/mas_devops/roles/db2/templates/db2u_namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: "{{ db2_namespace }}"
+  labels: 
+    ibm.com/kyverno: audit

--- a/ibm/mas_devops/roles/dro/tasks/install-dro/main.yml
+++ b/ibm/mas_devops/roles/dro/tasks/install-dro/main.yml
@@ -29,7 +29,20 @@
   kubernetes.core.k8s:
     definition: "{{ lookup('template', 'templates/operatorgroup.yml.j2') }}"
 
-# 4. Create a PVC using the Chosen Storage Class
+# 4. Patch the namespace with the ibm.com/kyverno: audit label
+# ----------------------------------------------------------------------------
+- name: "Patch {{ dro_namespace }} namespace with ibm.com/kyverno: audit label"
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ dro_namespace }}"
+        labels:
+          "ibm.com/kyverno": audit
+
+# 5. Create a PVC using the Chosen Storage Class
 # ----------------------------------------------------------------------------
 - name: "Debug User Provided DRO Storage Class"
   debug:
@@ -52,7 +65,7 @@
     definition: "{{ lookup('template', 'templates/dro-pvc.yml.j2') }}"
   when: dro_installed_pvc.resources is defined and dro_installed_pvc.resources | length == 0
 
-# 5. Create Marketplace Pull Secret
+# 6. Create Marketplace Pull Secret
 # ----------------------------------------------------------------------------
 - name: Get marketplace secret
   kubernetes.core.k8s_info:
@@ -117,14 +130,14 @@
     fail_msg: "Provide IBM Entitlement Key, Access https://myibm.ibm.com/products-services/containerlibrary using your IBMId to access your entitlement key"
   when: (rm_sec.resources is defined) and (rm_sec.resources | length == 0)
 
-# 6. Load PodTemplates configuration
+# 7. Load PodTemplates configuration
 # -----------------------------------------------------------------------------
 - name: "Load podTemplates configuration"
   include_tasks: "{{ role_path }}/../../common_tasks/pod_templates/main.yml"
   vars:
     config_files: ["ibm-mas-bascfg.yml"]
 
-# 7. Install ibm-metrics-operator
+# 8. Install ibm-metrics-operator
 # -----------------------------------------------------------------------------
 - name: Get ibm-metrics-operator Subscription
   kubernetes.core.k8s_info:
@@ -166,7 +179,7 @@
     wait_timeout: 60
   when: (imo_subscription.resources is defined) and (imo_subscription.resources | length == 0)
 
-# 8. Install ibm-data-reporter-operator
+# 9. Install ibm-data-reporter-operator
 # -----------------------------------------------------------------------------
 - name: Get ibm-data-operator Subscription
   kubernetes.core.k8s_info:
@@ -205,32 +218,32 @@
     wait_timeout: 60
   when: (dro_subscription.resources is defined) and (dro_subscription.resources | length == 0)
 
-# 9. Wait until the marketplaceconfigs CRD is available
+# 10. Wait until the marketplaceconfigs CRD is available
 # -----------------------------------------------------------------------------
 - name: "Wait until the marketplaceconfigs CRD is available"
   include_tasks: "{{ role_path }}/../../common_tasks/wait_for_crd.yml"
   vars:
     crd_name: marketplaceconfigs.marketplace.redhat.com
 
-# 10. Apply MarketplaceConfig CR
+# 11. Apply MarketplaceConfig CR
 # -----------------------------------------------------------------------------
 - name: Create MarketplaceConfig CR
   kubernetes.core.k8s:
     definition: "{{ lookup('template', 'templates/MarketplaceConfig-cr.yml.j2') }}"
 
-# 11. Create DRO Pull Secret
+# 12. Create DRO Pull Secret
 # -----------------------------------------------------------------------------
 - name: "Create Secret redhat-marketplace-pull-secret"
   kubernetes.core.k8s:
     definition: "{{ lookup('template', 'templates/rhm-pull-secret.yml.j2') }}"
   when: (rm_sec.resources is defined) and (rm_sec.resources | length == 0)
 
-# 12. Apply required RBACs
+# 13. Apply required RBACs
 - name: "Create ClusterRoleBindings for metric-state"
   kubernetes.core.k8s:
     definition: "{{ lookup('template', 'templates/role_binding.yml.j2') }}"
 
-# 13. Check deployment status
+# 14. Check deployment status
 # -----------------------------------------------------------------------------
 - name: "Wait for the rhm-data-service to be ready"
   kubernetes.core.k8s_info:

--- a/ibm/mas_devops/roles/sls/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/sls/tasks/install/main.yml
@@ -176,6 +176,7 @@
     icr_password: "{{ sls_entitlement_key }}"
     artifactory_username: "{{ artifactory_username }}"
     artifactory_password: "{{ artifactory_token }}"
+    kyverno_labels: true
 
 - name: "Create ibm-sls Subscription"
   ibm.mas_devops.apply_subscription:

--- a/ibm/mas_devops/roles/sls/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/sls/tasks/install/main.yml
@@ -176,7 +176,7 @@
     icr_password: "{{ sls_entitlement_key }}"
     artifactory_username: "{{ artifactory_username }}"
     artifactory_password: "{{ artifactory_token }}"
-    kyverno_labels: true
+    namespace_kyverno_label: "audit"
 
 - name: "Create ibm-sls Subscription"
   ibm.mas_devops.apply_subscription:

--- a/ibm/mas_devops/roles/suite_app_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/main.yml
@@ -66,6 +66,7 @@
     icr_password: "{{ mas_entitlement_key }}"
     artifactory_username: "{{ artifactory_username }}"
     artifactory_password: "{{ artifactory_token }}"
+    kyverno_labels: true
 
 - name: "Create ibm-mas Subscription"
   ibm.mas_devops.apply_subscription:

--- a/ibm/mas_devops/roles/suite_app_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_install/tasks/main.yml
@@ -66,7 +66,7 @@
     icr_password: "{{ mas_entitlement_key }}"
     artifactory_username: "{{ artifactory_username }}"
     artifactory_password: "{{ artifactory_token }}"
-    kyverno_labels: true
+    namespace_kyverno_label: "audit"
 
 - name: "Create ibm-mas Subscription"
   ibm.mas_devops.apply_subscription:

--- a/ibm/mas_devops/roles/suite_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_install/tasks/main.yml
@@ -185,7 +185,7 @@
     icr_password: "{{ mas_entitlement_key }}"
     artifactory_username: "{{ artifactory_username }}"
     artifactory_password: "{{ artifactory_token }}"
-    kyverno_labels: true
+    namespace_kyverno_label: "audit"
 
 - name: "Create ibm-mas Subscription"
   ibm.mas_devops.apply_subscription:

--- a/ibm/mas_devops/roles/suite_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_install/tasks/main.yml
@@ -185,6 +185,7 @@
     icr_password: "{{ mas_entitlement_key }}"
     artifactory_username: "{{ artifactory_username }}"
     artifactory_password: "{{ artifactory_token }}"
+    kyverno_labels: true
 
 - name: "Create ibm-mas Subscription"
   ibm.mas_devops.apply_subscription:


### PR DESCRIPTION
## Issue
MASCORE-9195

## Description
Add `ibm.com/kyverno: audit` in all namespaces to enable Kyverno Policy audit

## Test Results
### Roles that use IBM Entitlement task to create the namespace:
<img width="1144" height="1004" alt="image" src="https://github.com/user-attachments/assets/a04854d9-e31a-4dfc-92cc-064e22785c0b" />
### DRO
<img width="938" height="319" alt="image" src="https://github.com/user-attachments/assets/e63e20cd-03d2-42a2-bc59-ec778669b494" />
<img width="1008" height="858" alt="image" src="https://github.com/user-attachments/assets/0607ba41-9544-42a7-99e3-e4192e242f56" />


<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
