### PR TITLE
[patch] Fix unsupported parameter for aiservice_tenant namespace

### DIFF
--- a/ibm/mas_devops/roles/aiservice_tenant/tasks/namespace/install/main.yml
+++ b/ibm/mas_devops/roles/aiservice_tenant/tasks/namespace/install/main.yml
@@ -8,10 +8,13 @@
 
 - name: "Create namespace: {{ tenantNamespace }}"
   kubernetes.core.k8s:
-    name: "{{ tenantNamespace }}"
-    api_version: v1
-    kind: Namespace
-    labels:
-      ibm.com/kyverno: "audit"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ tenantNamespace }}"
+        labels:
+          ibm.com/kyverno: "audit"
   when:
     - namespace_info.resources | length == 0


### PR DESCRIPTION
## Issue
Unsupported parameters for (kubernetes.core.k8s) module: labels.

## Description
Added definition and moved labels under metadata.

## Test Results
Ran aiservice_tenant role directly on cluster.
<img width="634" height="647" alt="Screenshot 2025-09-06 at 1 30 42 PM" src="https://github.com/user-attachments/assets/19c5f99b-9e2a-4016-80be-7d90c149fb64" />


<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
