### PR TITLE
[patch] Fix default channel

### DIFF
--- a/ibm/mas_devops/playbooks/mas_add_iot.yml
+++ b/ibm/mas_devops/playbooks/mas_add_iot.yml
@@ -14,7 +14,7 @@
 
     # Application Installation
     mas_app_id: iot
-    mas_app_channel: "{{ lookup('env', 'MAS_APP_CHANNEL') | default('9.0.x', true) }}"
+    mas_app_channel: "{{ lookup('env', 'MAS_APP_CHANNEL') | default('9.1.x', true) }}"
 
     # Application Configuration
     mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') | default('masdev', true) }}"


### PR DESCRIPTION
## Description
IoT playbook default `mas_app_channel` is still set to MAS 9.0 release version, all other playbooks are already updated to 9.1, this one needs to be too.

## Test Results
No testing performed, simple change to one of the sample playbooks.

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
