### PR TITLE
[doc] Add missing SLS gencfg information

### DIFF
--- a/ibm/mas_devops/roles/sls/README.md
+++ b/ibm/mas_devops/roles/sls/README.md
@@ -9,7 +9,7 @@ The role assumes that you have already installed the Certificate Manager in the 
 Role Variables
 -------------------------------------------------------------------------------
 ### sls_action
-Inform the role whether to perform an install or uninstall of the Suite License Service.
+Inform the role whether to perform an install, uninstall or gencfg of the Suite License Service.
 
 - Optional
 - Environment Variable: `SLS_ACTION`
@@ -339,6 +339,7 @@ Example Playbook
     mas_instance_id: inst1
     mas_config_dir: /home/me/masconfig
 
+    sls_action: gencfg
     sls_tls_crt_local_file_path: "/home/me/sls.crt"
     slscfg_url: "https://xxx"
     slscfg_registration_key: "xxx"


### PR DESCRIPTION
the playbook example for generating slscfg for an existing sls instance is missing the "sls_action: gencfg" variable.

## Issue
<!-- Provide the ID numbers of issues related to this change. Please do not provide direct links to IBM-internal systems. If there are no issues related to this change, why are you working on it? -->

## Description
<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
