### PR TITLE
[patch] resolve table space access error in db2 setup

### DIFF
--- a/ibm/mas_devops/roles/suite_db2_setup_for_manage/templates/setupdb.sh.j2
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_manage/templates/setupdb.sh.j2
@@ -3,9 +3,6 @@
 # Fix SQL0290N  Table space access is not allowed.  SQLSTATE=55039
 if ! $(ls /mnt/tempts/systemp/db2inst1/NODE0000/{{ db2_dbname }}/T0000001); then
     db2 "restart database {{ db2_dbname }} drop pending tablespaces (TEMPSPACE1)"
-    db2 connect to {{ db2_dbname }}
-    db2 "drop tablespace TEMPSPACE1"
-    db2 "CREATE SYSTEM TEMPORARY TABLESPACE TEMPSPACE1 MANAGED BY SYSTEM USING ('/mnt/tempts/systemp')"
 fi
 
 TBSP_SQL="/tmp/.tbsp.sql"

--- a/ibm/mas_devops/roles/suite_db2_setup_for_manage/templates/setupdb.sh.j2
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_manage/templates/setupdb.sh.j2
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Fix SQL0290N  Table space access is not allowed.  SQLSTATE=55039
+if ! $(ls /mnt/tempts/systemp/db2inst1/NODE0000/{{ db2_dbname }}/T0000001); then
+    db2 "restart database {{ db2_dbname }} drop pending tablespaces (TEMPSPACE1)"
+    db2 connect to {{ db2_dbname }}
+    db2 "drop tablespace TEMPSPACE1"
+    db2 "CREATE SYSTEM TEMPORARY TABLESPACE TEMPSPACE1 MANAGED BY SYSTEM USING ('/mnt/tempts/systemp')"
+fi
+
 TBSP_SQL="/tmp/.tbsp.sql"
 
 if [ -f $TBSP_SQL ]


### PR DESCRIPTION
## Description
After some investigation, the problem is because the TEMPSPACE1 tablespace doesn’t have path created in the PVC tempts. In a healthy Db2 we should see `/mnt/tempts/systemp/db2inst1/NODE0000/BLUDB/T0000001` while in a unhealthy one we see only `/mnt/tempts/systemp/`.

At first I thought that the problem was related to our code, but then I checked the Db2 logs and saw that `db2_restore_morph` didn’t create the correct paths after showing a successful run. In fact, in the own startup logs it already shows some failures in Db2 showing something like this:

```
+ TEMPTS_LOC=/mnt/tempts/BLUDB
+ logger_debug 'Rsync of tempspace from /mnt/tempts/BLUDB to /mnt/tempts/c-mas-db2tst-db2tst-manage-db2u ...'
+ local LEVEL=DEBUG
+ [[ -n Rsync of tempspace from /mnt/tempts/BLUDB to /mnt/tempts/c-mas-db2tst-db2tst-manage-db2u ... ]]
+ logger 'DEBUG: Rsync of tempspace from /mnt/tempts/BLUDB to /mnt/tempts/c-mas-db2tst-db2tst-manage-db2u ...'
+ [[ -z /var/log/db2u.log ]]
++ dirname /var/log/db2u.log
+ log_dir=/var/log
+ [[ -d /var/log ]]
++ timestamp
++ date '+%Y-%m-%d %H:%M:%S,%3N'
++ basename /db2u/scripts/include/common_functions.sh
+ echo '[2026-04-23 20:14:10,852] - common_functions.sh:1400(rsync_tempspace_to_fid) - DEBUG: Rsync of tempspace from /mnt/tempts/BLUDB to /mnt/tempts/c-mas-db2tst-db2tst-manage-db2u ...'
+ return 0
+ return 0
++ ls /mnt/tempts/BLUDB/db2inst1
++ grep NODE
++ wc -l
ls: cannot access '/mnt/tempts/BLUDB/db2inst1': No such file or directory
+ [[ 0 -eq 0 ]]
+ logger_debug 'rsync of tempspace skipped: node directory not found in /mnt/tempts/BLUDB/db2inst1'
```
A healthy Db2, during the `db2_restore_morph` creates the paths as below:
```
[2026-04-23 19:00:25,503] - INFO: Stopping Db2 Engine
[2026-04-23 19:00:32,572] - INFO: Db2 Engine stopped successfully.
[2026-04-23 19:00:32,573] - INFO: Starting Db2 Engine
[2026-04-23 19:00:38,713] - INFO: Deactivating database: BLUDB
[2026-04-23 19:00:38,762] - INFO: Activating database: BLUDB
[2026-04-23 19:00:39,946] - INFO: Activating database: BLUDB
[2026-04-23 19:00:41,113] - INFO: Temporary tablespaces storage volume detected, configuring systemp tablespaces
[2026-04-23 19:00:41,115] - INFO: Creating tablespace storage group IBMDB2UTEMPSG1 on /mnt/tempts/systemp
[2026-04-23 19:00:47,817] - INFO: Running autoconfigure for BLUDB
[2026-04-23 19:00:49,762] - INFO: Applying Db2 database configmap
[2026-04-23 19:00:49,762] - INFO: Applying db configmap for BLUDB
[2026-04-23 19:00:50,982] - INFO: Restarting Db2 engine
[2026-04-23 19:00:50,982] - INFO: Stopping Db2 Engine
```
This PR recreates the paths under `/mnt/tmpts/systemp` and recreates `TEMPSPACE1` allowing the `setupdb.sh` to move on. 

## Fixes

#2211 

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
