### PR TITLE
[patch] keep default db2_namespace consistent in b&r playbook and docs improvement

### DIFF
--- a/docs/playbooks/backup-restore.md
+++ b/docs/playbooks/backup-restore.md
@@ -117,21 +117,27 @@ ansible-playbook ibm.mas_devops.br_mongodb
 
 Backup/Restore for Db2
 -------------------------------------------------------------------------------
-This playbook `ibm.mas_devops.br_db2` will invoke the role [db2](../roles/db2.md) to backup/restore Db2 instance.
+This playbook `ibm.mas_devops.br_db2` will invoke the role [db2](../roles/db2.md) to backup/restore a single Db2 instance.
 
 ### Environment Variables
 
-- `DB2_INSTANCE_NAME`: **Required**. This playbook only supports backing up specific Db2 instance at a time. If you want to backup all Db2 instances in the Db2 cluster, you need to run this playbook multiple times with different value of this environment variable.
+- `DB2_INSTANCE_NAME`: **Required** This playbook only supports backing up specific Db2 instance at a time. If you want to backup all Db2 instances in the Db2 cluster, you need to run this playbook multiple times with different value of this environment variable.
+- `MAS_INSTANCE_ID`: **Required** Set the instance ID for the MAS install.
+- `MASBR_ACTION`: **Required** Set the action to be performed, `backup` or `restore`.
+- `MASBR_STORAGE_LOCAL_FOLDER`: **Required** Set the local path to the directory to be used for backup and restore.
+- `DB2_NAMESPACE`: **Optional** Set the DB2 namespace, defaults to `db2u`
 
 ### Examples
 ```bash
 # Full backup for the db2w-shared Db2 instance
+export MAS_INSTANCE_ID=dev
 export MASBR_ACTION=backup
 export MASBR_STORAGE_LOCAL_FOLDER=/tmp/backup
 export DB2_INSTANCE_NAME=db2w-shared
 ansible-playbook ibm.mas_devops.br_db2
 
 # Incremental backup for the db2w-shared Db2 instance
+export MAS_INSTANCE_ID=dev
 export MASBR_ACTION=backup
 export MASBR_BACKUP_TYPE=incr
 export MASBR_STORAGE_LOCAL_FOLDER=/tmp/backup
@@ -139,6 +145,7 @@ export DB2_INSTANCE_NAME=db2w-shared
 ansible-playbook ibm.mas_devops.br_db2
 
 # Restore for the db2w-shared Db2 instance
+export MAS_INSTANCE_ID=dev
 export MASBR_ACTION=restore
 export MASBR_STORAGE_LOCAL_FOLDER=/tmp/backup
 export MASBR_RESTORE_FROM_VERSION=20240630132439
@@ -201,6 +208,7 @@ This playbook `ibm.mas_devops.br_manage` will backup the following components th
 - `MAS_INSTANCE_ID` **Required**. This playbook only supports backing up components belong to a specific MAS instance at a time. If you have multiple MAS instances in the cluster to be backed up, you need to run this playbook multiple times with different value of this environment variable.
 - `MAS_WORKSPACE_ID` **Required**. This playbook only supports backing up components belong to a specific MAS workspace at a time. If you have multiple MAS workspaces in the cluster to be backed up, you need to run this playbook multiple times with different value of this environment variable.
 - `DB2_INSTANCE_NAME` **Optional**. When defined, this playbook will backup the Db2 instance used by Manage. DB2 role is skipped when environment variable is not defined..
+- `DB2_NAMESPACE`: **Optional** Set the DB2 namespace, defaults to `db2u`
 
 ### Examples
 
@@ -249,6 +257,7 @@ This playbook `ibm.mas_devops.br_iot` will backup the following components that 
 - `MAS_INSTANCE_ID` **Required**. This playbook only supports backing up components belong to a specific MAS instance at a time. If you have multiple MAS instances in the cluster to be backed up, you need to run this playbook multiple times with different value of this environment variable.
 - `MAS_WORKSPACE_ID` **Required**. This playbook only supports backing up components belong to a specific MAS workspace at a time. If you have multiple MAS workspaces in the cluster to be backed up, you need to run this playbook multiple times with different value of this environment variable.
 - `DB2_INSTANCE_NAME` **Required**. This playbook will backup the the Db2 instance used by IoT, you need to set the correct Db2 instance name for this environment variable.
+- `DB2_NAMESPACE`: **Optional** Set the DB2 namespace, defaults to `db2u`
 
 ### Examples
 
@@ -300,6 +309,7 @@ This playbook `ibm.mas_devops.br_monitor` will backup the following components t
 - `MAS_INSTANCE_ID` **Required**. This playbook only supports backing up components belong to a specific MAS instance at a time. If you have multiple MAS instances in the cluster to be backed up, you need to run this playbook multiple times with different value of this environment variable.
 - `MAS_WORKSPACE_ID` **Required**. This playbook only supports backing up components belong to a specific MAS workspace at a time. If you have multiple MAS workspaces in the cluster to be backed up, you need to run this playbook multiple times with different value of this environment variable.
 - `DB2_INSTANCE_NAME` **Required**. This playbook will backup the the Db2 instance used by IoT and Monitor, you need to set the correct Db2 instance name for this environment variable.
+- `DB2_NAMESPACE`: **Optional** Set the DB2 namespace, defaults to `db2u`
 
 ### Examples
 
@@ -398,6 +408,7 @@ This playbook `ibm.mas_devops.br_optimizer` will backup the following components
 - `MAS_INSTANCE_ID` **Required**. This playbook only supports backing up components belong to a specific MAS instance at a time. If you have multiple MAS instances in the cluster to be backed up, you need to run this playbook multiple times with different value of this environment variable.
 - `MAS_WORKSPACE_ID` **Required**. This playbook only supports backing up components belong to a specific MAS workspace at a time. If you have multiple MAS workspaces in the cluster to be backed up, you need to run this playbook multiple times with different value of this environment variable.
 - `DB2_INSTANCE_NAME` **Required**. This playbook will backup the the Db2 instance used by Manage, you need to set the correct Db2 instance name for this environment variable.
+- `DB2_NAMESPACE`: **Optional** Set the DB2 namespace, defaults to `db2u`
 
 ### Examples
 

--- a/ibm/mas_devops/common_tasks/backup_restore/check_common_vars.yml
+++ b/ibm/mas_devops/common_tasks/backup_restore/check_common_vars.yml
@@ -33,7 +33,7 @@
 - name: "Fail if masbr_storage_local_folder is not provided"
   assert:
     that: masbr_storage_local_folder is defined and masbr_storage_local_folder != ""
-    fail_msg: "masbr_storage_local_folder is required"
+    fail_msg: "MASBR_STORAGE_LOCAL_FOLDER is required"
 
 - name: "Debug: variables for local backup storage"
   debug:

--- a/ibm/mas_devops/common_tasks/backup_restore/check_restore_vars.yml
+++ b/ibm/mas_devops/common_tasks/backup_restore/check_restore_vars.yml
@@ -30,12 +30,12 @@
 - name: "Fail if masbr_restore_from_version is not provided"
   assert:
     that: masbr_restore_from_version is defined and masbr_restore_from_version != ""
-    fail_msg: "masbr_restore_from_version is required for running restore job"
+    fail_msg: "MASBR_RESTORE_FROM_VERSION is required for running restore job"
 
 - name: "Fail if masbr_restore_overwrite is not provided"
   assert:
     that: masbr_restore_overwrite is defined and masbr_restore_overwrite != ""
-    fail_msg: "masbr_restore_overwrite is required for running restore job"
+    fail_msg: "MASBR_RESTORE_OVERWRITE is required for running restore job"
 
 # Check 'masbr_job_component'
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/playbooks/br_core.yml
+++ b/ibm/mas_devops/playbooks/br_core.yml
@@ -49,12 +49,12 @@
     - name: "Fail if mas_instance_id is not provided"
       assert:
         that: mas_instance_id is defined and mas_instance_id != ""
-        fail_msg: "mas_instance_id is required"
+        fail_msg: "MAS_INSTANCE_ID is required"
 
     - name: "Fail if masbr_action is not set to backup|restore"
       assert:
         that: masbr_action in ["backup", "restore"]
-        fail_msg: "masbr_action is required and must be set to 'backup' or 'restore'"
+        fail_msg: "MASBR_ACTION is required and must be set to 'backup' or 'restore'"
 
     # Common checks before run tasks
     # -------------------------------------------------------------------------

--- a/ibm/mas_devops/playbooks/br_db2.yml
+++ b/ibm/mas_devops/playbooks/br_db2.yml
@@ -51,17 +51,17 @@
     - name: "Fail if mas_instance_id is not provided"
       assert:
         that: mas_instance_id is defined and mas_instance_id != ""
-        fail_msg: "mas_instance_id is required"
+        fail_msg: "MAS_INSTANCE_ID is required"
 
     - name: "Fail if db2_instance_id is not provided"
       assert:
         that: db2_instance_id is defined and db2_instance_id != ""
-        fail_msg: "db2_instance_id is required"
+        fail_msg: "DB2_INSTANCE_NAME is required"
 
     - name: "Fail if masbr_action is not set to backup|restore"
       assert:
         that: masbr_action in ["backup", "restore"]
-        fail_msg: "masbr_action is required and must be set to 'backup' or 'restore'"
+        fail_msg: "MASBR_ACTION is required and must be set to 'backup' or 'restore'"
 
     # Common checks before run tasks
     # -------------------------------------------------------------------------

--- a/ibm/mas_devops/playbooks/br_health.yml
+++ b/ibm/mas_devops/playbooks/br_health.yml
@@ -7,7 +7,7 @@
     mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
     mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') }}"
     db2_instance_id: "{{ lookup('env', 'DB2_INSTANCE_NAME') }}"
-    db2_namespace: "{{ lookup('env', 'DB2_NAMESPACE') }}"
+    db2_namespace: "{{ lookup('env', 'DB2_NAMESPACE') | default('db2u', true) }}"
 
     # Define what action to perform
     masbr_action: "{{ lookup('env', 'MASBR_ACTION') }}"
@@ -52,22 +52,22 @@
     - name: "Fail if mas_instance_id is not provided"
       assert:
         that: mas_instance_id is defined and mas_instance_id != ""
-        fail_msg: "mas_instance_id is required"
+        fail_msg: "MAS_INSTANCE_ID is required"
 
     - name: "Fail if mas_workspace_id is not provided"
       assert:
         that: mas_workspace_id is defined and mas_workspace_id != ""
-        fail_msg: "mas_workspace_id is required"
+        fail_msg: "MAS_WORKSPACE_ID is required"
 
     - name: "Fail if db2_instance_id is not provided"
       assert:
         that: db2_instance_id is defined and db2_instance_id != ""
-        fail_msg: "db2_instance_id is required"
+        fail_msg: "DB2_INSTANCE_NAME is required"
 
     - name: "Fail if masbr_action is not set to backup|restore"
       assert:
         that: masbr_action in ["backup", "restore"]
-        fail_msg: "masbr_action is required and must be set to 'backup' or 'restore'"
+        fail_msg: "MASBR_ACTION is required and must be set to 'backup' or 'restore'"
 
     # Common checks before run tasks
     # -------------------------------------------------------------------------

--- a/ibm/mas_devops/playbooks/br_iot.yml
+++ b/ibm/mas_devops/playbooks/br_iot.yml
@@ -7,7 +7,7 @@
     mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
     mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') }}"
     db2_instance_id: "{{ lookup('env', 'DB2_INSTANCE_NAME') }}"
-    db2_namespace: "{{ lookup('env', 'DB2_NAMESPACE') }}"
+    db2_namespace: "{{ lookup('env', 'DB2_NAMESPACE') | default('db2u', true) }}"
 
     # Define what action to perform
     masbr_action: "{{ lookup('env', 'MASBR_ACTION') }}"

--- a/ibm/mas_devops/playbooks/br_manage.yml
+++ b/ibm/mas_devops/playbooks/br_manage.yml
@@ -7,7 +7,7 @@
     mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
     mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') }}"
     db2_instance_id: "{{ lookup('env', 'DB2_INSTANCE_NAME') }}"
-    db2_namespace: "{{ lookup('env', 'DB2_NAMESPACE') }}"
+    db2_namespace: "{{ lookup('env', 'DB2_NAMESPACE') | default('db2u', true) }}"
 
     # Define what action to perform
     masbr_action: "{{ lookup('env', 'MASBR_ACTION') }}"

--- a/ibm/mas_devops/playbooks/br_monitor.yml
+++ b/ibm/mas_devops/playbooks/br_monitor.yml
@@ -7,7 +7,7 @@
     mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
     mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') }}"
     db2_instance_id: "{{ lookup('env', 'DB2_INSTANCE_NAME') }}"
-    db2_namespace: "{{ lookup('env', 'DB2_NAMESPACE') }}"
+    db2_namespace: "{{ lookup('env', 'DB2_NAMESPACE') | default('db2u', true) }}"
 
     # Define what action to perform
     masbr_action: "{{ lookup('env', 'MASBR_ACTION') }}"

--- a/ibm/mas_devops/playbooks/br_optimizer.yml
+++ b/ibm/mas_devops/playbooks/br_optimizer.yml
@@ -7,7 +7,7 @@
     mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
     mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') }}"
     db2_instance_id: "{{ lookup('env', 'DB2_INSTANCE_NAME') }}"
-    db2_namespace: "{{ lookup('env', 'DB2_NAMESPACE') }}"
+    db2_namespace: "{{ lookup('env', 'DB2_NAMESPACE') | default('db2u', true) }}"
 
     # Define what action to perform
     masbr_action: "{{ lookup('env', 'MASBR_ACTION') }}"


### PR DESCRIPTION
## Issue
MASCORE-9435

## Description

- For MASCORE-9435, br_manage playbook wasn't having a default db2 namespace and was failing in a common check, this is not consistent with br_db2 playbook and was causing confusion.
- General docs and logs improvement

## Test Results

Tested playbooks locally.

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
