### PR TITLE
[minor] Rotate Db2 versions in release verification pipeline

### DIFF
--- a/ibm/mas_devops/roles/db2/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/db2/tasks/install/main.yml
@@ -102,7 +102,6 @@
   delay: 30 # seconds
   when: db2_channel is not defined or db2_channel == "" or db2_version is not defined or db2_version == ""
 
-  # Test: Adding new concept to rotate db2_channel
   # Rotate DB2 channel by day of the week
 - name: "Select DB2 channel based on day of the week"
   when: db2_channel is defined and db2_channel == "rotate"
@@ -112,11 +111,11 @@
     rotate_db2_channel:
       Monday: "v110509.0"
       Tuesday: "v120101.0"
-      Wednesday: "v120102.0"
-      Thursday: "v110509.0"
-      Friday: "v120101.0"
-      Saturday: "v120102.0"
-      Sunday: "v120100.0"
+      Wednesday: "v110509.0"
+      Thursday: "v120101.0"
+      Friday: "v110509.0"
+      Saturday: "v120101.0"
+      Sunday: "v120101.0"
 
 - name: "Debug DB2 channel after rotation"
   when: db2_channel is defined and db2_channel != ""


### PR DESCRIPTION
## Description
This PR introduces support for rotating Db2 operand versions (v11 and v12) in the release verification (FVT) pipeline using a user-provided db2_channel=rotate value in **dev mode.**

When db2_channel is set to rotate, the pipeline dynamically alternates between Db2 v11 and v12 across different environments and/or different execution days. This allows continuous validation of both Db2 versions without requiring manual intervention.

## Story
[Jira 11100](https://jsw.ibm.com/browse/MASCORE-11100)

## What’s Changed

- Added support for db2_channel=rotate as a valid user input in dev mode
- Release verification (FVT) pipeline now:
- Automatically selects Db2 v11 or v12 when rotate is specified
- Alternates Db2 versions across runs, environments, or schedules
- No impact to non-dev mode or production installations

## Test Results
1. Db2 channel resolution in dev mode:
    db2_channel=rotate
     → Db2 version is selected dynamically (v11 or v12)
2. Explicit db2_channel=v11|v12
     → Requested version is used
3. No db2_channel provided
    → Falls back to catalog-defined default
    
## Positives
- Continuous validation of both Db2 v11 and v12
- Increased test coverage without duplicating pipelines
- Early detection of Db2 version-specific regressions
- Zero manual changes required in the FVT pipeline

NB: 
Rotation logic is intentionally limited to dev mode / FVT pipelines
Non-dev flows remain fully deterministic

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
