### PR TITLE
[patch] Updated ocp rotate to include new version 4.20

### DIFF
--- a/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
@@ -30,11 +30,11 @@
   vars:
     rotate_ocp_version:
       Monday: 4.20
-      Tuesday: 4.19
-      Wednesday: 4.18
-      Thursday: 4.17
-      Friday: 4.20
-      Saturday: 4.16
+      Tuesday: 4.18
+      Wednesday: 4.19
+      Thursday: 4.16
+      Friday: 4.17
+      Saturday: 4.20
       Sunday: 4.19
 
 - name: "Set default OCP version"


### PR DESCRIPTION
## Description
Updated ocp_provision role to support new version 4.20 in rotate.

## Test Results
Refer Jira [Story- OCP 4.20 Support  for rotate](https://jsw.ibm.com/browse/MASCORE-12057)

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
