### PR TITLE
[patch] Fix again min release for odf-dependencies

### DIFF
--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -84,7 +84,7 @@ mirror:
         - name: lvms-operator  # Not used by any of our roles, but used in SNO installations
           channels:
             - name: stable-{{ ocp_release }}
-{% if ocp_release >= "4.17" %}
+{% if ocp_release >= "4.18" %}
         - name: odf-dependencies  # Required by ibm.mas_devops.ocs role
           channels:
             - name: stable-{{ ocp_release }}


### PR DESCRIPTION

## Issue
https://github.com/ibm-mas/cli/issues/1783

## Description
Mirror on OCP 4.17 doesn't work due to the odf-dependencies package not found in registry.redhat.io/redhat/redhat-operator-index:v4.17. It is present in OCP 4.18.

## Test Results
No error mirror-xx-ocp4.17.log when `mas mirror-redhat-images` for ocp 4.17 was ran in test.

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
