### PR TITLE
[patch] Fix DNS failures, WAF deprecation, and broken conditional check

### DIFF
--- a/ibm/mas_devops/common_tasks/detect_cert_manager.yml
+++ b/ibm/mas_devops/common_tasks/detect_cert_manager.yml
@@ -54,7 +54,7 @@
   when: certmanager_cr.resources[0].spec.unsupportedConfigOverrides.controller.args is defined
 
 - name: Set cert_manager_cluster_resource_namespace from CertManager CR
-  when: cert_manager_args is defined and item | regex_search(regex)
+  when: cert_manager_args is defined and (item | regex_search(regex)) != None
   vars:
     regex: '(?<=\--cluster-resource-namespace=).*'
   set_fact:

--- a/ibm/mas_devops/plugins/modules/cis_dns_entries.py
+++ b/ibm/mas_devops/plugins/modules/cis_dns_entries.py
@@ -197,9 +197,9 @@ def main():
                     url = f"https://api.cis.cloud.ibm.com/v1/{crn}/zones/{zoneId}/dns_records/{dnsId}"
                     # proxied = True
                     if cisProxy and 'reportdb' not in entryName and 'messaging.iot' not in entryName:
-                        payload="{\n    \"name\": \"" + entryName + "\",\n    \"type\": \"CNAME\",\n    \"content\": \"" + openshiftIngress  + "\",\n    \"proxied\": true \n}"    
+                        payload="{\n    \"name\": \"" + entryName + "\",\n    \"type\": \"CNAME\",\n    \"content\": \"" + openshiftIngress  + "\",\n    \"proxied\": true \n}"
                     else:
