### PR TITLE
[patch] fix oc mirror --v2

### DIFF
--- a/ibm/mas_devops/roles/mirror_ocp/tasks/actions/direct.yml
+++ b/ibm/mas_devops/roles/mirror_ocp/tasks/actions/direct.yml
@@ -34,7 +34,7 @@
 
     - name: "{{ ocp_release }} : dry mode mirror command"
       shell: >
-        DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dry-run --dest-tls-verify=falses -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml docker://{{ registry_public_url_with_path_redhat }} --workspace file://{{ mirror_working_dir }}/.ibm-mas --v2
+        DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dry-run --dest-tls-verify=false -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml docker://{{ registry_public_url_with_path_redhat }} --workspace file://{{ mirror_working_dir }}/.ibm-mas --v2
       register: ocimagemirror_dryrun_result
       ignore_errors: true
 

--- a/ibm/mas_devops/roles/mirror_ocp/tasks/actions/direct.yml
+++ b/ibm/mas_devops/roles/mirror_ocp/tasks/actions/direct.yml
@@ -34,7 +34,7 @@
 
     - name: "{{ ocp_release }} : dry mode mirror command"
       shell: >
-        DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dry-run --dest-skip-tls --config={{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml docker://{{ registry_public_url_with_path_redhat }}
+        DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dry-run --dest-tls-verify=falses -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml docker://{{ registry_public_url_with_path_redhat }} --workspace file://{{ mirror_working_dir }}/.ibm-mas --v2
       register: ocimagemirror_dryrun_result
       ignore_errors: true
 
@@ -64,9 +64,9 @@
 - name: "Debug Information"
   debug:
     msg:
-      - "Command ...................... DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-skip-tls --config={{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml docker://{{ registry_public_url_with_path_redhat }}"
+      - "Command ...................... DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-tls-verify=false -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml docker://{{ registry_public_url_with_path_redhat }} --workspace file://{{ mirror_working_dir }}/.ibm-mas --v2"
       - "Log File ..................... {{ mirror_working_dir }}/logs/mirror-direct-ocp{{ ocp_release }}.log"
 
 - name: "Mirror Red Hat content from source registry to target registry"
   shell: >
-    DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-skip-tls --config={{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml docker://{{ registry_public_url_with_path_redhat }} &> {{ mirror_working_dir }}/logs/mirror-direct-ocp{{ ocp_release }}.log
+    DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-tls-verify=false -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml docker://{{ registry_public_url_with_path_redhat }} --workspace file://{{ mirror_working_dir }}/.ibm-mas --v2 &> {{ mirror_working_dir }}/logs/mirror-direct-ocp{{ ocp_release }}.log

--- a/ibm/mas_devops/roles/mirror_ocp/tasks/actions/from-filesystem.yml
+++ b/ibm/mas_devops/roles/mirror_ocp/tasks/actions/from-filesystem.yml
@@ -24,7 +24,7 @@
 
     - name: "{{ ocp_release }} : dry mode mirror command"
       shell: >
-        DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dry-run --dest-skip-tls --max-per-registry=1 --from={{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }}
+        DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dry-run --dest-tls-verify=false --max-per-registry=1 --from={{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }} --v2
       register: ocimagemirror_dryrun_result
       ignore_errors: true
 
@@ -56,9 +56,9 @@
 - name: "Debug Information"
   debug:
     msg:
-      - "Command ...................... DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-skip-tls --max-per-registry=1 --from={{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }}"
+      - "Command ...................... DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-tls-verify=false --max-per-registry=1 --from={{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }}"
       - "Log File ..................... {{ mirror_working_dir }}/logs/mirror-from-filesystem-ocp{{ ocp_release }}.log"
 
 - name: "Mirror Red Hat content from filesystem to target registry"
   shell: >
-    DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-skip-tls --max-per-registry=1 --from={{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }} &> {{ mirror_working_dir }}/logs/mirror-from-filesystem-ocp{{ ocp_release }}.log
+    DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-tls-verify=false --max-per-registry=1 --from {{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }} --v2 &> {{ mirror_working_dir }}/logs/mirror-from-filesystem-ocp{{ ocp_release }}.log

--- a/ibm/mas_devops/roles/mirror_ocp/tasks/actions/from-filesystem.yml
+++ b/ibm/mas_devops/roles/mirror_ocp/tasks/actions/from-filesystem.yml
@@ -24,7 +24,7 @@
 
     - name: "{{ ocp_release }} : dry mode mirror command"
       shell: >
-        DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dry-run --dest-tls-verify=false --max-per-registry=1 --from file://{{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }} --v2
+        DOCKER_CONFIG={{ mirror_working_dir }} oc mirror -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml --dry-run --dest-tls-verify=false --parallel-images=1 --from file://{{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }} --v2
       register: ocimagemirror_dryrun_result
       ignore_errors: true
 
@@ -56,9 +56,9 @@
 - name: "Debug Information"
   debug:
     msg:
-      - "Command ...................... DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-tls-verify=false --max-per-registry=1 --from file://{{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }}"
+      - "Command ...................... DOCKER_CONFIG={{ mirror_working_dir }} oc mirror -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml --dest-tls-verify=false --parallel-images=1 --from file://{{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }}"
       - "Log File ..................... {{ mirror_working_dir }}/logs/mirror-from-filesystem-ocp{{ ocp_release }}.log"
 
 - name: "Mirror Red Hat content from filesystem to target registry"
   shell: >
-    DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-tls-verify=false --max-per-registry=1 --from file://{{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }} --v2 &> {{ mirror_working_dir }}/logs/mirror-from-filesystem-ocp{{ ocp_release }}.log
+    DOCKER_CONFIG={{ mirror_working_dir }} oc mirror -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml --dest-tls-verify=false --parallel-images=1 --from file://{{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }} --v2 &> {{ mirror_working_dir }}/logs/mirror-from-filesystem-ocp{{ ocp_release }}.log

--- a/ibm/mas_devops/roles/mirror_ocp/tasks/actions/from-filesystem.yml
+++ b/ibm/mas_devops/roles/mirror_ocp/tasks/actions/from-filesystem.yml
@@ -24,7 +24,7 @@
 
     - name: "{{ ocp_release }} : dry mode mirror command"
       shell: >
-        DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dry-run --dest-tls-verify=false --max-per-registry=1 --from={{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }} --v2
+        DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dry-run --dest-tls-verify=false --max-per-registry=1 --from file://{{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }} --v2
       register: ocimagemirror_dryrun_result
       ignore_errors: true
 
@@ -56,9 +56,9 @@
 - name: "Debug Information"
   debug:
     msg:
-      - "Command ...................... DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-tls-verify=false --max-per-registry=1 --from={{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }}"
+      - "Command ...................... DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-tls-verify=false --max-per-registry=1 --from file://{{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }}"
       - "Log File ..................... {{ mirror_working_dir }}/logs/mirror-from-filesystem-ocp{{ ocp_release }}.log"
 
 - name: "Mirror Red Hat content from filesystem to target registry"
   shell: >
-    DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-tls-verify=false --max-per-registry=1 --from {{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }} --v2 &> {{ mirror_working_dir }}/logs/mirror-from-filesystem-ocp{{ ocp_release }}.log
+    DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-tls-verify=false --max-per-registry=1 --from file://{{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }} --v2 &> {{ mirror_working_dir }}/logs/mirror-from-filesystem-ocp{{ ocp_release }}.log

--- a/ibm/mas_devops/roles/mirror_ocp/tasks/actions/to-filesystem.yml
+++ b/ibm/mas_devops/roles/mirror_ocp/tasks/actions/to-filesystem.yml
@@ -19,9 +19,9 @@
 - name: "Debug Information"
   debug:
     msg:
-      - "Command ...................... DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --config={{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml file:///{{ mirror_working_dir }}"
+      - "Command ...................... DOCKER_CONFIG={{ mirror_working_dir }} oc mirror -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml file:///{{ mirror_working_dir }} --v2"
       - "Log File ..................... {{ mirror_working_dir }}/logs/mirror-to-filesystem-ocp{{ ocp_release }}.log"
 
 - name: "Mirror Red Hat content from source registry to filesystem"
   shell: >
-    DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --config={{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml file:///{{ mirror_working_dir }} &> {{ mirror_working_dir }}/logs/mirror-to-filesystem-ocp{{ ocp_release }}.log
+    DOCKER_CONFIG={{ mirror_working_dir }} oc mirror -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml file:///{{ mirror_working_dir }} --v2 &> {{ mirror_working_dir }}/logs/mirror-to-filesystem-ocp{{ ocp_release }}.log

--- a/ibm/mas_devops/roles/mirror_ocp/tasks/main.yml
+++ b/ibm/mas_devops/roles/mirror_ocp/tasks/main.yml
@@ -22,7 +22,7 @@
     fail_msg: "oc command must be installed"
 
 - name: "Test if oc-mirror is installed"
-  shell: oc mirror help
+  shell: oc mirror --v2  help
   register: _oc_mirror_help
   ignore_errors: true
 

--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -30,6 +30,7 @@ mirror:
             - name: v24.9
             - name: v25.3
             - name: v25.10
+            - name: v26.3
         - name: kubeturbo-certified  # Required by ibm.mas_devops.kubeturbo role
           channels:
             - name: stable
@@ -51,6 +52,7 @@ mirror:
         - name: strimzi-kafka-operator  #  Required by ibm.mas_devops.kafka role
           channels:
             - name: strimzi-0.45.x
+            - name: stable
 
     # redhat-operators
     - catalog: registry.redhat.io/redhat/redhat-operator-index:v{{ ocp_release }}

--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -51,9 +51,6 @@ mirror:
         - name: strimzi-kafka-operator  #  Required by ibm.mas_devops.kafka role
           channels:
             - name: strimzi-0.45.x
-        - name: opendatahub-operator
-          channels:
-            - name: fast
 
     # redhat-operators
     - catalog: registry.redhat.io/redhat/redhat-operator-index:v{{ ocp_release }}


### PR DESCRIPTION
## Description
<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->
oc mirror command expecting --v1 / --v2 flag. Have updated with --v2 flags.

## Issue:
- https://github.com/ibm-mas/cli/issues/2153
- 
## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->
```
2026/04/02 17:13:16 [INFO] : === Results ===
2026/04/02 17:13:16 [INFO] : ✗ 272 / 281 operator images mirrored: Some operator images failed to be mirrored - please check the logs
2026/04/02 17:13:16 [INFO] : ✓ 3 / 3 additional images mirrored successfully
2026/04/02 17:13:16 [ERROR] : [Worker] error mirroring image docker://registry.connect.redhat.com/nvidia/gpu-operator-bundle@sha256:b897e25e03133513f9afdb5abe38cbf0f2ac0556c27518d9d80e792eb07ecf28 (Operator bundles: [gpu-operator-certified.v24.9.2] - Operators: [gpu-operator-certified]) error: reading signatures: reading manifest sha256-b897e25e03133513f9afdb5abe38cbf0f2ac0556c27518d9d80e792eb07ecf28.sig in registry.connect.redhat.com/nvidia/gpu-operator-bundle: name unknown: Image not found
2026/04/02 17:13:16 [ERROR] : [Worker] error mirroring image docker://registry.connect.redhat.com/nvidia/gpu-operator-bundle@sha256:cbd83ff041c3e6e9a5d76dc2cfa1894893c5e2f92583b16df9c418232cbce78c (Operator bundles: [gpu-operator-certified.v25.3.4] - Operators: [gpu-operator-certified]) error: reading signatures: reading manifest sha256-cbd83ff041c3e6e9a5d76dc2cfa1894893c5e2f92583b16df9c418232cbce78c.sig in registry.connect.redhat.com/nvidia/gpu-operator-bundle: name unknown: Image not found
2026/04/02 17:13:16 [ERROR] : [Worker] error mirroring image docker://registry.connect.redhat.com/nvidia/gpu-operator-bundle@sha256:10acae5f724b07faa6e6c7716f3342d3cf2306a2c22971825e1a23753c21e8c3 (Operator bundles: [gpu-operator-certified.v25.10.1] - Operators: [gpu-operator-certified]) error: reading signatures: reading manifest sha256-10acae5f724b07faa6e6c7716f3342d3cf2306a2c22971825e1a23753c21e8c3.sig in registry.connect.redhat.com/nvidia/gpu-operator-bundle: name unknown: Image not found
2026/04/02 17:13:16 [ERROR] : [Worker] error mirroring image docker://registry.connect.redhat.com/nvidia/gpu-operator-bundle@sha256:708291528f26c70c561745967a1200edcb2f984687f749a49a2860fee580423f (Operator bundles: [gpu-operator-certified.v23.3.2] - Operators: [gpu-operator-certified]) error: reading signatures: reading manifest sha256-708291528f26c70c561745967a1200edcb2f984687f749a49a2860fee580423f.sig in registry.connect.redhat.com/nvidia/gpu-operator-bundle: name unknown: Image not found
2026/04/02 17:13:16 [ERROR] : [Worker] error mirroring image docker://registry.connect.redhat.com/nvidia/gpu-operator-bundle@sha256:5fbbe99eba2ebb1809b8fb8499297616607d122b82cacce8f36cd4a8669c5a90 (Operator bundles: [gpu-operator-certified.v26.3.0] - Operators: [gpu-operator-certified]) error: reading signatures: reading manifest sha256-5fbbe99eba2ebb1809b8fb8499297616607d122b82cacce8f36cd4a8669c5a90.sig in registry.connect.redhat.com/nvidia/gpu-operator-bundle: name unknown: Image not found
2026/04/02 17:13:16 [ERROR] : [Worker] error mirroring image docker://registry.connect.redhat.com/rh-marketplace/ibm-data-reporter-operator-bundle@sha256:1365982e36b0ed86c815d74b7d9f6d1ec59eedbd25951a0c18b9245fe5fad3ae (Operator bundles: [ibm-data-reporter-operator.v2.24.2] - Operators: [ibm-data-reporter-operator]) error: reading signatures: reading manifest sha256-1365982e36b0ed86c815d74b7d9f6d1ec59eedbd25951a0c18b9245fe5fad3ae.sig in registry.connect.redhat.com/rh-marketplace/ibm-data-reporter-operator-bundle: name unknown: Image not found
2026/04/02 17:13:16 [ERROR] : [Worker] error mirroring image docker://registry.connect.redhat.com/rh-marketplace/ibm-metrics-operator-bundle@sha256:cc0a6ef08cecb12ab8cddb7a2cccc4dcf8a1e798ce27a821f142d6490ca80ed9 (Operator bundles: [ibm-metrics-operator.v2.24.2] - Operators: [ibm-metrics-operator]) error: reading signatures: reading manifest sha256-cc0a6ef08cecb12ab8cddb7a2cccc4dcf8a1e798ce27a821f142d6490ca80ed9.sig in registry.connect.redhat.com/rh-marketplace/ibm-metrics-operator-bundle: name unknown: Image not found
2026/04/02 17:13:16 [ERROR] : [Worker] error mirroring image docker://registry.connect.redhat.com/turbonomic/kubeturbo-operator-bundle@sha256:3789b73bc561bbb61edfba8413c57fd8951cdf8b076e3fb3a435a52061876f04 (Operator bundles: [kubeturbo-operator.v8.19.30] - Operators: [kubeturbo-certified]) error: reading signatures: reading manifest sha256-3789b73bc561bbb61edfba8413c57fd8951cdf8b076e3fb3a435a52061876f04.sig in registry.connect.redhat.com/turbonomic/kubeturbo-operator-bundle: name unknown: Image not found
2026/04/02 17:13:16 [ERROR] : [Worker] error mirroring image docker://quay.io/strimzi/kaniko-executor@sha256:ef1a39c363e145041d80103c3c12da9429ce06cf21dff6fb1fb75d0c0ed9c35b (Operator bundles: [strimzi-cluster-operator.v0.45.2] - Operators: [strimzi-kafka-operator]) error: copying image 3/4 from manifest list: reading signatures: Get "https://cdn01.quay.io/quayio-production-s3/sha256/f5/f538811e8c55dc177a53b0e689bc42015989d7e40d6534f66a4134cba63dda97?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIATAAF2YHTGR23ZTE6%!F(MISSING)20260402%!F(MISSING)us-east-1%!F(MISSING)s3%!F(MISSING)aws4_request&X-Amz-Date=20260402T171315Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&X-Amz-Signature=5c28c2cff435ac55a550203fe9c94b64f8a7435c95b1ad20006d79b899cb043d&region=us-east-1&namespace=strimzi&username=openshift-release-dev+ocm_access_52896f29ff6c421eac6dd015485ce6a5&repo_name=kaniko-executor&akamai_signature=exp=1775150895~hmac=3455f6cc633e20a50eec6dd1a70765f5dda9d3d838225163bef6aedc90531af5": context dea...
2026/04/02 17:13:16 [INFO] : 📄 Generating IDMS file...
2026/04/02 17:13:16 [INFO] : /tmp/mirror/.ibm-mas/working-dir/cluster-resources/idms-oc-mirror.yaml file created
2026/04/02 17:13:16 [INFO] : 📄 Generating ITMS file...
2026/04/02 17:13:16 [INFO] : /tmp/mirror/.ibm-mas/working-dir/cluster-resources/itms-oc-mirror.yaml file created
2026/04/02 17:13:16 [INFO] : 📄 Generating CatalogSource file...
2026/04/02 17:13:16 [INFO] : /tmp/mirror/.ibm-mas/working-dir/cluster-resources/cs-redhat-operator-index-v4-20.yaml file created
2026/04/02 17:13:16 [INFO] : /tmp/mirror/.ibm-mas/working-dir/cluster-resources/cs-community-operator-index-v4-20.yaml file created
2026/04/02 17:13:16 [INFO] : /tmp/mirror/.ibm-mas/working-dir/cluster-resources/cs-certified-operator-index-v4-20.yaml file created
2026/04/02 17:13:16 [INFO] : 📄 Generating ClusterCatalog file...
2026/04/02 17:13:16 [INFO] : /tmp/mirror/.ibm-mas/working-dir/cluster-resources/cc-redhat-operator-index-v4-20.yaml file created
2026/04/02 17:13:16 [INFO] : /tmp/mirror/.ibm-mas/working-dir/cluster-resources/cc-community-operator-index-v4-20.yaml file created
2026/04/02 17:13:16 [INFO] : /tmp/mirror/.ibm-mas/working-dir/cluster-resources/cc-certified-operator-index-v4-20.yaml file created
2026/04/02 17:13:16 [INFO] : mirror time : 33m0.686443775s
2026/04/02 17:13:16 [INFO] : 👋 Goodbye, thank you for using oc-mirror
2026/04/02 17:13:16 [ERROR] : [Executor] [Worker] some errors occurred during the mirroring.
Please review /tmp/mirror/.ibm-mas/working-dir/logs/mirroring_errors_20260402_164015.txt for a list of mirroring errors.
You may consider:
* removing images or operators that cause the error from the image set config, and retrying
* keeping the image set config (images are mandatory for you), and retrying
* mirroring the failing images manually, if retries also fail.
```
<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
