### PR TITLE
[patch] Fix secret type name

### DIFF
--- a/ibm/mas_devops/roles/dro/templates/bascfg.yml.j2
+++ b/ibm/mas_devops/roles/dro/templates/bascfg.yml.j2
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 kind: Secret
-type: opaque
+type: Opaque
 metadata:
   name: dro-apikey
   namespace: "mas-{{ mas_instance_id }}-core"

--- a/ibm/mas_devops/roles/sls/templates/slscfg.yml.j2
+++ b/ibm/mas_devops/roles/sls/templates/slscfg.yml.j2
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 kind: Secret
-type: opaque
+type: Opaque
 metadata:
   name: sls-registration-key
   namespace: "mas-{{ mas_instance_id }}-core"

--- a/ibm/mas_devops/roles/suite_install/templates/secret-filebeat-output.yml.j2
+++ b/ibm/mas_devops/roles/suite_install/templates/secret-filebeat-output.yml.j2
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 kind: Secret
-type: opaque
+type: Opaque
 metadata:
   name: filebeat-output
   namespace: "{{ mas_namespace }}"

--- a/ibm/mas_devops/roles/suite_install/templates/secret-superuser.yml.j2
+++ b/ibm/mas_devops/roles/suite_install/templates/secret-superuser.yml.j2
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 kind: Secret
-type: opaque
+type: Opaque
 metadata:
   name: {{ mas_instance_id }}-credentials-superuser
   namespace: "{{ mas_namespace }}"


### PR DESCRIPTION
## Description
OCP appears to be now strictly enforcing the naming convention of secret types. `opaque` is now flagged as invalid value:
```yaml
14:13:42 [ERROR]: Task failed: Module failed: Failed to patch object: b'{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Secret \\"sls-registration-key\\" is invalid: type: Invalid value: \\"opaque\\": field is immutable","reason":"Invalid","details":{"name":"sls-registration-key","kind":"Secret","causes":[{"reason":"FieldValueInvalid","message":"Invalid value: \\"opaque\\": field is immutable","field":"type"}]},"code":422}\n'
```
we have to change it so that it begins with a capital `Opaque` everywhere.

## Test Results
- Tested in cluster directly with OCP 4.19.25

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
