### PR TITLE
[patch] OCP version modified as string in rotate

### DIFF
--- a/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
@@ -29,13 +29,13 @@
     ocp_version: "{{ rotate_ocp_version[ansible_date_time['weekday']] ~ ('_openshift' if cluster_type == 'roks' else '') }}"
   vars:
     rotate_ocp_version:
-      Monday: 4.20
-      Tuesday: 4.18
-      Wednesday: 4.19
-      Thursday: 4.16
-      Friday: 4.20
-      Saturday: 4.17
-      Sunday: 4.19
+      Monday: "4.20"
+      Tuesday: "4.18"
+      Wednesday: "4.19"
+      Thursday: "4.16"
+      Friday: "4.20"
+      Saturday: "4.17"
+      Sunday: "4.19"
 
 - name: "Set default OCP version"
   when: ocp_version == "default"


### PR DESCRIPTION
## Description
OCP version modified as string in rotate

Attached screenshot of testing the change
<img width="1716" height="405" alt="Screenshot 2026-02-13 at 12 22 23 PM" src="https://github.com/user-attachments/assets/f93f71d5-e5e6-478a-9e86-6788243853f8" />

<img width="1716" height="62" alt="Screenshot 2026-02-13 at 12 22 57 PM" src="https://github.com/user-attachments/assets/9c3105f5-a4a4-431f-b934-e94fb8fa43cc" />
