### PR TITLE
[patch] Check for None in mongo and kafka roles

### DIFF
--- a/ibm/mas_devops/roles/kafka/tasks/provider/aws/utils/create-security-group.yml
+++ b/ibm/mas_devops/roles/kafka/tasks/provider/aws/utils/create-security-group.yml
@@ -12,7 +12,7 @@
     sg_id: "{{security_group_info.stdout | from_json | json_query('SecurityGroups[0].GroupId')}}"
 
 - name: Create a Security Group {{ aws_msk_security_group_name }}, if doesn't exists
-  when: sg_id is not defined or sg_id | length == 0
+  when: sg_id is not defined or sg_id == None or sg_id | length == 0
   shell: |
     aws ec2 create-security-group \
     --group-name '{{ aws_msk_security_group_name }}' \
@@ -21,7 +21,7 @@
   register: sg_info
 
 - name: Fail if Security group not created
-  when: sg_id is not defined or sg_id | length == 0
+  when: sg_id is not defined or sg_id == None or sg_id | length == 0
   assert:
     that:
       - sg_info is defined and sg_info != None and sg_info != ''
@@ -29,7 +29,7 @@
       - sg_info.stdout | from_json | json_query('GroupId')
 
 - name: Set Fact, Security group Id
-  when: sg_id is not defined or sg_id | length == 0
+  when: sg_id is not defined or sg_id == None or sg_id | length == 0
   set_fact:
     sg_id: "{{sg_info.stdout | from_json | json_query('GroupId')}}"
 

--- a/ibm/mas_devops/roles/kafka/tasks/provider/aws/utils/create-subnet.yml
+++ b/ibm/mas_devops/roles/kafka/tasks/provider/aws/utils/create-subnet.yml
@@ -20,7 +20,7 @@
     subnet_id: "{{ subnet_info.stdout | from_json | json_query('Subnets[0].SubnetId') }}"
 
 - name: Create subnet in availability zone if it doen't exists
-  when: subnet_id is not defined or subnet_id | length == 0
+  when: subnet_id is not defined or subnet_id == None or subnet_id | length == 0
   command: >
     aws ec2 create-subnet \
       --vpc-id '{{ vpc_id }}' \
@@ -30,7 +30,7 @@
   register: create_subnet_info
 
 - name: Fail if Subnet not created successfully
-  when: subnet_id is not defined or subnet_id | length == 0
+  when: subnet_id is not defined or subnet_id == None or subnet_id | length == 0
   assert:
     that:
       - create_subnet_info is defined and create_subnet_info != None and create_subnet_info != ''
@@ -43,6 +43,6 @@
     subnet_id_list: "{{ subnet_id_list|default([]) + [subnet_id] }}"
 
 - name: Add Newly created subnet Id to list
-  when: subnet_id is not defined or subnet_id | length == 0
+  when: subnet_id is not defined or subnet_id == None or subnet_id | length == 0
   set_fact:
     subnet_id_list: "{{ subnet_id_list | default([]) + [create_subnet_info.stdout | from_json | json_query('Subnet.SubnetId')] }}"

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/aws/install.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/aws/install.yml
@@ -125,7 +125,7 @@
     sg_id: "{{security_group_info.stdout | from_json | json_query('SecurityGroups[0].GroupId')}}"
 
 - name: Create a Security Group {{ docdb_security_group_name }}, if doesn't exists
-  when: sg_id is not defined or sg_id | length == 0
+  when: sg_id is not defined or sg_id == None or sg_id | length == 0
   command: >
     aws ec2 create-security-group \
     --group-name '{{ docdb_security_group_name }}' \
@@ -134,7 +134,7 @@
   register: sg_info
 
 - name: Fail if Security group not created
-  when: sg_id is not defined or sg_id | length == 0
+  when: sg_id is not defined or sg_id == None or sg_id | length == 0
   assert:
     that:
       - sg_info is defined and sg_info != None and sg_info != ''
@@ -142,7 +142,7 @@
       - sg_info.stdout | from_json | json_query('GroupId')
 
 - name: Set Fact, Security group Id
-  when: sg_id is not defined or sg_id | length == 0
+  when: sg_id is not defined or sg_id == None or sg_id | length == 0
   set_fact:
     sg_id: "{{sg_info.stdout | from_json | json_query('GroupId')}}"
 

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/aws/utils/create-subnet.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/aws/utils/create-subnet.yml
@@ -20,7 +20,7 @@
     subnet_id: "{{ subnet_info.stdout | from_json | json_query('Subnets[0].SubnetId') }}"
 
 - name: Create subnet in availability zone if it doen't exists
-  when: subnet_id is not defined or not subnet_id
+  when: subnet_id is not defined or subnet_id == None or not subnet_id
   command: >
     aws ec2 create-subnet \
       --vpc-id '{{ vpc_id }}' \
@@ -30,7 +30,7 @@
   register: create_subnet_info
 
 - name: Fail if Subnet not created successfully
-  when: subnet_id is not defined or not subnet_id
+  when: subnet_id is not defined or subnet_id == None or not subnet_id
   assert:
     that:
       - create_subnet_info is defined and create_subnet_info != ''
@@ -43,6 +43,6 @@
     subnet_id_list: "{{ subnet_id_list|default([]) + [subnet_id] }}"
 
 - name: Add Newly created subnet Id to list
-  when: subnet_id is not defined or not subnet_id
+  when: subnet_id is not defined or subnet_id == None or not subnet_id
   set_fact:
     subnet_id_list: "{{ subnet_id_list | default([]) + [create_subnet_info.stdout | from_json | json_query('Subnet.SubnetId')] }}"


### PR DESCRIPTION
## Description
Mongo and kafka provisioning failed in fvtsaas with below error
`object of type 'NoneType' has no len()`
To resolve this, we need to check for None as well

## Test Results
Tested in local test playbook to verify this condition works

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