-                        payload="{\n    \"name\": \"" + entryName + "\",\n    \"type\": \"CNAME\",\n    \"content\": \"" + openshiftIngress  + "\",\n    \"proxied\": false \n}"    
+                        payload="{\n    \"name\": \"" + entryName + "\",\n    \"type\": \"CNAME\",\n    \"content\": \"" + openshiftIngress  + "\",\n    \"proxied\": false \n}"
 
             
                     headers = {
@@ -211,15 +211,16 @@ def main():
                     response = requests.request("PUT", url, headers=headers, data=payload)
                     if(response.status_code == 200):
                         changed = True
-                    #     DNS record updated successfully                    
+                    else:
+                        module.fail_json(msg = f"Failed to update DNS entry '{entryName}'. Status code: {response.status_code}, Response: {response.content}")
 
             else:
                 # Adding DNS entry
                 url = f"https://api.cis.cloud.ibm.com/v1/{crn}/zones/{zoneId}/dns_records"
                 if cisProxy and 'reportdb' not in entryName and 'messaging.iot' not in entryName:
-                    payload="{\n    \"name\": \"" + entryName + "\",\n    \"type\": \"CNAME\",\n    \"content\": \"" + openshiftIngress  + "\",\n    \"proxied\": true \n}"    
+                    payload="{\n    \"name\": \"" + entryName + "\",\n    \"type\": \"CNAME\",\n    \"content\": \"" + openshiftIngress  + "\",\n    \"proxied\": true \n}"
                 else:
-                    payload="{\n    \"name\": \"" + entryName + "\",\n    \"type\": \"CNAME\",\n    \"content\": \"" + openshiftIngress  + "\",\n    \"proxied\": false \n}"    
+                    payload="{\n    \"name\": \"" + entryName + "\",\n    \"type\": \"CNAME\",\n    \"content\": \"" + openshiftIngress  + "\",\n    \"proxied\": false \n}"
 
                 headers = {
                 'Content-Type': 'application/json',
@@ -230,7 +231,8 @@ def main():
                 response = requests.request("POST", url, headers=headers, data=payload)
                 if(response.status_code == 200):
                     changed = True
-                    # DNS record created successfully
+                else:
+                    module.fail_json(msg = f"Failed to create DNS entry '{entryName}'. Status code: {response.status_code}, Response: {response.content}")
         
         if delete_wildcards:
             for entry in existingDNSEntries:

--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_waf_rule.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_waf_rule.yml
@@ -5,25 +5,52 @@
   ansible.builtin.shell: |
     if echo $(ibmcloud cis waf-rule {{(_cis_domains_result.stdout | from_json)[0].id}} {{ item.rule_package_id }} {{ item.rule_id }} -i "{{cis_service_name}}") | grep 'Invalid or missing WAF Rule ID'; then echo "not_exists"; else echo "exists"; fi
   register: _cis_waf_rule_exists_result
+  failed_when: false
+
+- name: "cis : Check if WAF is deprecated (Managed Rulesets in use)"
+  ansible.builtin.shell: |
+    if echo $(ibmcloud cis waf-rule {{(_cis_domains_result.stdout | from_json)[0].id}} {{ item.rule_package_id }} {{ item.rule_id }} -i "{{cis_service_name}}") | grep 'WAF is deprecated for this zone'; then echo "deprecated"; else echo "not_deprecated"; fi
+  register: _cis_waf_deprecated_result
+  failed_when: false
+  when: _cis_waf_rule_exists_result.stdout_lines[-1] == "exists"
+
+- name: "cis : Skip WAF rule configuration - Managed Rulesets in use"
+  debug:
+    msg: "WAF is deprecated for this zone. Managed Rulesets should be used instead. Skipping WAF rule {{ item.rule_id }} configuration."
+  when:
+    - _cis_waf_rule_exists_result.stdout_lines[-1] == "exists"
+    - _cis_waf_deprecated_result.stdout_lines[-1] == "deprecated"
 
 - name: "cis : Check WAF rule mode:  {{ item.rule_id }}"
   ansible.builtin.shell: |
     if echo $(ibmcloud cis waf-rule {{(_cis_domains_result.stdout | from_json)[0].id}} {{ item.rule_package_id }} {{ item.rule_id }} -i "{{cis_service_name}}") | grep 'Mode disable'; then echo "disabled"; else echo "not_disabled"; fi
   register: _cis_waf_rule_mode_result
-  when: _cis_waf_rule_exists_result.stdout_lines[-1] == "exists"
+  failed_when: false
+  when:
+    - _cis_waf_rule_exists_result.stdout_lines[-1] == "exists"
+    - _cis_waf_deprecated_result.stdout_lines[-1] == "not_deprecated"
 
 - name: "cis : Output WAF rule exists or not {{ item.rule_id }}"
   debug:
     msg: WAF rule {{ item.rule_id }} {{_cis_waf_rule_mode_result.stdout_lines[-1]}}
-  when: _cis_waf_rule_exists_result.stdout_lines[-1] == "exists"
+  when:
+    - _cis_waf_rule_exists_result.stdout_lines[-1] == "exists"
+    - _cis_waf_deprecated_result.stdout_lines[-1] == "not_deprecated"
 
 - name: "cis : Disable WAF rule: {{ item.rule_id }}"
   ansible.builtin.shell: |
     ibmcloud cis waf-rule-mode-set {{(_cis_domains_result.stdout | from_json)[0].id}} {{ item.rule_package_id }} {{ item.rule_id }} disable -i "{{cis_service_name}}"
   register: _cis_waf_rule_disable_result
-  when: _cis_waf_rule_mode_result.stdout_lines[-1] == "not_disabled" and _cis_waf_rule_exists_result.stdout_lines[-1] == "exists"
+  failed_when: false
+  when:
+    - _cis_waf_rule_mode_result.stdout_lines[-1] == "not_disabled"
+    - _cis_waf_rule_exists_result.stdout_lines[-1] == "exists"
+    - _cis_waf_deprecated_result.stdout_lines[-1] == "not_deprecated"
 
 - name: "cis : Output WAF rule disable result: {{ item.rule_id }}"
   debug:
     msg: WAF rule disable {{_cis_waf_rule_disable_result}}
-  when: _cis_waf_rule_mode_result.stdout_lines[-1] == "not_disabled" and _cis_waf_rule_exists_result.stdout_lines[-1] == "exists"
+  when:
+    - _cis_waf_rule_mode_result.stdout_lines[-1] == "not_disabled"
+    - _cis_waf_rule_exists_result.stdout_lines[-1] == "exists"
+    - _cis_waf_deprecated_result.stdout_lines[-1] == "not_deprecated"


### PR DESCRIPTION
## Description
This pr contains fix to 3 problems mentioned below:

The module was not checking HTTP response status codes for POST/PUT operations when creating or updating DNS entries. It only set changed = True on success but didn't fail on errors, leading to false positive success messages, Here are the changes for that -> [ibm/mas_devops/plugins/modules/cis_dns_entries.py](https://github.com/ibm-mas/ansible-devops/commit/2e885f8526e76cc0366a85c4e711b77f0c8b39b8#diff-5408d9decce43f1bfd928594a2833ce9dbfd91ba5764986774e0bc2b9064b894R200)

IBM Cloud CIS has deprecated the old WAF API in favor of managed rulesets. The role was attempting to disable WAF rules using the deprecated API without checking if managed rulesets were already in use, resulting in: Error response from server. Status code: 403; message: {"success": false, "errors": [{"code": 1040, "message": "WAF is deprecated for this zone, Managed Rulesets should be used instead"}]} Here are the change for it -> [ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_waf_rule.yml](https://github.com/ibm-mas/ansible-devops/commit/2e885f8526e76cc0366a85c4e711b77f0c8b39b8#diff-d63e2d717750f2615a07c9db3a89e4ec56912deb582a810fa1bf0dbc55c64d33R8)

The conditional when: cert_manager_args is defined and item | regex_search(regex) was evaluating a string result from regex_search() as a boolean, which ansible treats as an error. The regex_search() filter returns either a string (match) or None (no match), not a boolean. Here are the change for it [ibm/mas_devops/common_tasks/detect_cert_manager.yml](https://github.com/ibm-mas/ansible-devops/commit/2e885f8526e76cc0366a85c4e711b77f0c8b39b8#diff-2edf143c2a4eb46a186cfec012cbc15847a43c34cb3f38fd6453652c8e5d707cR57)
## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
