### PR TITLE
[patch] Add v25.10 tag for gpu-operator-certified to fix mirroring fa…

### DIFF
--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -29,6 +29,7 @@ mirror:
             # - https://issues.redhat.com/browse/OCPBUGS-385
             - name: v24.9
             - name: v25.3
+            - name: v25.10
         - name: kubeturbo-certified  # Required by ibm.mas_devops.kubeturbo role
           channels:
             - name: stable


### PR DESCRIPTION
## Description

- The mirroring process for the GPU operator failed due to the missing version reference for gpu-operator-certified.
- Added the explicit version tag v25.10 in the imageset configuration to resolve the issue.
Mirroring was re-tested successfully after this change.

## Testing

Verified the fix by running the mirror with the latest catalog.