### PR TITLE
[patch] change temp dir to use backup_dir/restore_dir instead of /tmp

### DIFF
--- a/ibm/mas_devops/roles/download_backup_archive/README.md
+++ b/ibm/mas_devops/roles/download_backup_archive/README.md
@@ -130,8 +130,8 @@ Name of the Artifactory repository where the archive is stored.
 Temporary directory where the archive will be downloaded before extraction. The directory is created if it doesn't exist and can be cleaned up after extraction.
 
 - **Optional**
-- Environment Variable: `BACKUP_TEMP_DIR`
-- Default Value: `/tmp/mas-restore`
+- Environment Variable: None
+- Default Value: `<mas_restore_dir>/mas-restore-<backup_version>`
 
 #### download_timeout
 Maximum time in seconds to wait for the download to complete. Useful for large archives or slow network connections.

--- a/ibm/mas_devops/roles/download_backup_archive/defaults/main.yml
+++ b/ibm/mas_devops/roles/download_backup_archive/defaults/main.yml
@@ -22,7 +22,7 @@ artifactory_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}"
 artifactory_repository: "{{ lookup('env', 'ARTIFACTORY_REPOSITORY') }}"
 
 # General settings
-backup_temp_dir: "{{ lookup('env', 'BACKUP_TEMP_DIR') | default('/tmp/mas-restore', true) }}"
+backup_temp_dir: "{{ mas_restore_dir }}/mas-restore-{{ backup_version }}"
 download_timeout: "{{ lookup('env', 'DOWNLOAD_TIMEOUT_SECS') | default(3600, true) }}"  # Download timeout in seconds (1 hour)
 extract_archive: "{{ lookup('env', 'EXTRACT_ARCHIVE') | default(true, true) }}"  # Whether to extract the archive after download
 cleanup_archive: "{{ lookup('env', 'CLEANUP_ARCHIVE') | default(true, true) }}"  # Whether to remove the archive file after extraction

--- a/ibm/mas_devops/roles/download_backup_archive/tasks/main.yml
+++ b/ibm/mas_devops/roles/download_backup_archive/tasks/main.yml
@@ -40,6 +40,12 @@
     state: directory
     mode: '0755'
 
+# Delete temporary directory to make sure its clean
+- name: "Delete temporary directory before creating to make sure it is clean"
+  ansible.builtin.file:
+    path: "{{ backup_temp_dir }}"
+    state: absent
+
 # Create temporary directory for download
 - name: "Create temporary directory for download"
   ansible.builtin.file:

--- a/ibm/mas_devops/roles/upload_backup_archive/README.md
+++ b/ibm/mas_devops/roles/upload_backup_archive/README.md
@@ -173,7 +173,7 @@ Temporary directory where the archive will be created before upload. The directo
 
 - **Optional**
 - Environment Variable: None
-- Default Value: `/tmp/mas-backup-{{ backup_version }}`
+- Default Value: `<mas_backup_dir>/mas-backup-{{ backup_version }}`
 
 #### upload_timeout
 Maximum time in seconds to wait for the upload to complete. Useful for large archives or slow network connections.

--- a/ibm/mas_devops/roles/upload_backup_archive/defaults/main.yml
+++ b/ibm/mas_devops/roles/upload_backup_archive/defaults/main.yml
@@ -30,5 +30,5 @@ artifactory_repository: "{{ lookup('env', 'ARTIFACTORY_REPOSITORY') }}"
 
 # General settings
 backup_archive_name: "mas-backup-{{ backup_version }}.tar.gz"
-backup_temp_dir: "/tmp/mas-backup-{{ backup_version }}"
+backup_temp_dir: "{{ mas_backup_dir }}/mas-backup-{{ backup_version }}"
 upload_timeout: 3600  # Upload timeout in seconds (1 hour)

--- a/ibm/mas_devops/roles/upload_backup_archive/tasks/create_archive.yml
+++ b/ibm/mas_devops/roles/upload_backup_archive/tasks/create_archive.yml
@@ -39,6 +39,11 @@
     msg: "No backup directories found in {{ mas_backup_dir }} for version {{ backup_version }}"
   when: existing_backup_dirs | length == 0
 
+- name: "Remove temporary dir if it exists to avoid conflicts"
+  ansible.builtin.file:
+    path: "{{ backup_temp_dir }}"
+    state: absent
+
 - name: "Create temporary directory for archive"
   ansible.builtin.file:
     path: "{{ backup_temp_dir }}"


### PR DESCRIPTION
## Description

Change temp dir to use mas_backup_dir or mas_restore_dir instead of /tmp to avoid using pod's storage.

mas_backup_dir/mas_restore_dir is expected to have pvc mounted path

Also, cleanup temp dir just to make sure its emtpy.

## Test Results
<img width="1079" height="383" alt="Screenshot 2026-02-06 at 14 29 18" src="https://github.com/user-attachments/assets/5bed7cd7-a592-4f43-ae54-081d202033fa" />


<img width="1504" height="459" alt="Screenshot 2026-02-06 at 14 32 00" src="https://github.com/user-attachments/assets/91665019-da46-48aa-9bc5-8f737ea5974f" />



### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
