### PR TITLE
[patch] backup sls mongo database

### DIFF
--- a/ibm/mas_devops/roles/mongodb/templates/community/backup-restore/database-backup.sh.j2
+++ b/ibm/mas_devops/roles/mongodb/templates/community/backup-restore/database-backup.sh.j2
@@ -8,7 +8,6 @@ TMP_BACKUP_MONGODUMP_DIR="${TMP_BACKUP_DIR}/mongodump"
 ALL_DATABASES_FILTER="^(mas|iot|sls|ibm-sls)(_|-)({{ mas_instance_id }}|sls)(_|-)(?!.*monitor$)"
 
 tlsCAFile=$(ls /var/lib/tls/ca/*.pem)
-echo "Using TLS CA file: $tlsCAFile"
 primary_host=""
 
 is_primary=$(mongosh --quiet -u {{ mongodb_admin_user }} -p {{ mongodb_admin_password }} --host {{ mongodb_host }} --tlsCAFile $tlsCAFile --authenticationDatabase=admin --tls --eval 'db.isMaster().ismaster')


### PR DESCRIPTION
## Description

update mongo databse lookup regex to include sls database for mongo database backup.
support two sls databases
- sls-fvtcore_sls_licensing
- ibm-sls_sls_licensing


## Test Results

<img width="1022" height="390" alt="Screenshot 2026-01-16 at 12 24 51" src="https://github.com/user-attachments/assets/14fedb26-c3b9-4cc9-99c5-828bc6d1be19" />


<img width="1512" height="582" alt="Screenshot 2026-01-16 at 12 25 06" src="https://github.com/user-attachments/assets/ef4b8613-eba2-4a33-a7df-0f20560b89f0" />

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
