### PR TITLE
[patch] Remove indentation and Refactor conditional blocks for adoption metrics

### DIFF
--- a/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
+++ b/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
@@ -88,15 +88,15 @@ spec:
       allowSpecialChars: {{ mas_special_characters | bool}}
 {% endif %}
 {% if mas_channel != '8.7.x' and mas_channel != '8.8.x' and mas_channel != '8.9.x' and mas_channel != '8.10.x' and mas_channel != '8.11.x' and mas_channel != '9.0.x' %}
-    {% if mas_deployment_progression is defined and mas_deployment_progression != '' %}
-    deploymentProgression: {{ mas_deployment_progression | bool | lower }}
-    {% endif %}
-    {% if mas_usability_metrics is defined and mas_usability_metrics != '' %}
-    usability: {{ mas_usability_metrics | bool | lower }}
-    {% endif %}
-    {% if mas_feature_usage is defined and mas_feature_usage != '' %}
-    featureUse: {{ mas_feature_usage | bool | lower }}
-    {% endif %}
+{% if mas_deployment_progression is defined and mas_deployment_progression != '' %}
+    deploymentProgression: {{ mas_deployment_progression | bool }}
+{% endif %}
+{% if mas_usability_metrics is defined and mas_usability_metrics != '' %}
+    usability: {{ mas_usability_metrics | bool }}
+{% endif %}
+{% if mas_feature_usage is defined and mas_feature_usage != '' %}
+    featureUse: {{ mas_feature_usage | bool }}
+{% endif %}
 {% endif %}
     icr:
       cp: "{{ mas_icr_cp }}"


### PR DESCRIPTION
Issue reported here: https://ibm-ai-apps.slack.com/archives/C031Q7W21FZ/p1770748325332479

## PR Title:

Fix ScannerError in MAS Suite YAML template due to Jinja indentation


```
TASK [ibm.mas_devops.suite_install : Create suite.ibm.com/v1 CR] *****************************************************************************************************************************************************************************
[WARNING]: WorkerProcess for [localhost/TASK: ibm.mas_devops.suite_install : Create suite.ibm.com/v1 CR] errantly sent data directly to stdout instead of using Display:
    Annotation block processing failed, set the annotation_dict blank

[ERROR]: Task failed: ScannerError: mapping values are not allowed here
  in "<unicode string>", line 28, column 30:
            deploymentProgression: True
                                 ^

Task failed.
Origin: /opt/app-root/lib64/python3.12/site-packages/ansible_collections/ibm/mas_devops/roles/suite_install/tasks/main.yml:240:3

238 # 15. Suite installation
239 # -----------------------------------------------------------------------------
240 - name: Create suite.ibm.com/v1 CR
      ^ column 3

<<< caused by >>>

ScannerError: mapping values are not allowed here
  in "<unicode string>", line 28, column 30:
            deploymentProgression: True
                                 ^

fatal: [localhost]: FAILED! => {"changed": false, "msg": "ScannerError: mapping values are not allowed here\n  in \"<unicode string>\", line 28, column 30:\n            deploymentProgression: True\n                                 ^"}

PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
localhost                  : ok=281  changed=7    unreachable=0    failed=1    skipped=111  rescued=0    ignored=0   

```

## Description:

This PR resolves a ScannerError: mapping values are not allowed here that occurs when deploying the MAS Suite CR (suite.ibm.com/v1) via Ansible.

## Root Cause:

Conditional Jinja {% if %} blocks around keys like deploymentProgression, usability, and featureUse under settings: were indented inconsistently.

After Jinja rendering, the resulting YAML had misaligned keys, causing the parser to fail with:

ScannerError: mapping values are not allowed here
in "<unicode string>", line 31, column 30:
    deploymentProgression: True

Uppercase booleans (True / False) in rendered YAML also contributed to parsing issues in Ansible.

## Fix:

Adjusted indentation of all Jinja {% if %} and {% endif %} blocks to align correctly with the YAML parent keys.
Verified that the rendered YAML is fully valid and parses correctly.
Verified that keys are included only when corresponding variables are defined and non-empty.


## Test Results
Locally tested on lasted version of MAS CLI

suite_install task was successful

<img width="1681" height="359" alt="image" src="https://github.com/user-attachments/assets/691031c3-544f-41b9-a7a8-618f3c36b551" />


Suite CR successfully created

<img width="989" height="740" alt="image" src="https://github.com/user-attachments/assets/181716aa-a5f8-443f-bb00-401363ee88f1" />


### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
