### PR TITLE
[patch] move debug to a place where db2_releases_content is set

### DIFF
--- a/ibm/mas_devops/roles/db2/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/db2/tasks/install/main.yml
@@ -299,6 +299,11 @@
       set_fact:
         db2_releases_content: "{{ db2_release_info.resources[0].data.json | from_json }}"
 
+    - name: Debug DB2 Available versions
+      ansible.builtin.debug:
+        msg:
+          - "Available versions .................... {{ db2_releases_content.databases.db2u.keys() | list }}"
+
     - name: Extract major version from channel
       set_fact:
         db2_major_version: "{{ db2_channel | regex_replace('^v(\\d{2})(\\d+).*', '\\1') }}"
@@ -323,13 +328,6 @@
         - (db2_releases_content.databases.db2u.keys() | select('match', '^s' + db2_major_version) | list | length) > 0
 
   when: db2_version is not defined or db2_version == ""
-
-- name: Debug DB2 channel and determined version
-  ansible.builtin.debug:
-    msg:
-      - "DB2 Channel ........................... {{ db2_channel }}"
-      - "DB2 Version (determined) .............. {{ db2_version }}"
-      - "Available versions .................... {{ db2_releases_content.databases.db2u.keys() | list }}"
 
 # 11. Fail if required parameters are not set
 # -----------------------------------------------------------------------------


### PR DESCRIPTION

## Description
This PR allows DB2 Install to work when the db2_version is set
see https://github.com/ibm-mas/ansible-devops/issues/2204
see customer ticket https://ibmsf.lightning.force.com/lightning/r/Case/500gJ00000Aux66QAB/view

## Test Results
I have tested this change by installing DB2 in a test cluster with the version and other settings provided in the customer ticket.

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
