### PR TITLE
[patch] Add ca.crt conditionally only when available

### DIFF
--- a/ibm/mas_devops/roles/aiservice_tenant/templates/rsl/rsl-secret.yml.j2
+++ b/ibm/mas_devops/roles/aiservice_tenant/templates/rsl/rsl-secret.yml.j2
@@ -16,4 +16,6 @@ data:
   rsl_org_id: "{{ rsl_org_id | b64encode }}"
   rsl_url: "{{ rsl_url | b64encode }}"
   rsl_token: "{{ rsl_token | b64encode }}"
+{% if rsl_ca_crt is defined and rsl_ca_crt | length > 0 %}
   ca.crt: "{{ rsl_ca_crt | b64encode }}"
+{% else %}


### PR DESCRIPTION
## Issue
MASAIB-1580

## Description
Add `ca.crt` key in RSL secret conditionally when certificate value is provided.
