### PR TITLE
[patch] fix backup and restore links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,8 @@ nav:
       - "suite_app_uninstall": roles/suite_app_uninstall.md
       - "suite_app_upgrade": roles/suite_app_upgrade.md
       - "suite_app_rollback": roles/suite_app_rollback.md
+      - "suite_app_backup": roles/suite_app_backup.md
+      - "suite_app_restore": roles/suite_app_restore.md
       - "suite_certs": roles/suite_certs.md
       - "suite_config": roles/suite_config.md
       - "suite_db2_setup_for_manage": roles/suite_db2_setup_for_manage.md
@@ -99,6 +101,8 @@ nav:
       - "suite_upgrade": roles/suite_upgrade.md
       - "suite_rollback": roles/suite_rollback.md
       - "suite_verify": roles/suite_verify.md
+      - "suite_backup": roles/suite_backup.md
+      - "suite_restore": roles/suite_restore.md
   - "Roles: Utilities":
       - "ansible_version_check": roles/ansible_version_check.md
       - "entitlement_key_rotation": roles/entitlement_key_rotation.md


### PR DESCRIPTION
## Description
Fix for some of the links not working in backup and restore documentation - https://ibm-mas.github.io/ansible-devops/playbooks/backup-restore/

Fix:
Added the missing `.md` to the mkdocs.yml

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
