### PR TITLE
[minor] Add scheduling constraints configuration for AI service tenant

### DIFF
--- a/ibm/mas_devops/roles/aiservice_tenant/README.md
+++ b/ibm/mas_devops/roles/aiservice_tenant/README.md
@@ -221,7 +221,111 @@ End date for tenant entitlement period.
 - Should be after `tenant_entitlement_start_date`
 - Plan for entitlement renewal before expiration
 
+## Scheduling Configuration
 
+### aiservice_tenant_scheduling_config_file
+Path to YAML file containing scheduling configuration for pipeline and predictor workloads for tenant.
+
+- Optional
+- Environment Variable: `AISERVICE_TENANT_SCHEDULING_CONFIG_FILE`
+- Default: None (empty string)
+
+**Purpose**: Specifies tolerations and nodeSelector for pipeline and predictor workloads to control pod scheduling on specific nodes.
+
+**When to use**: Use when you need to:
+- Schedule AI workloads on dedicated nodes with specific taints
+- Direct pipeline and predictor pods to nodes with specific labels
+- Isolate AI workloads from other cluster workloads
+- Ensure GPU-enabled nodes are used for inference workloads
+
+**Valid values**: Path to a valid YAML file containing scheduling configuration
+
+**Impact**: Controls where pipeline and predictor pods are scheduled in the Kubernetes cluster. Improper configuration may prevent pods from scheduling.
+
+**Related variables**: None
+
+**Configuration File Structure**:
+
+The YAML file must contain `pipeline` and/or `predictor` objects. Each object can have:
+- `tolerations`: List of Kubernetes tolerations (required fields: `key`, `operator`, `effect`)
+- `nodeSelector`: Dictionary of node label key-value pairs
+
+At least one of `tolerations` or `nodeSelector` must be defined for each non-empty object.
+
+**Example Configuration File**:
+
+```yaml
+---
+# Pipeline scheduling configuration
+pipeline:
+  tolerations:
+    - key: "aiservice-pipeline"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+  nodeSelector:
+    workload-type: "aiservice-pipeline"
+    node-role: "compute"
+
+# Predictor scheduling configuration
+predictor:
+  tolerations:
+    - key: "aiservice-predictor"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+    - key: "gpu"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+  nodeSelector:
+    workload-type: "aiservice-predictor"
+    accelerator: "gpu"
+```
+
+**Validation Rules**:
+1. File must be in valid YAML format
+2. Must contain `pipeline` and/or `predictor` objects
+3. Non-empty objects must have `tolerations` or `nodeSelector` (or both)
+4. Tolerations must be a non-empty list with required fields: `key`, `operator`, `effect`
+5. Optional toleration fields: `value`, `tolerationSeconds`
+6. NodeSelector must be a non-empty dictionary
+
+**Notes**:
+- Configuration is applied to AIServiceTenant CR under `spec.settings.scheduling`
+- Empty objects (`pipeline: {}` or `predictor: {}`) are allowed and will be ignored
+
+**Common Use Cases**:
+
+1. **GPU Node Scheduling**: Direct predictor workloads to GPU-enabled nodes
+   ```yaml
+   predictor:
+     nodeSelector:
+       accelerator: "nvidia-gpu"
+     tolerations:
+       - key: "nvidia.com/gpu"
+         operator: "Exists"
+         effect: "NoSchedule"
+   ```
+
+2. **Dedicated Node Pools**: Isolate AI workloads on dedicated nodes
+   ```yaml
+   pipeline:
+     nodeSelector:
+       node-pool: "ai-workloads"
+     tolerations:
+       - key: "dedicated"
+         operator: "Equal"
+         value: "ai"
+         effect: "NoSchedule"
+   ```
+
+3. **Zone-based Scheduling**: Schedule workloads in specific availability zones
+   ```yaml
+   predictor:
+     nodeSelector:
+       topology.kubernetes.io/zone: "us-east-1a"
+   ```
 
 ## Example Playbook
 

