### PR TITLE
[patch] remove LOGARCHMETH1 from manage db2 setup vars

### DIFF
--- a/ibm/mas_devops/roles/suite_db2_setup_for_manage/vars/main.yml
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_manage/vars/main.yml
@@ -26,7 +26,6 @@ db2_configs:
           LOGPRIMARY: '100'
           LOGSECOND: '156'
           LOGFILSIZ: '32768'
-          LOGARCHMETH1: 'DISK:/mnt/bludata0/db2/archive_log/'
           MIRRORLOGPATH: '/mnt/backup'
           STMT_CONC: 'LITERALS'
           DDL_CONSTRAINT_DEF: 'YES'


### PR DESCRIPTION
## Issue

MASCORE-10384 - [all fvts] SQL1116N A connection to or activation of database "BLUDB" failed because the database is in BACKUP PENDING state. SQLSTATE=57019

## Description
Fixes a problem where the task suite-db2-setup-manage applies a configuration to manage db2 instance related to LOGARCHMETH that triggers a database backup. But for some reason the db2 manage instance is left in BACKUP PENDING state.

## Test Results
This was tested in a personal fvt cluster where this change was applied and this was the suite-db2-setup-manage result:
```
    Waiting for up to 180 sec until a change is detected in the relevant configmaps... change not detected, continuing anyways
    Applying all settings
    [2025-10-28 15:00:30,641] - INFO: Applying Database Instance Manager configuration configmap
    [2025-10-28 15:00:30,642] - INFO: Applying Db2 instance manager configmap
    [2025-10-28 15:00:33,076] - INFO: Persisting the Database Instance Manager configuration configmap settings
    DB20000I  The TERMINATE command completed successfully.
    (*) Applying Db2 db cfg parameters for BLUDB
    update db cfg for BLUDB using  APPLHEAPSZ 8192 AUTOMATIC AUTHN_CACHE_DURATION 10 AUTHN_CACHE_USERS 100 AUTO_DB_BACKUP OFF AUTO_DEL_REC_OBJ ON AUTO_MAINT ON AUTO_REORG OFF AUTO_REVAL DEFERRED AUTO_RUNSTATS ON AUTO_TBL_MAINT ON CATALOGCACHE_SZ 800 CHNGPGS_THRESH 40 CUR_COMMIT ON DATABASE_MEMORY AUTOMATIC DBHEAP AUTOMATIC DDL_CONSTRAINT_DEF YES DEC_TO_CHAR_FMT NEW DFT_QUERYOPT 5 DFT_SCHEMAS_DCC NO DFT_TABLE_ORG ROW EXTBL_LOCATION /mnt/blumeta0/db2/load;/mnt/blumeta0/home;/mnt/bludata0/scratch;/mnt/external;/mnt/backup EXTBL_STRICT_IO NO INDEXREC ACCESS LOCKLIST AUTOMATIC LOCKTIMEOUT 300 LOGARCHMETH1 OFF LOGARCHMETH2 OFF LOGBUFSZ 1024 LOGFILSIZ 32768 LOGPRIMARY 100 LOGSECOND 156 LOG_APPL_INFO NO LOG_DDL_STMTS NO MAXFILOP 61440 MIRRORLOGPATH /mnt/backup NUM_DB_BACKUPS 60 NUM_IOCLEANERS AUTOMATIC NUM_IOSERVERS AUTOMATIC PCKCACHESZ AUTOMATIC REC_HIS_RETENTN 60 SOFTMAX 0 STAT_HEAP_SZ AUTOMATIC STMTHEAP 20000 STMT_CONC LITERALS TRACKMOD YES WLM_ADMISSION_CTRL NO
    DB20000I  The UPDATE DATABASE CONFIGURATION command completed successfully.
  
    Wolverine HA management state was disabled successfully.
    Running db2stop force
    10/28/2025 15:01:05     0   0   SQL1064N  DB2STOP processing was successful.
    SQL1064N  DB2STOP processing was successful.
  
    Application ipclean: Removing all IPC resources for db2inst1(500)
    c-mas-mobt1-masdev-manage-db2u-0.c-mas-mobt1-masdev-manage-db2u-internal: ipclean -a completed ok
    Running db2start
    10/28/2025 15:01:24     0   0   SQL1063N  DB2START processing was successful.
    SQL1063N  DB2START processing was successful.
    Db2 was started successfully
    activate db BLUDB
    DB20000I  The ACTIVATE DATABASE command completed successfully.
  
    Database was activated successfully
    Wolverine HA management state was enabled successfully.
     Changed pages threshold                (CHNGPGS_THRESH) = 40
```

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
