### PR TITLE
[patch] Mongodb subnet nonetype error

### DIFF
--- a/ibm/mas_devops/roles/mongodb/tasks/providers/aws/utils/create-subnet.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/aws/utils/create-subnet.yml
@@ -20,7 +20,7 @@
     subnet_id: "{{ subnet_info.stdout | from_json | json_query('Subnets[0].SubnetId') }}"
 
 - name: Create subnet in availability zone if it doen't exists
-  when: subnet_id is not defined or subnet_id | length == 0
+  when: subnet_id is not defined or not subnet_id
   command: >
     aws ec2 create-subnet \
       --vpc-id '{{ vpc_id }}' \
@@ -30,19 +30,19 @@
   register: create_subnet_info
 
 - name: Fail if Subnet not created successfully
-  when: subnet_id is not defined or subnet_id | length == 0
+  when: subnet_id is not defined or not subnet_id
   assert:
     that:
       - create_subnet_info is defined and create_subnet_info != ''
-      - create_subnet_info.stdout | length > 0
+      - create_subnet_info.stdout and create_subnet_info.stdout | length > 0
       - create_subnet_info.stdout | from_json | json_query('Subnet.SubnetId')
 
 - name: If subnet Id already exists add it to list
-  when: subnet_id | length > 0
+  when: subnet_id and subnet_id | length > 0
   set_fact:
     subnet_id_list: "{{ subnet_id_list|default([]) + [subnet_id] }}"
 
 - name: Add Newly created subnet Id to list
-  when: subnet_id is not defined or subnet_id | length == 0
+  when: subnet_id is not defined or not subnet_id
   set_fact:
     subnet_id_list: "{{ subnet_id_list | default([]) + [create_subnet_info.stdout | from_json | json_query('Subnet.SubnetId')] }}"


### PR DESCRIPTION
## Description

When creating fvtsaasai pipeline, mongodb is failing with creationg of subnets due to checks that length > 0 on nonetypes

TASK [ibm.mas_devops.mongodb : Create subnet in availability zone if it doen't exists] ***
[ERROR]: Task failed: The filter plugin 'ansible.builtin.length' failed: object of type 'NoneType' has no len()

Task failed.
Origin: /opt/app-root/lib64/python3.12/site-packages/ansible_collections/ibm/mas_devops/roles/mongodb/tasks/providers/aws/utils/create-subnet.yml:22:3

20     subnet_id: "{{ subnet_info.stdout | from_json | json_query('Subnets[0].SubnetId') }}"
21
22 - name: Create subnet in availability zone if it doen't exists
     ^ column 3

<<< caused by >>>

The filter plugin 'ansible.builtin.length' failed: object of type 'NoneType' has no len()
Origin: /opt/app-root/lib64/python3.12/site-packages/ansible_collections/ibm/mas_devops/roles/mongodb/tasks/providers/aws/utils/create-subnet.yml:23:9

21
22 - name: Create subnet in availability zone if it doen't exists
23   when: subnet_id is not defined or subnet_id | length == 0
           ^ column 9

fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task failed: The filter plugin 'ansible.builtin.length' failed: object of type 'NoneType' has no len()"}

PLAY RECAP *********************************************************************
localhost                  : ok=21   changed=2    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   

[ERROR] Error occurred at /mascli/functions/gitops_mongo, line 255, exited with 2

## Test Results
No testing was done because only assertion statements were changes because of none type lengths being checked

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
