### PR TITLE
[patch] Fix MinIO IPv4 binding and AI Service MinIO secret

### DIFF
--- a/ibm/mas_devops/roles/aiservice/defaults/main.yml
+++ b/ibm/mas_devops/roles/aiservice/defaults/main.yml
@@ -49,6 +49,7 @@ mas_icr_cpopen: "{{ lookup('env', 'MAS_ICR_CPOPEN') | default('icr.io/cpopen', t
 
 # Enable IPv6?
 enable_ipv6: "{{ lookup('env', 'ENABLE_IPV6') | default('false', true) | bool }}"
+install_minio: "{{ lookup('env', 'INSTALL_MINIO') | default('False', true) | bool }}"
 
 
 # S3

--- a/ibm/mas_devops/roles/aiservice/templates/aiservice/s3-secret.yml.j2
+++ b/ibm/mas_devops/roles/aiservice/templates/aiservice/s3-secret.yml.j2
@@ -10,9 +10,8 @@ metadata:
     serving.kserve.io/s3-usehttps: "{{ aiservice_s3_ssl | ternary('1', '0') }}"
     serving.kserve.io/s3-region: "{{ aiservice_s3_region }}"
 data:
-  AWS_ACCESS_KEY_ID: "{{ aiservice_s3_accesskey | b64encode }}"
-  AWS_SECRET_ACCESS_KEY: "{{ aiservice_s3_secretkey | b64encode }}"
-
+  AWS_ACCESS_KEY_ID: "{{ ('' if install_minio else aiservice_s3_accesskey) | b64encode }}"
+  AWS_SECRET_ACCESS_KEY: "{{ ('' if install_minio else aiservice_s3_secretkey) | b64encode }}"
   S3_ACCESS_KEY: "{{ aiservice_s3_accesskey | b64encode }}"
   S3_SECRET_KEY: "{{ aiservice_s3_secretkey | b64encode }}"
   S3_HOST: "{{ aiservice_s3_host | b64encode }}"

--- a/ibm/mas_devops/roles/minio/templates/minio/minio-deployment.yml.j2
+++ b/ibm/mas_devops/roles/minio/templates/minio/minio-deployment.yml.j2
@@ -28,9 +28,9 @@ spec:
             - server
             - /data
             - --console-address
-            - "[::]:9090"
+            - "{{ '[::]:9090' if enable_ipv6 is true else '0.0.0.0:9090' }}"
             - --address
-            - "[::]:9000"
+            - "{{ '[::]:9000' if enable_ipv6 is true else '0.0.0.0:9000' }}"
           env:
             - name: MINIO_ROOT_USER
               value: "{{ minio_root_user }}"


### PR DESCRIPTION
## Description
This patch fixes two MinIO-specific issues in the AI Service installation flow.

1. The MinIO deployment template always bound the container listeners to IPv6 (`[::]:9090` and `[::]:9000`), which made the console and API unreachable on IPv4 clusters even when `ENABLE_IPV6=false`.
2. The AI Service `km-s3-secret` always populated `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. When `INSTALL_MINIO=true`, those keys must still exist but be empty; populating them breaks the service for the MinIO-backed configuration.

Impact:
- `ENABLE_IPV6=false` now renders MinIO listeners on `0.0.0.0:9090` and `0.0.0.0:9000`.
- `ENABLE_IPV6=true` keeps the IPv6 listener values unchanged.
- When `INSTALL_MINIO=true`, `km-s3-secret` now renders empty `AWS_*` values while keeping the `S3_*` values populated.
- Non-MinIO S3 configurations continue to render the real `AWS_*` and `S3_*` credential values.

## Test Results
- Static render verification for `ibm/mas_devops/roles/minio/templates/minio/minio-deployment.yml.j2` with `enable_ipv6=false` rendered `0.0.0.0:9090` and `0.0.0.0:9000`.
- Static render verification for the same template with `enable_ipv6=true` rendered `[::]:9090` and `[::]:9000`.
- Static render verification for `ibm/mas_devops/roles/aiservice/templates/aiservice/s3-secret.yml.j2` with `install_minio=true` rendered empty `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` and preserved populated `S3_*` values.
- Static render verification for the same secret with `install_minio=false` rendered populated `AWS_*` and `S3_*` values.
- Cluster end-to-end validation was not run from this workspace.