--- a/ibm/mas_devops/roles/aiservice_tenant/defaults/main.yml
+++ b/ibm/mas_devops/roles/aiservice_tenant/defaults/main.yml
@@ -71,3 +71,6 @@ rsl_url: "{{ lookup('env', 'RSL_URL') | default('', true) }}"
 rsl_org_id: "{{ lookup('env', 'RSL_ORG_ID') | default('', true) }}"
 rsl_token: "{{ lookup('env', 'RSL_TOKEN') | default('', true) }}"
 rsl_ca_crt: "{{ lookup('env', 'RSL_CA_CRT') | default('', true) }}"
+
+# Scheduling Configuration
+aiservice_tenant_scheduling_config_file: "{{ lookup('env', 'AISERVICE_TENANT_SCHEDULING_CONFIG_FILE') | default('', true) }}"

--- a/ibm/mas_devops/roles/aiservice_tenant/tasks/aiservice/main.yml
+++ b/ibm/mas_devops/roles/aiservice_tenant/tasks/aiservice/main.yml
@@ -4,7 +4,7 @@
     msg:
       - "Namespace ......................... {{ tenantNamespace }}"
       - "Channel ........................... {{ aiservice_channel }}"
-      - "MAS Instance Id ................... {{ aiservice_instance_id }}"
+      - "AI Service Instance Id ............ {{ aiservice_instance_id }}"
 
 - name: "Create IBM Entitlement Key"
   ibm.mas_devops.update_ibm_entitlement:

--- a/ibm/mas_devops/roles/aiservice_tenant/tasks/config_scheduling/main.yml
+++ b/ibm/mas_devops/roles/aiservice_tenant/tasks/config_scheduling/main.yml
@@ -1,0 +1,44 @@
+---
+# This task reads and validates scheduling configuration from a YAML file
+# The file should contain pipeline and predictor objects with tolerations or nodeSelector
+
+- name: "Process scheduling configuration from file"
+  when: aiservice_tenant_scheduling_config_file is defined and aiservice_tenant_scheduling_config_file != ''
+  block:
+    - name: "Check if scheduling config file exists"
+      ansible.builtin.stat:
+        path: "{{ aiservice_tenant_scheduling_config_file }}"
+      register: scheduling_config_file_stat
+
+    - name: "Fail if scheduling config file does not exist"
+      ansible.builtin.fail:
+        msg: "Scheduling config file not found at: {{ aiservice_tenant_scheduling_config_file }}"
+      when: not scheduling_config_file_stat.stat.exists
+
+    - name: "Read scheduling configuration from YAML file"
+      ansible.builtin.include_vars:
+        file: "{{ aiservice_tenant_scheduling_config_file }}"
+        name: scheduling_config
+
+    - name: "Validate scheduling configuration structure"
+      ansible.builtin.assert:
+        that:
+          - scheduling_config is defined
+          - scheduling_config is mapping
+        fail_msg: "Scheduling configuration file must contain a valid YAML object"
+
+    - name: "Prepare scheduling config for validation"
+      ansible.builtin.set_fact:
+        workload_types:
+          - name: "pipeline"
+            config: "{{ scheduling_config.pipeline | default({}) }}"
+            has_config: "{{ 'pipeline' in scheduling_config and scheduling_config.pipeline is not none and scheduling_config.pipeline != {} }}"
+          - name: "predictor"
+            config: "{{ scheduling_config.predictor | default({}) }}"
+            has_config: "{{ 'predictor' in scheduling_config and scheduling_config.predictor is not none and scheduling_config.predictor != {} }}"
+
+    - name: "Validate scheduling configurations"
+      ansible.builtin.include_tasks: tasks/config_scheduling/validate.yml
+      loop: "{{ workload_types }}"
+      loop_control:
+        label: "{{ item.name }}"

