### PR TITLE
[patch] Check for null value for deprovision mongo

### DIFF
--- a/ibm/mas_devops/roles/mongodb/tasks/providers/aws/uninstall.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/aws/uninstall.yml
@@ -108,7 +108,7 @@
     sg_group_id: "{{sg_info.stdout | from_json | json_query('SecurityGroups[0].GroupId')}}"
 
 - name: Delete Security Group for DocDb Instance
-  when: sg_group_id is defined and sg_group_id != ''
+  when: sg_group_id is defined and sg_group_id != '' and sg_group_id != None
   command: >
     aws ec2 delete-security-group \
     --group-id '{{ sg_group_id }}'


### PR DESCRIPTION
## Description
Deprovision Mongo failed when security group id is null. We need to check for None as well
