### PR TITLE
[patch] allow 'none' mongodb and db2 action value again as its passed by update pipeline

### DIFF
--- a/ibm/mas_devops/roles/db2/tasks/main.yml
+++ b/ibm/mas_devops/roles/db2/tasks/main.yml
@@ -7,6 +7,6 @@
 
 - name: "Fail if db2_action is invalid"
   fail:
-    msg: "db2_action must be one of ['install', 'upgrade', 'backup', 'restore-database', 'backup-database', 'restore']"
+    msg: "db2_action must be one of ['install', 'upgrade', 'backup', 'restore-database', 'backup-database', 'restore', 'none']"
   when:
-    - db2_action not in ["install", "upgrade", "backup", "restore-database", "backup-database", "restore"]
+    - db2_action not in ["none", "install", "upgrade", "backup", "restore-database", "backup-database", "restore"]

--- a/ibm/mas_devops/roles/mongodb/tasks/main.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/main.yml
@@ -12,8 +12,8 @@
   assert:
     that:
       - mongodb_action is defined
-      - mongodb_action in ["install", "uninstall", "backup", "backup-database", "restore-database", "restore"]
-    fail_msg: "mongodb_action property is required and must be one of 'install', 'uninstall', 'backup', 'backup-database','restore-database', 'restore'"
+      - mongodb_action in ["none", "install", "uninstall", "backup", "backup-database", "restore-database", "restore"]
+    fail_msg: "mongodb_action property is required and must be one of 'install', 'uninstall', 'backup', 'backup-database','restore-database', 'restore', 'none'"
 
 # 2. Run the install / uninstall for specified provider
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Description

[MASCORE-13803](https://jsw.ibm.com/browse/MASCORE-13803)

`mas update` pipeline fails when it passes "none" action to mongodb and db2 when it doesn't need to update them.
Recent changes had made this value invalid and fails. So allowing the roles to take "none"  value.

<img width="390" height="286" alt="Screenshot 2026-05-01 at 12 26 51" src="https://github.com/user-attachments/assets/5b9f53cb-469d-429a-937d-9a8d6bcbe288" />

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
