### PR TITLE
[patch] Fix string to object handling for Ansible v12

### DIFF
--- a/ibm/mas_devops/roles/db2/tasks/upgrade/run-db2-instances-upgrade.yml
+++ b/ibm/mas_devops/roles/db2/tasks/upgrade/run-db2-instances-upgrade.yml
@@ -43,7 +43,7 @@
     - name: Set db2u-release configmap content
       no_log: true
       set_fact:
-        db2_releases_content: "{{ db2_release_info.resources[0].data.json }}"
+        db2_releases_content: "{{ db2_release_info.resources[0].data.json | from_json }}"
 
     - name: Filter out s12* versions and pick latest s11*
       set_fact:


### PR DESCRIPTION
## Description
Another issue related to the Ansible core upgrade - found another code path where we require explicit conversion from string to object:

```
TASK [ibm.mas_devops.db2 : Filter out s12* versions and pick latest s11*] ******
[ERROR]: Task failed: Finalization of task args for 'ansible.builtin.set_fact' failed: Error while resolving value for 'db2_version': object of type 'str' has no attribute 'databases'

Task failed.
Origin: /opt/app-root/lib64/python3.12/site-packages/ansible_collections/ibm/mas_devops/roles/db2/tasks/upgrade/run-db2-instances-upgrade.yml:48:7

46         db2_releases_content: "{{ db2_release_info.resources[0].data.json }}"
47
48     - name: Filter out s12* versions and pick latest s11*
         ^ column 7
```


### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
