### PR TITLE
[minor] Add support to enable IPv6 SingleStack networking for Minio

### DIFF
--- a/ibm/mas_devops/roles/minio/defaults/main.yml
+++ b/ibm/mas_devops/roles/minio/defaults/main.yml
@@ -25,3 +25,6 @@ minio_root_user: "{{ lookup('env', 'MINIO_ROOT_USER') | default('minio', True) }
 minio_root_password: "{{ lookup('env', 'MINIO_ROOT_PASSWORD') | default('', True) }}"
 # needs to move to catalog
 minio_version: "RELEASE.2025-06-13T11-33-47Z"
+
+# Enable IPv6?
+enable_ipv6: "{{ lookup('env', 'ENABLE_IPV6') | default('false', true) | bool }}"

--- a/ibm/mas_devops/roles/minio/templates/minio/minio-deployment.yml.j2
+++ b/ibm/mas_devops/roles/minio/templates/minio/minio-deployment.yml.j2
@@ -27,7 +27,7 @@ spec:
             - /bin/bash
             - -c
           args:
-            - minio server /data --console-address :9090
+            - minio server /data --console-address "[::]:9090" --address "[::]:9000"
           env:
             - name: MINIO_ROOT_USER
               value: "{{ minio_root_user }}"

--- a/ibm/mas_devops/roles/minio/templates/minio/minio-deployment.yml.j2
+++ b/ibm/mas_devops/roles/minio/templates/minio/minio-deployment.yml.j2
@@ -23,11 +23,14 @@ spec:
           metadata:
             labels:
               tag: "{{ minio_image_tag }}"
-          command:
-            - /bin/bash
-            - -c
+          command: ["minio"]
           args:
-            - minio server /data --console-address "[::]:9090" --address "[::]:9000"
+            - server
+            - /data
+            - --console-address
+            - "[::]:9090"
+            - --address
+            - "[::]:9000"
           env:
             - name: MINIO_ROOT_USER
               value: "{{ minio_root_user }}"

--- a/ibm/mas_devops/roles/minio/templates/minio/minio-service.yml.j2
+++ b/ibm/mas_devops/roles/minio/templates/minio/minio-service.yml.j2
@@ -17,3 +17,8 @@ spec:
       protocol: TCP
   selector:
     app: {{ minio_instance_name }}
+{% if enable_ipv6 is true %}
+  ipFamilyPolicy: SingleStack
+  ipFamilies:
+    - IPv6
+{% endif %}


### PR DESCRIPTION
## Description

- Adding support for enabling IPv6 SingleStack networking for MinIO.
- Update the deployment command and args to use unspecified IPv6 address so that it can work in Dual Stack mode.

## Test Results

- Tested on IPv6 cluster and on IPv4 clusters.
### IPv6 environment
<img width="1117" height="448" alt="Screenshot 2026-04-09 at 3 20 20 PM" src="https://github.com/user-attachments/assets/5e9b8539-249b-4aaf-ba64-812ab9e02a47" />
<img width="738" height="476" alt="Screenshot 2026-04-09 at 3 19 21 PM" src="https://github.com/user-attachments/assets/2f41bde5-4c00-46cb-93d0-5e16794888c7" />
<img width="457" height="685" alt="Screenshot 2026-04-09 at 3 19 17 PM" src="https://github.com/user-attachments/assets/781b701a-0cf4-43cc-9bb0-e02858e815fa" />

### IPv4 environment
<img width="645" height="698" alt="Screenshot 2026-04-09 at 3 18 45 PM" src="https://github.com/user-attachments/assets/75ff6814-e6fd-43d8-bafa-af24b428c6ed" />
<img width="1220" height="353" alt="Screenshot 2026-04-09 at 3 18 34 PM" src="https://github.com/user-attachments/assets/9d952f7e-6bfc-417c-bdcb-cdbeaa38408e" />
<img width="947" height="412" alt="Screenshot 2026-04-09 at 3 18 51 PM" src="https://github.com/user-attachments/assets/0ea0f99e-e7ca-4652-bcdc-3b7a6a8d8d65" />


<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
