### PR TITLE
[patch] Fail build when Artifactory upload fails

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -61,7 +61,6 @@ jobs:
           echo "Copying $GITHUB_WORKSPACE/ibm/mas_devops/ibm-mas_devops-${{ env.VERSION }}.tar.gz to $GITHUB_WORKSPACE/ibm/mas_devops/ibm-mas_devops.tar.gz ..."
           cp $GITHUB_WORKSPACE/ibm/mas_devops/ibm-mas_devops-${{ env.VERSION }}.tar.gz $GITHUB_WORKSPACE/ibm/mas_devops/ibm-mas_devops.tar.gz
           $GITHUB_WORKSPACE/build/bin/artifactory-release.sh $GITHUB_WORKSPACE/ibm/mas_devops/ibm-mas_devops.tar.gz
-          echo $?
 
       - name: Publish Collection
         if: ${{ github.event_name == 'release' }}
@@ -72,7 +71,7 @@ jobs:
   build-ee:
     name: Build Ansible Execution Environment
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, '[doc]') }} && ${{ !contains(github.event.head_commit.message, '[skip-ee]') }}
+    if: ${{ !contains(github.event.head_commit.message, '[doc]') }} && ${{ !contains(github.event.head_commit.message, '[skip ee]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.1

--- a/build/bin/.functions.sh
+++ b/build/bin/.functions.sh
@@ -86,5 +86,5 @@ function artifactory_upload() {
   sha1Value="${sha1Value:0:40}"
 
   echo "Uploading $1 to $2"
-  curl -H "Authorization:Bearer $ARTIFACTORY_TOKEN"  -H "X-Checksum-Md5: $md5Value" -H "X-Checksum-Sha1: $sha1Value" -T $1 $2 || exit 1
+  curl --fail -H "Authorization:Bearer $ARTIFACTORY_TOKEN"  -H "X-Checksum-Md5: $md5Value" -H "X-Checksum-Sha1: $sha1Value" -T $1 $2 || exit 1
 }


### PR DESCRIPTION
## Description
As title, added `--fail` option to `curl` command used to upload to Artifactory

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
