### PR TITLE
[patch] Remove OCP 4.15 from rotation

### DIFF
--- a/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
@@ -29,13 +29,13 @@
     ocp_version: "{{ rotate_ocp_version[ansible_date_time['weekday']] ~ ('_openshift' if cluster_type == 'roks' else '') }}"
   vars:
     rotate_ocp_version:
-      Monday: 4.18
-      Tuesday: 4.19
+      Monday: 4.19
+      Tuesday: 4.18
       Wednesday: 4.17
       Thursday: 4.16
       Friday: 4.19
       Saturday: 4.18
-      Sunday: 4.15
+      Sunday: 4.16
 
 - name: "Set default OCP version"
   when: ocp_version == "default"


### PR DESCRIPTION
## Description
OCP 4.15 has reached EOS and should be removed from rotation in daily automated test.

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
