### PR TITLE
[Patch] Fix the regular expression in the role gencfg_jdbc

### DIFF
--- a/ibm/mas_devops/roles/gencfg_jdbc/tasks/main.yml
+++ b/ibm/mas_devops/roles/gencfg_jdbc/tasks/main.yml
@@ -85,7 +85,7 @@
     - db_pem_file is defined
     - ssl_enabled == true
   set_fact:
-    jdbc_tls_crt: "{{ lookup('file', db_pem_file) | regex_findall('(-----BEGIN .+?-----(?s).+?-----END .+?-----)', multiline=True, ignorecase=True) }}"
+    jdbc_tls_crt: "{{ lookup('file', db_pem_file) | regex_findall('(?s)(-----BEGIN .+?-----.+?-----END .+?-----)', multiline=True, ignorecase=True) }}"
   no_log: true
 
 # Load jdbc_certs template to dynamically set as many jdbc certificates as identified


### PR DESCRIPTION
## Description
Since the Python update, the TLS check (pem) has been failing. The cause is the regular expression that validates the PEM file. It only supports inline modifiers placed at the start of the Python regular expression (which is also the best practice).

## Test Results
Use an external JDBC connection with TLS. The role must verify the certificate without any error messages.


