### PR TITLE
[patch] Add check for whether mongodb_ca_pem_local_file exists

### DIFF
--- a/ibm/mas_devops/roles/gencfg_mongo/tasks/main.yml
+++ b/ibm/mas_devops/roles/gencfg_mongo/tasks/main.yml
@@ -86,6 +86,13 @@
 
 # 5. Read file information
 # -----------------------------------------------------------------------------
+# https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/file_test.html
+- name: "Validate the Mongo Certificate file exists"
+  when: mongodb_ca_pem_local_file | length > 0
+  assert:
+    that: mongodb_ca_pem_local_file is file
+    fail_msg: "mongodb_ca_pem_local_file '{{ mongodb_ca_pem_local_file }}' does not exist or is not a file"
+
 - name: Read Mongo Certificate file
   when: mongodb_ca_pem_local_file | length > 0
   set_fact:


### PR DESCRIPTION
## Description
Add a simple check for whether to the mongodb_ca_pem_local_file exists before trying to read from it.

## Test Results
Not tested.  Simple change

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
