### PR TITLE
[patch] Detect Manage and MREF apps during ArcGIS installation : MASCORE-10766

### DIFF
--- a/ibm/mas_devops/roles/arcgis/tasks/main.yml
+++ b/ibm/mas_devops/roles/arcgis/tasks/main.yml
@@ -68,6 +68,13 @@
     arcgis_mref_detected: "{{ mref_lookup.resources is defined and mref_lookup.resources | length > 0 }}"
     arcgis_mref_ready: "{{ mref_lookup.resources is defined and mref_lookup.resources | length > 0 and mref_lookup.resources | json_query('[*].status.conditions[?type==`Ready`][].status') | select('match', 'True') | list | length == 1 }}"
 
+- name: "Assert that ArcGIS is installed with Manage or MREF"
+  assert:
+    that:
+      - (arcgis_manage_detected and arcgis_manage_ready) or (arcgis_mref_detected and arcgis_mref_ready)
+    fail_msg: "ArcGIS must be installed bundled with at least one application: Manage (with Spatial) or MREF (Facilities). Valid combinations: ArcGIS+MREF, ArcGIS+Manage, or ArcGIS+MREF+Manage. Found: Manage Detected={{ arcgis_manage_detected }}, Manage Ready={{ arcgis_manage_ready }}, MREF Detected={{ arcgis_mref_detected }}, MREF Ready={{ arcgis_mref_ready }}"
+
+
 # 3. Provide Debug information
 # -----------------------------------------------------------------------------
 - name: "Debug information - IBM Maximo Location Services for Esri "


### PR DESCRIPTION
## Summary
Implements detection for Manage and MREF (Facilities) applications during ArcGIS installation

MASCORE-10766

## Description
- Added detection logic in arcgis role main.yml after ibm-operator-catalog check
- Stores detection results in facts:
  - \`arcgis_manage_detected\`: Boolean if Manage app exists
  - \`arcgis_manage_ready\`: Boolean if Manage app is Ready
  - \`arcgis_mref_detected\`: Boolean if MREF/Facilities app exists  
  - \`arcgis_mref_ready\`: Boolean if MREF/Facilities app is Ready
- Enhanced debug output to display detected applications
- Uses \`ignore_errors: yes\` to handle missing namespaces gracefully

## Test Results
Tested with local CLI and syntax validation.
Failed case : without manage
<img width="1676" height="677" alt="image" src="https://github.com/user-attachments/assets/d7a446cb-1f2f-4ded-8e3a-bcf5a47783ef" />
Success case: with manage
<img width="1672" height="736" alt="image" src="https://github.com/user-attachments/assets/75c264c5-9024-4d14-a239-fe954b55b9ec" />


<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
