### PR TITLE
[patch] Simplify assertion for COS resource ID check

### DIFF
--- a/ibm/mas_devops/roles/cos/tasks/providers/ibm/provision.yml
+++ b/ibm/mas_devops/roles/cos/tasks/providers/ibm/provision.yml
@@ -66,7 +66,7 @@
 - name: "Fail if COS resource ID not found"
   assert:
     that:
-      - cos_output.failed is not defined or cos_output.failed | length == 0
+      - cos_output.failed is not defined or not cos_output.failed
     fail_msg: "Failed to provision IBM COS Instance Reason:{{ cos_output.stderr }} "
 
 - name: "ibm : Retrieve cos instance ID"


### PR DESCRIPTION
https://jsw.ibm.com/browse/MASCORE-11756
change in check the conditions of cos resource

## Description
Error Message:

64 register: cos_output
65
66 - name: "Fail if COS resource ID not found"
^ column 3
<<< caused by >>>
The filter plugin 'ansible.builtin.length' failed: object of type 'bool' has no len()
Origin: /opt/app-root/lib64/python3.12/site-packages/ansible_collections/ibm/mas_devops/roles/cos/tasks/providers/ibm/provision.yml:sunglasses:9
67 assert:
68 that:
69 - cos_output.failed is not defined or cos_output.failed | length == 0
^ column 9
fatal: [localhost]: FAILED! =>
{"changed": false, "msg": "Task failed: The filter plugin 'ansible.builtin.length' failed: object of type 'bool' has no len()"}
## Test Results
changed in assert contion only, function length() can not support on boolean
<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
