### PR TITLE
[patch] Add condition to check for IPv6 CIDR in login-fyre.yml

### DIFF
--- a/ibm/mas_devops/roles/ocp_login/tasks/login-fyre.yml
+++ b/ibm/mas_devops/roles/ocp_login/tasks/login-fyre.yml
@@ -74,4 +74,4 @@
   register: _dualstackNetworkAddr
   when:
     - enable_ipv6 == true
-    - "'fd01::/48' not in (_network.resources[0].spec.clusterNetwork | map(attribute='cidr') | list)"
+    - "'fd01::/48' not in (_network.result.spec.clusterNetwork | map(attribute='cidr') | list)"

--- a/ibm/mas_devops/roles/ocp_login/tasks/login-fyre.yml
+++ b/ibm/mas_devops/roles/ocp_login/tasks/login-fyre.yml
@@ -74,3 +74,4 @@
   register: _dualstackNetworkAddr
   when:
     - enable_ipv6 == true
+    - "'fd01::/48' not in (_network.resources[0].spec.clusterNetwork | map(attribute='cidr') | list)"


### PR DESCRIPTION
## Description
to overcome the duplicate entries in network configuration, where we use existing cluster

## Test Results
tested by running the run role

<img width="3454" height="154" alt="image" src="https://github.com/user-attachments/assets/9e1acee2-6591-4254-9017-6f03aa9c9bca" />

now it's skipping this changes and so we will not have duplicate entries of ipv6 cidrs
<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
