### PR TITLE
[patch] Fix registry secret string rendering for older versions of Ansible

### DIFF
--- a/ibm/mas_devops/roles/db2/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/db2/tasks/install/main.yml
@@ -140,6 +140,7 @@
   set_fact:
     new_secret: "{{ content | join('') }}"
 
+# Note: We use "new_secret | to_json | string" to avoid older versions of Ansible creating invalid json representation containing single quotes
 - name: "Generate 'ibm-registry' secret"
   no_log: true
   kubernetes.core.k8s:


### PR DESCRIPTION
…ions - DB2 role

## Issue
https://jsw.ibm.com/browse/MASCORE-10964

## Description
We use new_secret | to_json | string to avoid older versions of Ansible creating invalid json representation with single quotes
this is for task: Generate 'ibm-registry' secret

## Test Results
tested by run tests, also created model

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
