### PR TITLE
[patch] Set default component for manage.

### DIFF
--- a/ibm/mas_devops/roles/suite_app_config/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/defaults/main.yml
@@ -15,7 +15,10 @@ mas_config_dir: "{{ lookup('env', 'MAS_CONFIG_DIR') }}"
 # -----------------------------------------------------------------------------
 mas_app_id: "{{ lookup('env', 'MAS_APP_ID') }}"
 mas_appws_bindings_jdbc: "{{ lookup('env', 'MAS_APPWS_BINDINGS_JDBC') }}"
-mas_appws_components: "{{ lookup('env', 'MAS_APPWS_COMPONENTS') | ibm.mas_devops.appws_components | default('{}', true) }}"
+
+# Set default components for manage application to include the required base component
+mas_appws_components_default: "{{ {'base': {'version': 'latest'}} if mas_app_id == 'manage' else {} }}"
+mas_appws_components: "{{ lookup('env', 'MAS_APPWS_COMPONENTS') | ibm.mas_devops.appws_components | default(mas_appws_components_default, true) }}"
 
 # Only used by Predict currently - will be deprecated in favour of OM3.1 implementation
 mas_appws_settings_deployment_size: "{{ lookup('env', 'MAS_APPWS_SETTINGS_DEPLOYMENT_SIZE') | default('small', true) }}"


### PR DESCRIPTION
## Issue
Fix for open issue https://github.com/ibm-mas/cli/issues/1696

## Description
The error "spec.components.base: Required value" occurs because the ManageWorkspace resource requires a base component in the spec.components section, but it's not being included in this configuration.

The issue is that the base component is conditionally included in the manage_components.yml.j2 template only if it's defined in the manageWorkspaceComponents variable, which comes from the MAS_APPWS_COMPONENTS environment variable.

To fix this issue, we need to ensure the base component is included in the configuration. Like we usually does while installing manage application

export MAS_APPWS_COMPONENTS="base=latest"

This will ensure that the required base component is included in the ManageWorkspace resource, resolving the error.


## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