--- a/ibm/mas_devops/roles/aiservice_tenant/tasks/config_scheduling/validate.yml
+++ b/ibm/mas_devops/roles/aiservice_tenant/tasks/config_scheduling/validate.yml
@@ -1,0 +1,44 @@
+---
+# This task validates scheduling configuration.
+
+- name: "Validate workload configurations"
+  when: item.config is not none and item.config != {}
+  block:
+    - name: "Check if {{ item.name }} has tolerations or nodeSelector"
+      ansible.builtin.assert:
+        that:
+          - "'tolerations' in item.config or 'nodeSelector' in item.config"
+        fail_msg: "{{ item.name | capitalize }} configuration must have either 'tolerations' or 'nodeSelector' defined"
+
+    - name: "Validate {{ item.name }} tolerations structure"
+      when: "'tolerations' in item.config"
+      ansible.builtin.assert:
+        that:
+          - item.config.tolerations is sequence
+          - item.config.tolerations | length > 0
+        fail_msg: "{{ item.name | capitalize }} tolerations must be a non-empty list"
+
+    - name: "Validate each toleration in {{ item.name }}"
+      when: "'tolerations' in item.config"
+      ansible.builtin.assert:
+        that:
+          - toleration.key is defined
+          - toleration.operator is defined
+          - toleration.operator in ['Equal', 'Exists']
+          - not (toleration.operator == 'Equal' and toleration.value is not defined)
+          - toleration.effect is defined
+          - toleration.effect in ['NoSchedule', 'PreferNoSchedule', 'NoExecute']
+        fail_msg: "Invalid toleration in {{ item.name }}"
+
+      loop: "{{ item.config.tolerations }}"
+      loop_control:
+        loop_var: toleration
+        label: "{{ item.name }} -> {{ toleration.key | default('undefined') }}"
+
+    - name: "Validate {{ item.name }} nodeSelector structure"
+      when: "'nodeSelector' in item.config"
+      ansible.builtin.assert:
+        that:
+          - item.config.nodeSelector is mapping
+          - item.config.nodeSelector | length > 0
+        fail_msg: "{{ item.name | capitalize }} nodeSelector must be a non-empty dictionary"

--- a/ibm/mas_devops/roles/aiservice_tenant/tasks/main.yml
+++ b/ibm/mas_devops/roles/aiservice_tenant/tasks/main.yml
@@ -1,33 +1,36 @@
 ---
 # Check if the namespace-scoped tenant operator is required.
 # This role will set "is_migration_needed" and "requires_namespaced_tenant_operator"
-- include_role:
-    name: ibm.mas_devops.aiservice_migration
-  vars:
-    catalog_channel: "{{ aiservice_tenant_channel }}"
-    instance_id: "{{ aiservice_instance_id }}"
-    perform_check_only: true
+# - include_role:
+#     name: ibm.mas_devops.aiservice_migration
+#   vars:
+#     catalog_channel: "{{ aiservice_tenant_channel }}"
+#     instance_id: "{{ aiservice_instance_id }}"
+#     perform_check_only: true
 
-- include_tasks: tasks/namespace/main.yml
+# - include_tasks: tasks/namespace/main.yml
 
-# Create config for SLS
-- include_tasks: tasks/config_sls/main.yml
+# # Create config for SLS
+# - include_tasks: tasks/config_sls/main.yml
 
-# Create config for RSL
-- include_tasks: tasks/config_rsl/main.yml
+# # Create config for RSL
+# - include_tasks: tasks/config_rsl/main.yml
 
-# Create config for DRO
-- include_tasks: tasks/config_dro/main.yml
+# # Create config for DRO
+# - include_tasks: tasks/config_dro/main.yml
+
+# Load and validate scheduling configuration
+- include_tasks: tasks/config_scheduling/main.yml
 
 # create wx secret
-- include_tasks: tasks/watsonx/main.yml
+# - include_tasks: tasks/watsonx/main.yml
 
-# Install the tenant operator
-- include_tasks: tasks/aiservice/main.yml
-  when:
-    - aiservice_channel is defined
-    - not aiservice_channel.startswith('9.1.')
-    - requires_namespaced_tenant_operator
+# # Install the tenant operator
+# - include_tasks: tasks/aiservice/main.yml
+#   when:
+#     - aiservice_channel is defined
+#     - not aiservice_channel.startswith('9.1.')
+#     - requires_namespaced_tenant_operator
 
-# create AI Broker tenant
-- include_tasks: tasks/tenant/main.yml
+# # create AI Broker tenant
+# - include_tasks: tasks/tenant/main.yml

--- a/ibm/mas_devops/roles/aiservice_tenant/tasks/main.yml
+++ b/ibm/mas_devops/roles/aiservice_tenant/tasks/main.yml
@@ -1,36 +1,36 @@
 ---
 # Check if the namespace-scoped tenant operator is required.
 # This role will set "is_migration_needed" and "requires_namespaced_tenant_operator"
