### PR TITLE
[patch] added digest value for NFD operator for OCP 4.19

### DIFF
--- a/ibm/mas_devops/roles/nvidia_gpu/templates/nfd-instance.yml.j2
+++ b/ibm/mas_devops/roles/nvidia_gpu/templates/nfd-instance.yml.j2
@@ -19,6 +19,9 @@ spec:
 {% if ocp_version < "4.17.0" %}
     image: >-
       registry.redhat.io/openshift4/ose-node-feature-discovery@sha256:042325bfcca24584f6b72f5f38a47cc77b34301bccb29e3e6a7cc77aeab45e6e
+{% elif ocp_version >= "4.19.0" %}
+    image: >-
+      registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9@sha256:69baa98abffdb066e7e325caa87141efde9899898c9a5d76ea7655de848fc8da
 {% else %}
     image: >-
       registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9@sha256:45192fef5a1250ee573975ced1e897662116d5a30a1f8f4baa4497f64933fba3


### PR DESCRIPTION
## Issue
NFD Master pod keeps on restarting
[MASR-6152](https://jsw.ibm.com/browse/MASR-6152)

## Description
NFD Master pod keeps on restarting so Identified and added new digest value for NFD operator compatible with OCP version 4.19

## Test Results
Changes have been tested in Quickburn cluster. Verified master pod is in status running 1/1. Results attached in [MASR-6152](https://jsw.ibm.com/browse/MASR-6152)

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
