### PR TITLE
[patch] Increase install wait for EDC

### DIFF
--- a/ibm/mas_devops/roles/suite_app_config/vars/iot.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/iot.yml
@@ -2,5 +2,5 @@
 mas_app_ws_fqn: iotworkspaces.iot.ibm.com
 mas_app_ws_apiversion: iot.ibm.com/v1
 mas_app_ws_kind: IoTWorkspace
-mas_app_cfg_delay: "{{ lookup('env', 'MAS_APP_CFG_DELAY') | default(120, true)}}"
+mas_app_cfg_delay: "{{ lookup('env', 'MAS_APP_CFG_DELAY') | default(180, true)}}"
 mas_app_cfg_retries: "{{ lookup('env', 'MAS_APP_CFG_RETRIES') | default(30, true)}}"


### PR DESCRIPTION
## Description
EDC install time continues to be a problem on low performing hardware, this update increases the timeout for Maximo IoT install from 1 1/2 hours to 2 1/4 hours.

```
TASK [ibm.mas_devops.suite_app_install : Wait for application to be ready (120s delay)] ***
Polling for IoT/djp to report ready state with 120s delay and 45 retry limit
[1/45] IoT/djp has no ready status condition
[2/45] IoT/djp is not in ready state: No components are currently installed
[3/45] IoT/djp is not in ready state: No components are currently installed
[4/45] IoT/djp is not in ready state: No components are currently installed
[5/45] IoT/djp is not in ready state: No components are currently installed
[6/45] IoT/djp is not in ready state: No components are currently installed
[7/45] IoT/djp is not in ready state: No components are currently installed
[8/45] IoT/djp is not in ready state: No components are currently installed
[9/45] IoT/djp is not in ready state: No components are currently installed
[10/45] IoT/djp is not in ready state: No components are currently installed
[11/45] IoT/djp is not in ready state: No components are currently installed
[12/45] IoT/djp is not in ready state: No components are currently installed
[13/45] IoT/djp is not in ready state: No components are currently installed
[14/45] IoT/djp is not in ready state: No components are currently installed
[15/45] IoT/djp is not in ready state: No components are currently installed
[16/45] IoT/djp is not in ready state: No components are currently installed
[17/45] IoT/djp is not in ready state: No components are currently installed
[18/45] IoT/djp is not in ready state: No components are currently installed
[19/45] IoT/djp is not in ready state: IoT Deployment auth-auth-store does not have minimum availability
[20/45] IoT/djp is not in ready state: IoT Deployment auth-auth-store does not have minimum availability
[21/45] IoT/djp is not in ready state: IoT Deployment auth-auth-store does not have minimum availability
[22/45] IoT/djp is not in ready state: IoT Deployment auth-auth-store does not have minimum availability
[23/45] IoT/djp is not in ready state: 14/17 components are ready. Not ready: ['Edgeconfig', 'State', 'Fpl']
[24/45] IoT/djp is not in ready state: 14/17 components are ready. Not ready: ['Edgeconfig', 'State', 'Fpl']
[25/45] IoT/djp is not in ready state: 14/17 components are ready. Not ready: ['Edgeconfig', 'State', 'Fpl']
[26/45] IoT/djp is not in ready state: 14/17 components are ready. Not ready: ['Edgeconfig', 'State', 'Fpl']
[27/45] IoT/djp is not in ready state: 14/17 components are ready. Not ready: ['Edgeconfig', 'State', 'Fpl']
[28/45] IoT/djp is not in ready state: 14/17 components are ready. Not ready: ['Edgeconfig', 'State', 'Fpl']
[29/45] IoT/djp is not in ready state: 14/17 components are ready. Not ready: ['Edgeconfig', 'State', 'Fpl']
[30/45] IoT/djp is not in ready state: 16/17 components are ready. Not ready: ['Edgeconfig']
[31/45] IoT/djp is not in ready state: 16/17 components are ready. Not ready: ['Edgeconfig']
[32/45] IoT/djp is not in ready state: 16/17 components are ready. Not ready: ['Edgeconfig']
[33/45] IoT/djp is not in ready state: 16/17 components are ready. Not ready: ['Edgeconfig']
[34/45] IoT/djp is not in ready state: 16/17 components are ready. Not ready: ['Edgeconfig']
[35/45] IoT/djp is not in ready state: 16/17 components are ready. Not ready: ['Edgeconfig']
[36/45] IoT/djp is not in ready state: 16/17 components are ready. Not ready: ['Edgeconfig']
[37/45] IoT/djp is not in ready state: 16/17 components are ready. Not ready: ['Edgeconfig']
[38/45] IoT/djp is not in ready state: 16/17 components are ready. Not ready: ['Edgeconfig']
[39/45] IoT/djp is not in ready state: 16/17 components are ready. Not ready: ['Edgeconfig']
[40/45] IoT/djp is not in ready state: 16/17 components are ready. Not ready: ['Edgeconfig']
[41/45] IoT/djp is not in ready state: 16/17 components are ready. Not ready: ['Edgeconfig']
[42/45] IoT/djp is not in ready state: 16/17 components are ready. Not ready: ['Edgeconfig']
[43/45] IoT/djp is not in ready state: 16/17 components are ready. Not ready: ['Edgeconfig']
[44/45] IoT/djp is not in ready state: 16/17 components are ready. Not ready: ['Edgeconfig']
[45/45] IoT/djp is not in ready state: 16/17 components are ready. Not ready: ['Edgeconfig']
[ERROR]: Task failed: Action failed: Unknown error.
Origin: /opt/app-root/lib64/python3.12/site-packages/ansible_collections/ibm/mas_devops/roles/suite_app_install/tasks/main.yml:99:3
```

## Test Results
No testing required, simple value change

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
