### PR TITLE
[patch] Temporarily add --remove-signatures to oc mirror

### DIFF
--- a/ibm/mas_devops/roles/mirror_ocp/tasks/actions/direct.yml
+++ b/ibm/mas_devops/roles/mirror_ocp/tasks/actions/direct.yml
@@ -61,10 +61,12 @@
       ignore_errors: true
       loop: "{{ repos_to_add }}"
 
+# Important: We have added "--remove-signatures" temporarily due to a problem in the Red Hat Certified operator catalog
+# This is the only way we can get image mirroring working.  We will remove this as soon as Red Hat fix the operator catalog
 - name: "Debug Information"
   debug:
     msg:
-      - "Command ...................... DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-tls-verify=false -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml docker://{{ registry_public_url_with_path_redhat }} --workspace file://{{ mirror_working_dir }}/.ibm-mas --v2"
+      - "Command ...................... DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-tls-verify=false --remove-signatures -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml docker://{{ registry_public_url_with_path_redhat }} --workspace file://{{ mirror_working_dir }}/.ibm-mas --v2"
       - "Log File ..................... {{ mirror_working_dir }}/logs/mirror-direct-ocp{{ ocp_release }}.log"
 
 - name: "Mirror Red Hat content from source registry to target registry"

--- a/ibm/mas_devops/roles/mirror_ocp/tasks/actions/direct.yml
+++ b/ibm/mas_devops/roles/mirror_ocp/tasks/actions/direct.yml
@@ -69,4 +69,4 @@
 
 - name: "Mirror Red Hat content from source registry to target registry"
   shell: >
-    DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-tls-verify=false -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml docker://{{ registry_public_url_with_path_redhat }} --workspace file://{{ mirror_working_dir }}/.ibm-mas --v2 &> {{ mirror_working_dir }}/logs/mirror-direct-ocp{{ ocp_release }}.log
+    DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-tls-verify=false --remove-signatures -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml docker://{{ registry_public_url_with_path_redhat }} --workspace file://{{ mirror_working_dir }}/.ibm-mas --v2 &> {{ mirror_working_dir }}/logs/mirror-direct-ocp{{ ocp_release }}.log

--- a/ibm/mas_devops/roles/mirror_ocp/tasks/actions/from-filesystem.yml
+++ b/ibm/mas_devops/roles/mirror_ocp/tasks/actions/from-filesystem.yml
@@ -53,10 +53,12 @@
 
 # 2. Perform Mirroring
 # -----------------------------------------------------------------------------
+# Important: We have added "--remove-signatures" temporarily due to a problem in the Red Hat Certified operator catalog
+# This is the only way we can get image mirroring working.  We will remove this as soon as Red Hat fix the operator catalog
 - name: "Debug Information"
   debug:
     msg:
-      - "Command ...................... DOCKER_CONFIG={{ mirror_working_dir }} oc mirror -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml --dest-tls-verify=false --parallel-images=1 --from file://{{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }}"
+      - "Command ...................... DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --remove-signatures -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml --dest-tls-verify=false --parallel-images=1 --from file://{{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }}"
       - "Log File ..................... {{ mirror_working_dir }}/logs/mirror-from-filesystem-ocp{{ ocp_release }}.log"
 
 - name: "Mirror Red Hat content from filesystem to target registry"

--- a/ibm/mas_devops/roles/mirror_ocp/tasks/actions/from-filesystem.yml
+++ b/ibm/mas_devops/roles/mirror_ocp/tasks/actions/from-filesystem.yml
@@ -61,4 +61,4 @@
 
 - name: "Mirror Red Hat content from filesystem to target registry"
   shell: >
-    DOCKER_CONFIG={{ mirror_working_dir }} oc mirror -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml --dest-tls-verify=false --parallel-images=1 --from file://{{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }} --v2 &> {{ mirror_working_dir }}/logs/mirror-from-filesystem-ocp{{ ocp_release }}.log
+    DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --remove-signatures -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml --dest-tls-verify=false --parallel-images=1 --from file://{{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }} --v2 &> {{ mirror_working_dir }}/logs/mirror-from-filesystem-ocp{{ ocp_release }}.log

--- a/ibm/mas_devops/roles/mirror_ocp/tasks/actions/to-filesystem.yml
+++ b/ibm/mas_devops/roles/mirror_ocp/tasks/actions/to-filesystem.yml
@@ -19,9 +19,11 @@
 - name: "Debug Information"
   debug:
     msg:
-      - "Command ...................... DOCKER_CONFIG={{ mirror_working_dir }} oc mirror -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml file:///{{ mirror_working_dir }} --v2"
+      - "Command ...................... DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --remove-signatures -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml file:///{{ mirror_working_dir }} --v2"
       - "Log File ..................... {{ mirror_working_dir }}/logs/mirror-to-filesystem-ocp{{ ocp_release }}.log"
 
 - name: "Mirror Red Hat content from source registry to filesystem"
+# Important: We have added "--remove-signatures" temporarily due to a problem in the Red Hat Certified operator catalog
+# This is the only way we can get image mirroring working.  We will remove this as soon as Red Hat fix the operator catalog
   shell: >
     DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --remove-signatures -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml file:///{{ mirror_working_dir }} --v2 &> {{ mirror_working_dir }}/logs/mirror-to-filesystem-ocp{{ ocp_release }}.log

--- a/ibm/mas_devops/roles/mirror_ocp/tasks/actions/to-filesystem.yml
+++ b/ibm/mas_devops/roles/mirror_ocp/tasks/actions/to-filesystem.yml
@@ -24,4 +24,4 @@
 
 - name: "Mirror Red Hat content from source registry to filesystem"
   shell: >
-    DOCKER_CONFIG={{ mirror_working_dir }} oc mirror -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml file:///{{ mirror_working_dir }} --v2 &> {{ mirror_working_dir }}/logs/mirror-to-filesystem-ocp{{ ocp_release }}.log
+    DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --remove-signatures -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml file:///{{ mirror_working_dir }} --v2 &> {{ mirror_working_dir }}/logs/mirror-to-filesystem-ocp{{ ocp_release }}.log


### PR DESCRIPTION
During mirror-image `gpu-operator, turbonomic, ibm-data-reporter, ibm-metrics-operator` image failing to mirror with error: 

 `reading signatures: reading manifest sha256-[digest].sig in registry.connect.redhat.com/[path]: name unknown: Image not found`

The mirror process is trying to read image signatures (.sig files) from registry.connect.redhat.com, but these signature manifests do not exist in the registry.

fix: 
Include the `--remove-signatures` option in oc mirror invocations across mirror_ocp tasks. Updated direct.yml, to-filesystem.yml, and from-filesystem.yml so mirrors (direct, to filesystem, and from filesystem) strip image signatures during the mirror operations; other command arguments and log redirections remain unchanged.

**We need to get Red Hat to deliver a fix to their certified operator catalog so that image mirroring works again**, we will revert this change as soon as that is done.

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
