### PR TITLE
[patch] Revert to previous RedHat execution environment container image

### DIFF
--- a/build/ee/execution-environment.yml
+++ b/build/ee/execution-environment.yml
@@ -4,7 +4,7 @@ dependencies:
   system: bindep.txt
 images:
   base_image:
-    name: registry.redhat.io/ansible-automation-platform-24/ee-supported-rhel9:latest
+    name: registry.redhat.io/ansible-automation-platform-24/ee-supported-rhel9:1.0.0-1107
     # Custom package manager path for the RHEL based images
 options:
   package_manager_path: /usr/bin/microdnf


### PR DESCRIPTION
## Issue
<!-- Provide the ID numbers of issues related to this change. Please do not provide direct links to IBM-internal systems. If there are no issues related to this change, why are you working on it? -->

## Description
<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->
The latest redhat supported execution environment has an issue during the build and so we need to revert back to the latest good one. https://catalog.redhat.com/en/software/containers/ansible-automation-platform-24/ee-supported-rhel9/643d4c7255839fe0f27b0f30#overview 1.0.0-1116 is the bad one so reverting back to the previous one, whilst awaiting RedHat response.

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->
The build for the execution environment was successfull

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
