### PR TITLE
[patch] protect against None

### DIFF
--- a/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/defaultspecs/manage.yml
@@ -2,8 +2,8 @@
 # Default application spec for Manage
 mas_appws_spec:
   bindings: "{{ mas_app_bindings }}"
-  podTemplates: "{{ ((ibm_mas_manage_manageworkspace_pod_templates is defined) and (ibm_mas_manage_manageworkspace_pod_templates | length != 0)) | ternary(ibm_mas_manage_manageworkspace_pod_templates, []) }}"
-  components: "{{ ((mas_app_components_manage is defined) and (mas_app_components_manage | length != 0)) | ternary(mas_app_components_manage, {}) }}"
+  podTemplates: "{{ ((ibm_mas_manage_manageworkspace_pod_templates is defined) and (ibm_mas_manage_manageworkspace_pod_templates is not none) and (ibm_mas_manage_manageworkspace_pod_templates | length != 0)) | ternary(ibm_mas_manage_manageworkspace_pod_templates, []) }}"
+  components: "{{ ((mas_app_components_manage is defined) and (mas_app_components_manage is not none) and (mas_app_components_manage | length != 0)) | ternary(mas_app_components_manage, {}) }}"
   settings:
     deployment:
       persistentVolumes: "{{ mas_app_settings_persistent_volumes }}"
@@ -12,7 +12,7 @@ mas_appws_spec:
       serverTimezone: "{{ mas_app_settings_server_timezone }}"
     languages:
       baseLang: "{{ mas_app_settings_base_lang | default('EN' , true) }}"
-      secondaryLangs: "{{ mas_app_settings_secondary_langs.split(',') if (mas_app_settings_secondary_langs is defined and mas_app_settings_secondary_langs | length > 0) else [] }}"
+      secondaryLangs: "{{ mas_app_settings_secondary_langs.split(',') if (mas_app_settings_secondary_langs is defined and mas_app_settings_secondary_langs is not none and mas_app_settings_secondary_langs | length > 0) else [] }}"
     aio:
       install: "{{ mas_app_settings_aio_flag | bool  }}"
     db:
@@ -25,4 +25,4 @@ mas_appws_spec:
         bypassUpgradeVersionCheck: false
       upgrade:
         upgradeType: "{{ mas_appws_upgrade_type }}"
-    customizationList: "{{ mas_app_settings_customization_list if (mas_app_settings_customization_archive_url is defined and mas_app_settings_customization_archive_url | length > 0) else []  }}"
+    customizationList: "{{ mas_app_settings_customization_list if (mas_app_settings_customization_archive_url is defined and mas_app_settings_customization_archive_url is not none and mas_app_settings_customization_archive_url | length > 0) else []  }}"


### PR DESCRIPTION
## Additional protection against None

The recent upgrade of ansible now requires guarding against None type. 

Where we have if x is defined to protect against something not being defined we now also need to protect against None (because in newer versions of ansible there's a difference in how None/undefined are handled)