-# - include_role:
-#     name: ibm.mas_devops.aiservice_migration
-#   vars:
-#     catalog_channel: "{{ aiservice_tenant_channel }}"
-#     instance_id: "{{ aiservice_instance_id }}"
-#     perform_check_only: true
+- include_role:
+    name: ibm.mas_devops.aiservice_migration
+  vars:
+    catalog_channel: "{{ aiservice_tenant_channel }}"
+    instance_id: "{{ aiservice_instance_id }}"
+    perform_check_only: true
 
-# - include_tasks: tasks/namespace/main.yml
+- include_tasks: tasks/namespace/main.yml
 
-# # Create config for SLS
-# - include_tasks: tasks/config_sls/main.yml
+# Create config for SLS
+- include_tasks: tasks/config_sls/main.yml
 
-# # Create config for RSL
-# - include_tasks: tasks/config_rsl/main.yml
+# Create config for RSL
+- include_tasks: tasks/config_rsl/main.yml
 
-# # Create config for DRO
-# - include_tasks: tasks/config_dro/main.yml
+# Create config for DRO
+- include_tasks: tasks/config_dro/main.yml
 
 # Load and validate scheduling configuration
 - include_tasks: tasks/config_scheduling/main.yml
 
 # create wx secret
-# - include_tasks: tasks/watsonx/main.yml
+- include_tasks: tasks/watsonx/main.yml
 
-# # Install the tenant operator
-# - include_tasks: tasks/aiservice/main.yml
-#   when:
-#     - aiservice_channel is defined
-#     - not aiservice_channel.startswith('9.1.')
-#     - requires_namespaced_tenant_operator
+# Install the tenant operator
+- include_tasks: tasks/aiservice/main.yml
+  when:
+    - aiservice_channel is defined
+    - not aiservice_channel.startswith('9.1.')
+    - requires_namespaced_tenant_operator
 
-# # create AI Broker tenant
-# - include_tasks: tasks/tenant/main.yml
+# create AI Broker tenant
+- include_tasks: tasks/tenant/main.yml

--- a/ibm/mas_devops/roles/aiservice_tenant/templates/aiservice/aiservicetenant.yml.j2
+++ b/ibm/mas_devops/roles/aiservice_tenant/templates/aiservice/aiservicetenant.yml.j2
@@ -53,3 +53,14 @@ spec:
                 type: {{ tenant_entitlement_type }}
                 startDate: {{ tenant_entitlement_start_date }}
                 endDate: {{ tenant_entitlement_end_date }}
+{% if scheduling_config is defined and scheduling_config != {} %}
+        scheduling:
+{% if scheduling_config.pipeline is defined and scheduling_config.pipeline != {} %}
+            pipeline:
+                {{ scheduling_config.pipeline | indent(16) }}
+{% endif %}
+{% if scheduling_config.predictor is defined and scheduling_config.predictor != {} %}
+            predictor:
+                {{ scheduling_config.predictor | indent(16) }}
+{% endif %}
+{% endif %}

--- a/ibm/mas_devops/roles/aiservice_tenant/templates/aiservice/aiservicetenant.yml.j2
+++ b/ibm/mas_devops/roles/aiservice_tenant/templates/aiservice/aiservicetenant.yml.j2
@@ -57,10 +57,10 @@ spec:
         scheduling:
 {% if scheduling_config.pipeline is defined and scheduling_config.pipeline != {} %}
             pipeline:
-                {{ scheduling_config.pipeline | indent(16) }}
+                {{ scheduling_config.pipeline | to_nice_yaml(indent=2) | indent(16) }}
 {% endif %}
 {% if scheduling_config.predictor is defined and scheduling_config.predictor != {} %}
             predictor:
-                {{ scheduling_config.predictor | indent(16) }}
+                {{ scheduling_config.predictor | to_nice_yaml(indent=2) | indent(16) }}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
## Description

- Add support for configuring scheduling constraints for AI workloads(Training pipeline & predictor service) for AI Service tenant.
- Only tolerations & nodeSelector configuration is supported as of yet. Support for other scheduling constraints such as affinity will be added in future.

## Test Results

- Tested a tenant installation with scheduling constraints specified, ensured that tenant is installed successfully.
- Tested a tenant installation without specifying scheduling constraints, ensured that tenant is installed successfully.

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
* 