### PR TITLE
[patch] Fix bool as string: mas_hide_superuser_credentials

### DIFF
--- a/ibm/mas_devops/roles/suite_verify/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_verify/tasks/main.yml
@@ -56,7 +56,7 @@
 # 4. Lookup for superuser credentials
 # -----------------------------------------------------------------------------
 - name: "Lookup MAS superuser credentials"
-  when: not (mas_hide_superuser_credentials | bool)
+  when: not mas_hide_superuser_credentials
   kubernetes.core.k8s_info:
     api_version: v1
     kind: Secret
@@ -65,13 +65,13 @@
   register: superuser_credentials
 
 - name: "Show the username/password"
-  when: not (mas_hide_superuser_credentials | bool)
+  when: not mas_hide_superuser_credentials
   set_fact:
     superuser_username: "{{ superuser_credentials.resources[0].data.username | b64decode }}"
     superuser_password: "{{ superuser_credentials.resources[0].data.password | b64decode }}"
 
 - name: "Hide actual username/password"
-  when: mas_hide_superuser_credentials | bool
+  when: mas_hide_superuser_credentials
   set_fact:
     superuser_username: "Available in Secret/{{ mas_instance_id }}-credentials-superuser"
     superuser_password: "Available in Secret/{{ mas_instance_id }}-credentials-superuser"


### PR DESCRIPTION
## Description
Made the suite_verify role compatible with Ansible 2.20 by fixing how the strict bool check of MAS_HIDE_SUPERUSER_CREDENTIALS is handled.

This removes the error:
Conditional result (True) was derived from value of type 'str'.
10:23:19  [ERROR]: Task failed: Conditional result (True) was derived from value of type 'str' at '/root/.ansible/collections/ansible_collections/ibm/mas_devops/roles/suite_verify/defaults/main.yml:3:33'. Conditionals must have a boolean result.


## Test Results
Built and tested the updated ibm.mas_devops collection locally.
<img width="720" height="574" alt="image" src="https://github.com/user-attachments/assets/a0080132-3a33-4d8b-a3d8-8694ce1983ca" />
