### PR TITLE
[patch] Fix Artifactory cleanup workflow

### DIFF
--- a/.github/workflows/ansible-delete-branch.yml
+++ b/.github/workflows/ansible-delete-branch.yml
@@ -1,4 +1,4 @@
-name: Artifactory clean up
+name: Artifactory Clean Up
 on:
   delete:
     branches:
@@ -15,7 +15,6 @@ jobs:
           ARTIFACTORY_GENERIC_RELEASE_URL: ${{ secrets.ARTIFACTORY_GENERIC_RELEASE_URL }}
           ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
         run: |
-          FILE_NAME=ibm-mas_devops
-          FILE_EXT=tar.gz
-          BRANCH_TARGET_URL="${ARTIFACTORY_GENERIC_RELEASE_URL}/${GITHUB_REPOSITORY}/branches/${FILE_NAME}-${GITHUB_REF_NAME}.${FILE_EXT}"
+          echo "Clean up for branch ${{ github.event.ref }}"
+          BRANCH_TARGET_URL="${ARTIFACTORY_GENERIC_RELEASE_URL}/ibm-mas/ansible-devops/branches/ibm-mas_devops-${{ github.event.ref }}.tar.gz"
           curl -H "Authorization:Bearer $ARTIFACTORY_TOKEN" -X DELETE "${BRANCH_TARGET_URL}"


### PR DESCRIPTION
We need to use `github.event.ref` because the main ref points to the default branch on a delete event.