### PR TITLE
[patch] fix odf mirroring in v2

### DIFF
--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -81,6 +81,9 @@ mirror:
         - name: recipe # Required by odf
           channels:
             - name: stable-{{ ocp_release }}
+        - name: odf-prometheus-operator # Required by odf
+          channels:
+            - name: stable-{{ ocp_release }}
         - name: openshift-cert-manager-operator  # Required by ibm.mas_devops.cert_manager role
           channels:
             - name: stable-v1

--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -90,6 +90,9 @@ mirror:
         - name: odf-csi-addons-operator # Required by odf
           channels:
             - name: stable-{{ ocp_release }}
+        - name: ocs-operator # Required by odf
+          channels:
+            - name: stable-{{ ocp_release }}
         - name: openshift-cert-manager-operator  # Required by ibm.mas_devops.cert_manager role
           channels:
             - name: stable-v1

--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -78,6 +78,9 @@ mirror:
         - name: rook-ceph-operator # Required by odf
           channels:
             - name: stable-{{ ocp_release }}
+        - name: recipe # Required by odf
+          channels:
+            - name: stable-{{ ocp_release }}
         - name: openshift-cert-manager-operator  # Required by ibm.mas_devops.cert_manager role
           channels:
             - name: stable-v1

--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -99,6 +99,9 @@ mirror:
         - name: mcg-operator # Required by odf
           channels:
             - name: stable-{{ ocp_release }}
+        - name: cephcsi-operator # Required by odf
+          channels:
+            - name: stable-{{ ocp_release }}
         - name: openshift-cert-manager-operator  # Required by ibm.mas_devops.cert_manager role
           channels:
             - name: stable-v1

--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -96,6 +96,9 @@ mirror:
         - name: ocs-client-operator # Required by odf
           channels:
             - name: stable-{{ ocp_release }}
+        - name: mcg-operator # Required by odf
+          channels:
+            - name: stable-{{ ocp_release }}
         - name: openshift-cert-manager-operator  # Required by ibm.mas_devops.cert_manager role
           channels:
             - name: stable-v1

--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -93,6 +93,9 @@ mirror:
         - name: ocs-operator # Required by odf
           channels:
             - name: stable-{{ ocp_release }}
+        - name: ocs-client-operator # Required by odf
+          channels:
+            - name: stable-{{ ocp_release }}
         - name: openshift-cert-manager-operator  # Required by ibm.mas_devops.cert_manager role
           channels:
             - name: stable-v1

--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -84,6 +84,9 @@ mirror:
         - name: odf-prometheus-operator # Required by odf
           channels:
             - name: stable-{{ ocp_release }}
+        - name: odf-external-snapshotter-operator # Required by odf
+          channels:
+            - name: stable-{{ ocp_release }}
         - name: openshift-cert-manager-operator  # Required by ibm.mas_devops.cert_manager role
           channels:
             - name: stable-v1

--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -75,6 +75,9 @@ mirror:
         - name: odf-operator  # Required by ibm.mas_devops.ocs role
           channels:
             - name: stable-{{ ocp_release }}
+        - name: rook-ceph-operator # Required by odf
+          channels:
+            - name: stable-{{ ocp_release }}
         - name: openshift-cert-manager-operator  # Required by ibm.mas_devops.cert_manager role
           channels:
             - name: stable-v1

--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -87,6 +87,9 @@ mirror:
         - name: odf-external-snapshotter-operator # Required by odf
           channels:
             - name: stable-{{ ocp_release }}
+        - name: odf-csi-addons-operator # Required by odf
+          channels:
+            - name: stable-{{ ocp_release }}
         - name: openshift-cert-manager-operator  # Required by ibm.mas_devops.cert_manager role
           channels:
             - name: stable-v1


### PR DESCRIPTION
## Description
<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->

With the move to oc mirror --v2 the implicit dependencies of odf were not getting pulled in resulting in odf operator not installing. The options were to change the mirror mode to full but that would pull in a lot of images people don't want or to specify the dependencies individually. I opted for keeping the mirror size done. Note that once we only support OCP 4.18 and onwards then we should revisit how we do odf as there is a better way

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

Testing done in our standard airgap environment

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
