### PR TITLE
[patch] handle undefined mas_routing_mode in wildcard dns entries

### DIFF
--- a/ibm/mas_devops/roles/suite_certs/templates/dnsentries.yml.j2
+++ b/ibm/mas_devops/roles/suite_certs/templates/dnsentries.yml.j2
@@ -75,7 +75,7 @@ nowildcard:
 wildcard:
   - ""
   - "*"
-{% if mas_routing_mode is defined and mas_routing_mode == 'subdomain' %}
+{% if mas_routing_mode is not defined or mas_routing_mode == 'subdomain' %}
   - "*.optimizer"
   - "*.facilities"
   - "*.{{ mas_workspace_id }}.facilities"

--- a/ibm/mas_devops/roles/suite_dns/templates/dnsentries.yml.j2
+++ b/ibm/mas_devops/roles/suite_dns/templates/dnsentries.yml.j2
@@ -76,7 +76,7 @@ nowildcard:
 wildcard:
   - ""
   - "*"
-{% if mas_routing_mode is defined and mas_routing_mode == 'subdomain' %}
+{% if mas_routing_mode is not defined or mas_routing_mode == 'subdomain' %}
   - "*.optimizer"
   - "*.facilities"
   - "*.{{ mas_workspace_id }}.facilities"


### PR DESCRIPTION
## Description
- updates wildcard DNS entry generation in `suite_dns` and `suite_certs` templates so wildcard entries are included when mas_routing_mode is undefined, while preserving existing behavior for subdomain/path.

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
