### PR TITLE
[patch] check if efs id is not None in ocp_deprovision for rosa

### DIFF
--- a/ibm/mas_devops/roles/ocp_deprovision/tasks/providers/rosa.yml
+++ b/ibm/mas_devops/roles/ocp_deprovision/tasks/providers/rosa.yml
@@ -110,7 +110,7 @@
 # 11. Get Mount Id and Delete the associated Mount Target when we have an EFS ID
 # -----------------------------------------------------------------------------
 - name: Cleanup EFS if we have an EFS Id
-  when: efs_id != ""
+  when: efs_id != None and efs_id != ""
   block:
     - name: "rosa : Get-mountId : MountId"
       shell: aws efs describe-mount-targets --file-system-id {{ efs_id  }} --query "MountTargets[*].MountTargetId"


### PR DESCRIPTION
## Description
After ansible version is updated, efs id value returned is null but since we are only checking for not empty, it is trying to get efs detail for null efs id and failed

`TASK [ibm.mas_devops.ocp_deprovision : Filter-efsId : EfsId] *******************
ok: [localhost] => {"ansible_facts": {"efs_id": **null**}, "changed": false}

TASK [ibm.mas_devops.ocp_deprovision : rosa : Get-mountId : MountId] ***********
[ERROR]: Task failed: Module failed: non-zero return code
Origin: /opt/app-root/lib64/python3.12/site-packages/ansible_collections/ibm/mas_devops/roles/ocp_deprovision/tasks/providers/rosa.yml:115:7

113   when: efs_id != ""
114   block:
115     - name: "rosa : Get-mountId : MountId"
          ^ column 7

fatal: [localhost]: FAILED! => {"changed": true, "cmd": "aws efs describe-mount-targets --file-system-id  --query \"MountTargets[*].MountTargetId\"", "delta": "0:00:00.937337", "end": "2025-12-02 09:32:57.214194", "msg": "non-zero return code", "rc": 252, "start": "2025-12-02 09:32:56.276857", "stderr": "\naws: [ERROR]: argument --file-system-id: expected one argument\n\nusage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]\nTo see help text, you can run:\n\n  aws help\n  aws <command> help\n  aws <command> <subcommand> help", "stderr_lines": ["", "aws: [ERROR]: argument --file-system-id: expected one argument", "", "usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]", "To see help text, you can run:", "", "  aws help", "  aws <command> help", "  aws <command> <subcommand> help"], "stdout": "", "stdout_lines": []}
`