### PR TITLE
[minor] Add Vegetation Management (Vegm) add-on functionality for Manage

### DIFF
--- a/ibm/mas_devops/roles/suite_app_config/vars/customspecs/manage_components.yml.j2
+++ b/ibm/mas_devops/roles/suite_app_config/vars/customspecs/manage_components.yml.j2
@@ -123,6 +123,6 @@ aip:
 {% endif %}
 # -----------------------------------------------------------------------------
 {% if manageWorkspaceComponents['vegm'] is defined and manageWorkspaceComponents['vegm']['version'] is defined %}
-aip:
+vegm:
   version: {{ manageWorkspaceComponents['vegm']['version'] }}
 {% endif %}

--- a/ibm/mas_devops/roles/suite_app_config/vars/customspecs/manage_components.yml.j2
+++ b/ibm/mas_devops/roles/suite_app_config/vars/customspecs/manage_components.yml.j2
@@ -121,3 +121,8 @@ health:
 aip:
   version: {{ manageWorkspaceComponents['aip']['version'] }}
 {% endif %}
+# -----------------------------------------------------------------------------
+{% if manageWorkspaceComponents['vegm'] is defined and manageWorkspaceComponents['vegm']['version'] is defined %}
+aip:
+  version: {{ manageWorkspaceComponents['vegm']['version'] }}
+{% endif %}


### PR DESCRIPTION
## Issue
MASR-3108 - Create Maximo Vegetation Management Installable component


## Description
This change adds `vegm` add-on functionality. This has been tested with `cli version 15.3.2-pre.vegm`

## Test Results
This has been tested and here are the screenshots after testing
<img width="980" height="609" alt="image" src="https://github.com/user-attachments/assets/f481f475-80ca-477a-862f-cdf9b390cc94" />
<img width="1098" height="685" alt="image" src="https://github.com/user-attachments/assets/edac48e8-5a4e-471d-be4e-8b8e6028ae82" />
<img width="1116" height="669" alt="image" src="https://github.com/user-attachments/assets/f6e09ae5-2bda-47d0-9493-6f41ac09c8a2" />



<hr/>
