### PR TITLE
[patch] change routing mode default to "subdomain"

### DIFF
--- a/ibm/mas_devops/roles/suite_install/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_install/defaults/main.yml
@@ -45,7 +45,7 @@ mas_trust_default_cas: "{{ lookup('env', 'MAS_TRUST_DEFAULT_CAS') }}"
 
 # Network Routing
 # -----------------------------------------------------------------------------
-mas_routing_mode: "{{ lookup('env', 'MAS_ROUTING_MODE') | default('path', true) }}"
+mas_routing_mode: "{{ lookup('env', 'MAS_ROUTING_MODE') | default('subdomain', true) }}"
 
 # Source container registry
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Description
The default was prematurely set to "path" and is currently causing fvt tests to fail. For now the default should be "subdomain"