### PR TITLE
[patch] Fix deprovision failed_when condition

### DIFF
--- a/ibm/mas_devops/roles/ocp_deprovision/tasks/providers/fyre.yml
+++ b/ibm/mas_devops/roles/ocp_deprovision/tasks/providers/fyre.yml
@@ -52,8 +52,8 @@
       - 400
     force_basic_auth: yes
     validate_certs: false
-    register: _deprovision_result
-    failed_when:
-      - _deprovision_result.status == 400
-      - "'already has active jobs' in (_deprovision_result.json.details | default('')) or 'unable to start new job' in (_deprovision_result.json.details | default(''))"
+  register: _deprovision_result
+  failed_when:
+    - _deprovision_result.status == 400
+    - "'already has active jobs' in (_deprovision_result.json.details | default('')) or 'unable to start new job' in (_deprovision_result.json.details | default(''))"
 


### PR DESCRIPTION
## Description
This give error related to failed_when condition - 
`7 May, 12:06:48 TASK [ibm.mas_devops.ocp_deprovision : quickburn : Deprovision quick burn cluster] ***
7 May, 12:06:49 [ERROR]: Task failed: Module failed: Unsupported parameters for (ansible.legacy.uri) module: failed_when, register. Supported parameters include: attributes, body, body_format, ca_path, ciphers, client_cert, client_key, creates, decompress, dest, follow_redirects, force, force_basic_auth, group, headers, http_agent, method, mode, owner, remote_src, removes, return_content, selevel, serole, setype, seuser, src, status_code, timeout, unix_socket, unredirected_headers, unsafe_writes, url, url_password, url_username, use_gssapi, use_netrc, use_proxy, validate_certs (attr, password, user).
7 May, 12:06:49 Origin: /opt/app-root/lib64/python3.12/site-packages/ansible_collections/ibm/mas_devops/roles/ocp_deprovision/tasks/providers/fyre.yml:40:3
7 May, 12:06:49 
`

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
