### PR TITLE
[patch] Add missing "failed" property to return object

### DIFF
--- a/ibm/mas_devops/plugins/action/wait_for_app_ready.py
+++ b/ibm/mas_devops/plugins/action/wait_for_app_ready.py
@@ -56,11 +56,13 @@ class ActionModule(ActionBase):
             return dict(
                 message=f"Application {resourceName} is ready",
                 success=True,
+                failed=False,
                 changed=False
             )
         else:
             return dict(
                 message=f"Application {resourceName} is not ready",
                 success=False,
+                failed=True,
                 changed=False
             )


### PR DESCRIPTION
## Description
This task should have resulted in a failure when the `Wait for application to be ready (120s delay)` task failed to return success.  However the action does not return the `failed` property that Ansible actually uses (the `success` one is an unnecessary duplication/custom property and doesn't have any specific role in how Ansible interprets the result)

```
TASK [ibm.mas_devops.suite_app_install : Install application] ******************
changed: [localhost] => {"changed": true, "method": "create", "result": {"apiVersion": "apps.mas.ibm.com/v1", "kind": "VisualInspectionApp", "metadata": {"creationTimestamp": "2026-02-17T16:08:56Z", "generation": 1, "labels": {"mas.ibm.com/applicationId": "visualinspection", "mas.ibm.com/instanceId": "airgapv2"}, "managedFields": [{"apiVersion": "apps.mas.ibm.com/v1", "fieldsType": "FieldsV1", "fieldsV1": {"f:metadata": {"f:labels": {".": {}, "f:mas.ibm.com/applicationId": {}, "f:mas.ibm.com/instanceId": {}}}, "f:spec": {".": {}, "f:settings": {".": {}, "f:imagePullPolicy": {}, "f:storage": {".": {}, "f:objectStorageEnabled": {}, "f:size": {}, "f:storageClassName": {}}}, "f:size": {}}}, "manager": "OpenAPI-Generator", "operation": "Update", "time": "2026-02-17T16:08:56Z"}], "name": "airgapv2", "namespace": "mas-airgapv2-visualinspection", "resourceVersion": "2717869", "uid": "2505a734-02fc-451f-a453-d71bce1b5881"}, "spec": {"settings": {"imagePullPolicy": "IfNotPresent", "storage": {"objectStorageEnabled": false, "size": "100Gi", "storageClassName": "ocs-storagecluster-cephfs"}}, "size": 1}}}

TASK [ibm.mas_devops.suite_app_install : Wait for application to be ready (120s delay)] ***
Polling for VisualInspectionApp/airgapv2 to report ready state with 120s delay and 30 retry limit
[1/30] VisualInspectionApp/airgapv2 has no status
[2/30] VisualInspectionApp/airgapv2 has no status
[3/30] VisualInspectionApp/airgapv2 has no status
[4/30] VisualInspectionApp/airgapv2 has no status
[5/30] VisualInspectionApp/airgapv2 has no status
[6/30] VisualInspectionApp/airgapv2 has no status
[7/30] VisualInspectionApp/airgapv2 has no status
[8/30] VisualInspectionApp/airgapv2 has no status
[9/30] VisualInspectionApp/airgapv2 has no status
[10/30] VisualInspectionApp/airgapv2 has no status
[11/30] VisualInspectionApp/airgapv2 has no status
[12/30] VisualInspectionApp/airgapv2 has no status
[13/30] VisualInspectionApp/airgapv2 has no status
[14/30] VisualInspectionApp/airgapv2 has no status
[15/30] VisualInspectionApp/airgapv2 has no status
[16/30] VisualInspectionApp/airgapv2 has no status
[17/30] VisualInspectionApp/airgapv2 has no status
[18/30] VisualInspectionApp/airgapv2 has no status
[19/30] VisualInspectionApp/airgapv2 has no status
[20/30] VisualInspectionApp/airgapv2 has no status
[21/30] VisualInspectionApp/airgapv2 has no status
[22/30] VisualInspectionApp/airgapv2 has no status
[23/30] VisualInspectionApp/airgapv2 has no status
[24/30] VisualInspectionApp/airgapv2 has no status
[25/30] VisualInspectionApp/airgapv2 has no status
[26/30] VisualInspectionApp/airgapv2 has no status
[27/30] VisualInspectionApp/airgapv2 has no status
[28/30] VisualInspectionApp/airgapv2 has no status
[29/30] VisualInspectionApp/airgapv2 has no status
[30/30] VisualInspectionApp/airgapv2 has no status
No VisualInspectionApp/airgapv2 status available
ok: [localhost] => {"changed": false, "message": "Application airgapv2/visualinspection is not ready", "success": false}

TASK [ibm.mas_devops.suite_app_install : Apply final security context constraints] ***
changed: [localhost] => {"changed": true, "method": "apply", "result": {"allowHostDirVolumePlugin": false, "allowHostIPC": false, "allowHostNetwork": false, "allowHostPID": false, "allowHostPorts": false, "allowPrivilegeEscalation": false, "allowPrivilegedContainer": false, "allowedCapabilities": ["CHOWN", "DAC_OVERRIDE", "FOWNER", "FSETID", "KILL", "SETGID", "SETUID", "SETPCAP", "NET_BIND_SERVICE", "NET_RAW", "SYS_CHROOT"], "apiVersion": "security.openshift.io/v1", "defaultAddCapabilities": null, "fsGroup": {"ranges": [{"max": 65535, "min": 1}], "type": "MustRunAs"}, "groups": [], "kind": "SecurityContextConstraints", "metadata": {"annotations": {"kubectl.kubernetes.io/last-applied-configuration": "{\"allowHostDirVolumePlugin\":false,\"allowHostIPC\":false,\"allowHostNetwork\":false,\"allowHostPID\":false,\"allowHostPorts\":false,\"allowPrivilegeEscalation\":false,\"allowPrivilegedContainer\":false,\"allowedCapabilities\":[\"CHOWN\",\"DAC_OVERRIDE\",\"FOWNER\",\"FSETID\",\"KILL\",\"SETGID\",\"SETUID\",\"SETPCAP\",\"NET_BIND_SERVICE\",\"NET_RAW\",\"SYS_CHROOT\"],\"allowedUnsafeSysctls\":null,\"apiVersion\":\"security.openshift.io/v1\",\"defaultAddCapabilities\":null,\"fsGroup\":{\"ranges\":[{\"max\":65535,\"min\":1}],\"type\":\"MustRunAs\"},\"groups\":[],\"kind\":\"SecurityContextConstraints\",\"metadata\":{\"annotations\":{\"kubernetes.io/description\":\"This policy is the most restrictive for IBM Maximo Visual Inspection.\"},\"name\":\"ibm-mas-visualinspection-scc\"},\"readOnlyRootFilesystem\":false,\"requiredDropCapabilities\":[\"ALL\"],\"runAsUser\":{\"type\":\"MustRunAsRange\",\"uidRangeMax\":65535,\"uidRangeMin\":0},\"seLinuxContext\":{\"type\":\"RunAsAny\"},\"seccompProfiles\":null,\"supplementalGroups\":{\"ranges\":[{\"max\":65535,\"min\":1}],\"type\":\"MustRunAs\"},\"users\":[],\"volumes\":[\"configMap\",\"downwardAPI\",\"emptyDir\",\"persistentVolumeClaim\",\"projected\",\"secret\"]}", "kubernetes.io/description": "This policy is the most restrictive for IBM Maximo Visual Inspection."}, "creationTimestamp": "2026-02-17T16:07:52Z", "generation": 2, "managedFields": [{"apiVersion": "security.openshift.io/v1", "fieldsType": "FieldsV1", "fieldsV1": {"f:allowHostDirVolumePlugin": {}, "f:allowHostIPC": {}, "f:allowHostNetwork": {}, "f:allowHostPID": {}, "f:allowHostPorts": {}, "f:allowPrivilegeEscalation": {}, "f:allowPrivilegedContainer": {}, "f:allowedCapabilities": {}, "f:allowedUnsafeSysctls": {}, "f:fsGroup": {".": {}, "f:ranges": {}, "f:type": {}}, "f:groups": {}, "f:metadata": {"f:annotations": {".": {}, "f:kubectl.kubernetes.io/last-applied-configuration": {}, "f:kubernetes.io/description": {}}}, "f:readOnlyRootFilesystem": {}, "f:requiredDropCapabilities": {}, "f:runAsUser": {".": {}, "f:type": {}, "f:uidRangeMax": {}, "f:uidRangeMin": {}}, "f:seLinuxContext": {".": {}, "f:type": {}}, "f:seccompProfiles": {}, "f:supplementalGroups": {".": {}, "f:ranges": {}, "f:type": {}}, "f:users": {}, "f:volumes": {}}, "manager": "OpenAPI-Generator", "operation": "Update", "time": "2026-02-17T17:08:58Z"}], "name": "ibm-mas-visualinspection-scc", "resourceVersion": "2824966", "uid": "e961ed34-e9e7-479f-ab41-b291dd9373a0"}, "priority": null, "readOnlyRootFilesystem": false, "requiredDropCapabilities": ["ALL"], "runAsUser": {"type": "MustRunAsRange", "uidRangeMax": 65535, "uidRangeMin": 0}, "seLinuxContext": {"type": "RunAsAny"}, "supplementalGroups": {"ranges": [{"max": 65535, "min": 1}], "type": "MustRunAs"}, "users": [], "volumes": ["configMap", "downwardAPI", "emptyDir", "persistentVolumeClaim", "projected", "secret"]}}

TASK [ibm.mas_devops.suite_app_install : Remove anyuid permissions from visualinspection service account] ***
changed: [localhost] => {"changed": true, "cmd": "oc adm policy remove-scc-from-user anyuid system:serviceaccount:mas-airgapv2-visualinspection:ibm-mas-visualinspection-operator\n", "delta": "0:00:00.126605", "end": "2026-02-17 17:08:59.487934", "msg": "", "rc": 0, "start": "2026-02-17 17:08:59.361329", "stderr": "", "stderr_lines": [], "stdout": "clusterrole.rbac.authorization.k8s.io/system:openshift:scc:anyuid removed: \"ibm-mas-visualinspection-operator\"", "stdout_lines": ["clusterrole.rbac.authorization.k8s.io/system:openshift:scc:anyuid removed: \"ibm-mas-visualinspection-operator\""]}

PLAY RECAP *********************************************************************
localhost                  : ok=27   changed=5    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0   
```

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
