### PR TITLE
[patch] move code of ipv6 configuration from ocp_login to ocp_config, also to overcome duplicate entry

### DIFF
--- a/ibm/mas_devops/roles/aiservice/README.md
+++ b/ibm/mas_devops/roles/aiservice/README.md
@@ -108,11 +108,11 @@ Custom domain override for AI Service.
 
 **Note**: This is an advanced configuration option. Most deployments should use `app_domain` or cluster auto-detection. Only set this if AI Service requires a separate domain.
 
-#### enable_ipv6
+#### ocp_enable_ipv6
 Enables SingleStack IPv6 service configuration for AI Service.
 
 - **Optional**
-- Environment Variable: `ENABLE_IPV6`
+- Environment Variable: `OCP_ENABLE_IPV6`
 - Default: False
 
 **Purpose**: Provide a way to enable IPv6 networking for all the services that are created by AI Service operator.

--- a/ibm/mas_devops/roles/aiservice/defaults/main.yml
+++ b/ibm/mas_devops/roles/aiservice/defaults/main.yml
@@ -4,7 +4,6 @@ aiservice_namespace: "aiservice-{{ aiservice_instance_id }}"
 aiservice_channel: "{{ lookup('env', 'AISERVICE_CHANNEL') }}"
 mas_config_dir: "{{ lookup('env', 'MAS_CONFIG_DIR') }}"
 
-
 # Custom Labels
 # -----------------------------------------------------------------------------
 custom_labels: "{{ lookup('env', 'CUSTOM_LABELS') | default(None, true) | string | ibm.mas_devops.string2dict() }}"
@@ -12,12 +11,10 @@ custom_labels: "{{ lookup('env', 'CUSTOM_LABELS') | default(None, true) | string
 # Operator logging: 0 for errors, 1 for warnings, 2 for info, 3 to 7 for debug.
 aiservice_operator_log_level: "{{ lookup('env', 'AISERVICE_OPERATOR_LOG_LEVEL') | default('0', true) }}"
 
-
 # Source container registry
 # -----------------------------------------------------------------------------
 icr_cp: "{{ lookup('env', 'MAS_ICR_CP') | default('cp.icr.io/cp', true) }}"
 icr_cpopen: "{{ lookup('env', 'MAS_ICR_CPOPEN') | default('icr.io/cpopen', true) }}"
-
 
 # IBM Entitlement
 # -----------------------------------------------------------------------------
@@ -30,15 +27,13 @@ mas_entitlement_key: "{{ lookup('env', 'MAS_ENTITLEMENT_KEY') | default(ibm_enti
 artifactory_username: "{{ lookup('env', 'ARTIFACTORY_USERNAME') | lower }}"
 artifactory_token: "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"
 
-
 # MAS Annotation block
 # -----------------------------------------------------------------------------
 mas_annotations: "{{ lookup('env', 'MAS_ANNOTATIONS') | default(None, true) }}"
 
 # aiservice vars
 mas_catalog_source: "{{ lookup('env', 'MAS_CATALOG_SOURCE') | default('ibm-operator-catalog', true) }}"
-pullSecretName: 'ibm-entitlement'
-
+pullSecretName: "ibm-entitlement"
 
 # General
 # -----------------------------------------------------------------------------
@@ -48,8 +43,7 @@ mas_icr_cp: "{{ lookup('env', 'MAS_ICR_CP') | default('cp.icr.io/cp', true) }}"
 mas_icr_cpopen: "{{ lookup('env', 'MAS_ICR_CPOPEN') | default('icr.io/cpopen', true) }}"
 
 # Enable IPv6?
-enable_ipv6: "{{ lookup('env', 'ENABLE_IPV6') | default('false', true) | bool }}"
-
+ocp_enable_ipv6: "{{ lookup('env', 'OCP_ENABLE_IPV6') | default('false', true) | bool }}"
 
 # S3
 # -----------------------------------------------------------------------------
@@ -69,7 +63,6 @@ aiservice_s3_secret: "aiservice-s3cfg"
 aiservice_s3_templates_bucket: "{{ lookup('env', 'AISERVICE_S3_TEMPLATES_BUCKET') | default('km-templates', True) }}"
 aiservice_s3_tenants_bucket: "{{ lookup('env', 'AISERVICE_S3_TENANTS_BUCKET') | default('km-tenants', True) }}"
 
-
 # SAAS
 # -----------------------------------------------------------------------------
 aiservice_domain: "{{ lookup('env', 'AISERVICE_DOMAIN') }}"
@@ -78,8 +71,7 @@ aiservice_dro_url: "{{ lookup('env', 'AISERVICE_DRO_URL') }}"
 aiservice_saas: "{{ lookup('env', 'AISERVICE_SAAS') | default('false', true) | bool }}"
 aiservice_sls_registration_key: "{{ lookup('env', 'AISERVICE_SLS_REGISTRATION_KEY') }}"
 aiservice_dro_token: "{{ lookup('env', 'AISERVICE_DRO_TOKEN') }}"
-aiservice_path_ca_crt: './certs'
-
+aiservice_path_ca_crt: "./certs"
 
 #  DRO
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/aiservice/tasks/main.yml
+++ b/ibm/mas_devops/roles/aiservice/tasks/main.yml
@@ -20,7 +20,7 @@
   debug:
     msg:
       - "AI Service domain ........................ {{ aiservice_domain }}"
-      - "IPv6 Enabled ............................. {{ enable_ipv6 }}"
+      - "IPv6 Enabled ............................. {{ ocp_enable_ipv6 }}"
 
 - name: "Debug: certificate issuer if defined"
   when: aiservice_certificate_issuer is defined and aiservice_certificate_issuer != ''

--- a/ibm/mas_devops/roles/aiservice/templates/aiservice/aiserviceapp.yml.j2
+++ b/ibm/mas_devops/roles/aiservice/templates/aiservice/aiserviceapp.yml.j2
@@ -45,7 +45,7 @@ spec:
       cpopen: "{{ mas_icr_cpopen }}"
     watsonxai:
       ca: "{{ aiservice_watsonxai_ca_crt | b64encode }}"
-{% if enable_ipv6 is defined and enable_ipv6 == true %}
+{% if ocp_enable_ipv6 is defined and ocp_enable_ipv6 == true %}
     services:
       ipFamilyPolicy: "SingleStack"
       ipFamilies: ["IPv6"]

--- a/ibm/mas_devops/roles/minio/defaults/main.yml
+++ b/ibm/mas_devops/roles/minio/defaults/main.yml
@@ -27,4 +27,4 @@ minio_root_password: "{{ lookup('env', 'MINIO_ROOT_PASSWORD') | default('', True
 minio_version: "RELEASE.2025-06-13T11-33-47Z"
 
 # Enable IPv6?
-enable_ipv6: "{{ lookup('env', 'ENABLE_IPV6') | default('false', true) | bool }}"
+ocp_enable_ipv6: "{{ lookup('env', 'OCP_ENABLE_IPV6') | default('false', true) | bool }}"

--- a/ibm/mas_devops/roles/minio/templates/minio/minio-service.yml.j2
+++ b/ibm/mas_devops/roles/minio/templates/minio/minio-service.yml.j2
@@ -17,7 +17,7 @@ spec:
       protocol: TCP
   selector:
     app: {{ minio_instance_name }}
-{% if enable_ipv6 is true %}
+{% if ocp_enable_ipv6 is true %}
   ipFamilyPolicy: SingleStack
   ipFamilies:
     - IPv6

--- a/ibm/mas_devops/roles/ocp_config/README.md
+++ b/ibm/mas_devops/roles/ocp_config/README.md
@@ -3,40 +3,42 @@
 Configure OpenShift Container Platform cluster-level settings for optimal MAS deployment. This role provides essential tuning for ingress timeouts, TLS cipher compatibility with IBM Java Semeru FIPS mode, and OperatorHub catalog source management.
 
 Key capabilities:
+
 - **Ingress timeout tuning**: Prevent request failures for long-running operations
 - **FIPS-compatible TLS ciphers**: Enable IBM Java Semeru runtime in FIPS mode
 - **Catalog source management**: Disable default Red Hat catalogs for air-gapped environments
 - **Path-based routing**: Configure namespace ownership for multi-namespace route support
 
 This role configures:
+
 - Tune the `IngressController` to avoid request failures due to timeout for long running requests
 - Configure the `IngressController` namespace ownership for path-based routing support
 - Update `APIServer` and `IngressController` to set a custom `tlsSecurityProfile` to accommodate ciphers supported by IBM Java Semeru runtime. This is required for allowing the Java applications using Semeru runtime to run in FIPS mode. The following ciphers will be enabled:
-    - `TLS_AES_128_GCM_SHA256`
-    - `TLS_AES_256_GCM_SHA384`
-    - `TLS_CHACHA20_POLY1305_SHA256`
-    - `ECDHE-ECDSA-AES128-GCM-SHA256`
-    - `ECDHE-RSA-AES128-GCM-SHA256`
-    - `ECDHE-ECDSA-AES256-GCM-SHA384`
-    - `ECDHE-RSA-AES256-GCM-SHA384`
-    - `ECDHE-ECDSA-CHACHA20-POLY1305`
-    - `ECDHE-RSA-CHACHA20-POLY1305`
-    - `DHE-RSA-AES128-GCM-SHA256`
-    - `DHE-RSA-AES256-GCM-SHA384`
-    - `ECDHE-RSA-AES128-SHA256`
-    - `ECDHE-RSA-AES128-SHA`
-    - `ECDHE-RSA-AES256-SHA`
+  - `TLS_AES_128_GCM_SHA256`
+  - `TLS_AES_256_GCM_SHA384`
+  - `TLS_CHACHA20_POLY1305_SHA256`
+  - `ECDHE-ECDSA-AES128-GCM-SHA256`
+  - `ECDHE-RSA-AES128-GCM-SHA256`
+  - `ECDHE-ECDSA-AES256-GCM-SHA384`
+  - `ECDHE-RSA-AES256-GCM-SHA384`
+  - `ECDHE-ECDSA-CHACHA20-POLY1305`
+  - `ECDHE-RSA-CHACHA20-POLY1305`
+  - `DHE-RSA-AES128-GCM-SHA256`
+  - `DHE-RSA-AES256-GCM-SHA384`
+  - `ECDHE-RSA-AES128-SHA256`
+  - `ECDHE-RSA-AES128-SHA`
+  - `ECDHE-RSA-AES256-SHA`
 - Disable the default Red Hat `CatalogSources`:
-    - `certified-operators`
-    - `community-operators`
-    - `redhat-operators`
-
+  - `certified-operators`
+  - `community-operators`
+  - `redhat-operators`
 
 ## Role Variables - API Server
 
 ## Role Variables - General
 
 ### ocp_update_ciphers_for_semeru
+
 Enable custom TLS cipher configuration for IBM Java Semeru FIPS mode compatibility.
 
 - Optional
@@ -48,24 +50,28 @@ Enable custom TLS cipher configuration for IBM Java Semeru FIPS mode compatibili
 **When to use**: Required when running MAS applications (particularly Manage) in FIPS mode with IBM Java Semeru runtime.
 
 **Valid values**:
+
 - `true` - Apply custom cipher configuration
 - `false` - Use default OpenShift cipher configuration
 
 **Impact**: When enabled, updates the `tlsSecurityProfile` on both APIServer and IngressController resources to include the following ciphers:
+
 - TLS 1.3: `TLS_AES_128_GCM_SHA256`, `TLS_AES_256_GCM_SHA384`, `TLS_CHACHA20_POLY1305_SHA256`
 - TLS 1.2: `ECDHE-ECDSA-AES128-GCM-SHA256`, `ECDHE-RSA-AES128-GCM-SHA256`, `ECDHE-ECDSA-AES256-GCM-SHA384`, `ECDHE-RSA-AES256-GCM-SHA384`, `ECDHE-ECDSA-CHACHA20-POLY1305`, `ECDHE-RSA-CHACHA20-POLY1305`, `DHE-RSA-AES128-GCM-SHA256`, `DHE-RSA-AES256-GCM-SHA384`, `ECDHE-RSA-AES128-SHA256`, `ECDHE-RSA-AES128-SHA`, `ECDHE-RSA-AES256-SHA`
 
 **Related variables**: None
 
 **Notes**:
+
 - Required for FIPS-compliant MAS deployments using Semeru runtime
 - Changes affect cluster-wide TLS configuration
 - May require cluster restart to fully apply
 - Verify compatibility with other applications in the cluster
 
-
 ## Role Variables - Ingress Controller
+
 ### ocp_ingress_controller_name
+
 The name of the Ingress Controller to configure.
 
 - **Optional**
@@ -77,21 +83,25 @@ The name of the Ingress Controller to configure.
 **When to use**: Use the default value unless you have multiple Ingress Controllers in your cluster and need to configure a specific one.
 
 **Valid values**:
+
 - `default` - The default cluster Ingress Controller (most common)
 - Any custom Ingress Controller name in your cluster
 
 **Impact**: All timeout and namespace ownership configurations will be applied to this specific Ingress Controller.
 
 **Related variables**:
+
 - [`ocp_ingress_update_timeouts`](#ocp_ingress_update_timeouts) - Timeout settings apply to this controller
 - [`ocp_ingress_namespace_ownership`](#ocp_ingress_namespace_ownership) - Namespace policy applies to this controller
 
 **Notes**:
+
 - Most OpenShift clusters use only the `default` Ingress Controller
 - Custom Ingress Controllers are rare and typically used for advanced routing scenarios
 - Verify the controller name exists before configuring
 
 ### ocp_ingress_update_timeouts
+
 Enable custom timeout configuration for the OpenShift Ingress Controller.
 
 - Optional
@@ -103,6 +113,7 @@ Enable custom timeout configuration for the OpenShift Ingress Controller.
 **When to use**: Enable when experiencing timeout issues with long-running MAS operations such as large file uploads, report generation, or data imports.
 
 **Valid values**:
+
 - `true` - Apply custom timeout values
 - `false` - Use default OpenShift timeout values (30s)
 
@@ -111,11 +122,13 @@ Enable custom timeout configuration for the OpenShift Ingress Controller.
 **Related variables**: `ocp_ingress_client_timeout`, `ocp_ingress_server_timeout`
 
 **Notes**:
+
 - Default 30s timeout may be insufficient for MAS Manage operations
 - Recommended to enable for production MAS deployments
 - Changes apply to all routes in the cluster
 
 ### ocp_ingress_client_timeout
+
 Client-side timeout duration for ingress connections.
 
 - Optional
@@ -127,6 +140,7 @@ Client-side timeout duration for ingress connections.
 **When to use**: Increase when clients need more time to upload large files or send data to MAS applications.
 
 **Valid values**: Duration string with unit suffix (e.g., `30s`, `5m`, `1h`). Common values:
+
 - `30s` - Default, suitable for most operations
 - `5m` - Recommended for MAS Manage file uploads
 - `10m` - For very large file operations
@@ -136,12 +150,14 @@ Client-side timeout duration for ingress connections.
 **Related variables**: `ocp_ingress_update_timeouts` (must be `true`), `ocp_ingress_server_timeout`
 
 **Notes**:
+
 - Only applies when `ocp_ingress_update_timeouts` is `true`
 - Consider network latency and file sizes when setting
 - Affects all routes in the cluster
 - Balance between user experience and resource consumption
 
 ### ocp_ingress_server_timeout
+
 Server-side timeout duration for ingress connections.
 
 - Optional
@@ -153,6 +169,7 @@ Server-side timeout duration for ingress connections.
 **When to use**: Increase when MAS applications perform long-running operations like report generation, data processing, or complex queries.
 
 **Valid values**: Duration string with unit suffix (e.g., `30s`, `5m`, `1h`). Common values:
+
 - `30s` - Default, suitable for most operations
 - `5m` - Recommended for MAS Manage report generation
 - `10m` - For complex data processing operations
@@ -163,12 +180,14 @@ Server-side timeout duration for ingress connections.
 **Related variables**: `ocp_ingress_update_timeouts` (must be `true`), `ocp_ingress_client_timeout`
 
 **Notes**:
+
 - Only applies when `ocp_ingress_update_timeouts` is `true`
 - Critical for MAS Manage report generation and data imports
 - Affects all routes in the cluster
 - Monitor application logs to determine appropriate values
 
 ### ocp_ingress_namespace_ownership
+
 Specifies the namespace ownership policy for the Ingress Controller. Set to `InterNamespaceAllowed` to enable path-based routing support, which allows routes to claim the same hostname across different namespaces.
 
 - Optional
@@ -176,12 +195,12 @@ Specifies the namespace ownership policy for the Ingress Controller. Set to `Int
 - Default Value: Not set (empty string)
 
 !!! note
-    When both timeout settings and namespace ownership are configured, they will be applied in a single atomic operation to the IngressController resource.
-
+When both timeout settings and namespace ownership are configured, they will be applied in a single atomic operation to the IngressController resource.
 
 ## Role Variables - OperatorHub
 
 ### ocp_operatorhub_disable_redhat_sources
+
 Disable default Red Hat OperatorHub catalog sources.
 
 - Optional
@@ -193,6 +212,7 @@ Disable default Red Hat OperatorHub catalog sources.
 **When to use**: Required for air-gapped/disconnected environments where external catalog sources are not accessible. Also useful to enforce use of mirrored catalogs only.
 
 **Valid values**:
+
 - `true` - Disable default Red Hat catalog sources
 - `false` - Leave catalog sources unchanged (default)
 
@@ -201,11 +221,42 @@ Disable default Red Hat OperatorHub catalog sources.
 **Related variables**: None
 
 **Notes**:
+
 - **Important**: Setting to `false` does NOT re-enable disabled sources
 - Required for disconnected/air-gapped MAS installations
 - Ensure custom catalogs are configured before disabling defaults
 - Affects all operator installations in the cluster
 - Cannot install operators from Red Hat catalogs after disabling
+- `ocp_enable_ipv6`: Required for RTP site
+
+**Note**: SVL (San Jose Valley) is the default site. RTP (Research Triangle Park) requires IPv6 enablement.
+
+### ocp_enable_ipv6
+
+Enable IPv6 for Fyre RTP site.
+
+- **Optional**
+- Environment Variable: `OCP_ENABLE_IPV6`
+- Default: `false`
+
+**Purpose**: Enables IPv6 networking for Fyre clusters at the RTP (Research Triangle Park) site.
+
+**When to use**:
+
+- Set to `true` only for Fyre RTP site clusters
+- Leave as `false` for all other sites (including SVL)
+- Only applies when `cluster_type=fyre`
+
+**Valid values**: `true`, `false`
+
+**Impact**: Configures network settings for IPv6 connectivity to RTP site clusters.
+
+**Related variables**:
+
+- `cluster_type`: Must be `fyre`
+- `fyre_site`: Should be `rtp` when this is `true`
+
+**Note**: Only required for Fyre RTP site. SVL and other sites use IPv4.
 
 ## Example Playbook
 
@@ -220,10 +271,11 @@ Disable default Red Hat OperatorHub catalog sources.
     ocp_ingress_namespace_ownership: InterNamespaceAllowed
     ocp_ingress_controller_name: default
     ocp_operatorhub_disable_redhat_sources: True
+    ocp_enable_ipv6: True
   roles:
     - ibm.mas_devops.ocp_config
 ```
 
-
 ## License
+
 EPL-2.0

--- a/ibm/mas_devops/roles/ocp_config/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_config/defaults/main.yml
@@ -4,7 +4,6 @@
 ocp_ingress_update_timeouts: "{{ lookup('env', 'OCP_INGRESS_UPDATE_TIMEOUTS') | default('False', true) | bool }}"
 ocp_update_ciphers_for_semeru: "{{ lookup('env', 'OCP_UPDATE_CIPHERS_FOR_SEMERU') | default('False', true) | bool }}"
 
-
 # Ingress Controller Settings
 # -----------------------------------------------------------------------------
 ocp_ingress_client_timeout: "{{ lookup('env', 'OCP_INGRESS_CLIENT_TIMEOUT') | default('30s', true) }}"
@@ -12,7 +11,9 @@ ocp_ingress_server_timeout: "{{ lookup('env', 'OCP_INGRESS_SERVER_TIMEOUT') | de
 ocp_ingress_controller_name: "{{ lookup('env', 'OCP_INGRESS_CONTROLLER_NAME') | default('default', true) }}"
 ocp_ingress_namespace_ownership: "{{ lookup('env', 'OCP_INGRESS_NAMESPACE_OWNERSHIP') }}"
 
-
 # OperatorHub Settings
 # -----------------------------------------------------------------------------
 ocp_operatorhub_disable_redhat_sources: "{{ lookup('env', 'OCP_OPERATORHUB_DISABLE_REDHAT_SOURCES') | default('False', true) | bool }}"
+
+# Enable ipv6?
+enable_ipv6: "{{ lookup('env', 'ENABLE_IPV6') | default('false', true) | bool }}"

--- a/ibm/mas_devops/roles/ocp_config/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_config/defaults/main.yml
@@ -16,4 +16,4 @@ ocp_ingress_namespace_ownership: "{{ lookup('env', 'OCP_INGRESS_NAMESPACE_OWNERS
 ocp_operatorhub_disable_redhat_sources: "{{ lookup('env', 'OCP_OPERATORHUB_DISABLE_REDHAT_SOURCES') | default('False', true) | bool }}"
 
 # Enable ipv6?
-enable_ipv6: "{{ lookup('env', 'ENABLE_IPV6') | default('false', true) | bool }}"
+ocp_enable_ipv6: "{{ lookup('env', 'OCP_ENABLE_IPV6') | default('false', true) | bool }}"

--- a/ibm/mas_devops/roles/ocp_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_config/tasks/main.yml
@@ -10,20 +10,50 @@
       - "ocp_ingress_controller_name ............ {{ ocp_ingress_controller_name }}"
       - "ocp_operatorhub_disable_redhat_sources . {{ ocp_operatorhub_disable_redhat_sources }}"
 
-
 # 2. Update API Server
 # -----------------------------------------------------------------------------
 - include_tasks: update-ciphers-for-semeru.yml
   when: ocp_update_ciphers_for_semeru
-
 
 # 3. Update Ingress Controller (timeouts and/or namespace ownership)
 # -----------------------------------------------------------------------------
 - include_tasks: update-ingress-controller.yml
   when: ocp_ingress_update_timeouts or ocp_ingress_namespace_ownership != ''
 
-
 # 4. Update OperatorHub
 # -----------------------------------------------------------------------------
 - include_tasks: update-operatorhub.yml
   when: ocp_operatorhub_disable_redhat_sources
+
+# 5. For IPv6 testing, lookup network
+- name: Lookup network for IPv6 testing
+  kubernetes.core.k8s:
+    api_version: config.openshift.io/v1
+    kind: Network
+    name: "cluster"
+  when:
+    - enable_ipv6 == true
+  register: _network
+
+- name: "fyre : Debug network"
+  debug:
+    var: _network
+
+# 6. For IPv6 testing, enable dual stack networking
+- name: "Enable dual stack networking"
+  kubernetes.core.k8s_json_patch:
+    kind: Network
+    name: "cluster"
+    api_version: config.openshift.io/v1
+    patch:
+      - op: add
+        path: /spec/clusterNetwork/-
+        value:
+          cidr: fd01::/48
+          hostPrefix: 64
+      - op: add
+        path: /spec/serviceNetwork/-
+        value: fd02::/112
+  register: _dualstackNetworkAddr
+  when:
+    - enable_ipv6 == true

--- a/ibm/mas_devops/roles/ocp_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_config/tasks/main.yml
@@ -32,7 +32,7 @@
     kind: Network
     name: "cluster"
   when:
-    - enable_ipv6 == true
+    - ocp_enable_ipv6 == true
   register: _network
 
 - name: "fyre : Debug network"
@@ -56,5 +56,5 @@
         value: fd02::/112
   register: _dualstackNetworkAddr
   when:
-    - enable_ipv6 == true
+    - ocp_enable_ipv6 == true
     - "'fd01::/48' not in (_network.result.spec.clusterNetwork | map(attribute='cidr') | list)"

--- a/ibm/mas_devops/roles/ocp_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_config/tasks/main.yml
@@ -57,3 +57,4 @@
   register: _dualstackNetworkAddr
   when:
     - enable_ipv6 == true
+    - "'fd01::/48' not in (_network.result.spec.clusterNetwork | map(attribute='cidr') | list)"

--- a/ibm/mas_devops/roles/ocp_login/README.md
+++ b/ibm/mas_devops/roles/ocp_login/README.md
@@ -2,10 +2,10 @@
 
 This role provides support to login to a cluster using the `oc` CLI by looking up cluster information from the infrastructure provider's APIs, it also supports setting `ocp_server` and `ocp_token` directly to support login to any Kubernetes cluster.
 
-
 ## Role Variables - General
 
 ### cluster_name
+
 Cluster name for credential lookup.
 
 - **Required** (unless `ocp_server` and `ocp_token` are set)
@@ -15,6 +15,7 @@ Cluster name for credential lookup.
 **Purpose**: Identifies the cluster to login to by name. Used to automatically lookup login credentials from the infrastructure provider's API.
 
 **When to use**:
+
 - Use with `cluster_type` for automatic credential lookup
 - Alternative to manually providing `ocp_server` and `ocp_token`
 - Recommended for managed clusters (ROKS, ROSA, Fyre)
@@ -24,12 +25,14 @@ Cluster name for credential lookup.
 **Impact**: Combined with `cluster_type`, automatically retrieves cluster server URL and login token from provider API.
 
 **Related variables**:
+
 - `cluster_type`: Required with this variable (roks, fyre, rosa)
 - `ocp_server`/`ocp_token`: Alternative manual login method
 
 **Note**: Requires provider-specific credentials (e.g., `ibmcloud_apikey` for ROKS, `rosa_token` for ROSA, `fyre_apikey` for Fyre).
 
 ### cluster_type
+
 Infrastructure provider type for cluster.
 
 - **Required** (unless `ocp_server` and `ocp_token` are set)
@@ -39,11 +42,13 @@ Infrastructure provider type for cluster.
 **Purpose**: Specifies the infrastructure provider type to determine which API to use for credential lookup.
 
 **When to use**:
+
 - Use with `cluster_name` for automatic credential lookup
 - Required for managed cluster login
 - Each type requires specific provider credentials
 
 **Valid values**: `roks`, `fyre`, `rosa`
+
 - `roks`: IBM Cloud Red Hat OpenShift Kubernetes Service
 - `fyre`: IBM DevIT Fyre clusters
 - `rosa`: AWS Red Hat OpenShift Service on AWS
@@ -51,6 +56,7 @@ Infrastructure provider type for cluster.
 **Impact**: Determines which provider API is called to retrieve cluster credentials. Each type requires different authentication variables.
 
 **Related variables**:
+
 - `cluster_name`: Cluster to lookup
 - `ibmcloud_apikey`: Required for `roks`
 - `fyre_username`/`fyre_apikey`: Required for `fyre`
@@ -59,6 +65,7 @@ Infrastructure provider type for cluster.
 **Note**: Alternative to using `ocp_server` and `ocp_token` for direct login.
 
 ### ocp_server
+
 OpenShift server URL for direct login.
 
 - **Required** (unless `cluster_name` and `cluster_type` are set)
@@ -68,6 +75,7 @@ OpenShift server URL for direct login.
 **Purpose**: Specifies the OpenShift API server URL for direct cluster login without provider API lookup.
 
 **When to use**:
+
 - Use with `ocp_token` for direct login
 - When cluster is not managed by supported providers
 - For custom or on-premises clusters
@@ -78,12 +86,14 @@ OpenShift server URL for direct login.
 **Impact**: Used directly for `oc login` command. Bypasses provider API credential lookup.
 
 **Related variables**:
+
 - `ocp_token`: Required with this variable
 - `cluster_name`/`cluster_type`: Alternative automatic lookup method
 
 **Note**: Both `ocp_server` and `ocp_token` must be provided together for direct login. This method works with any Kubernetes cluster.
 
 ### ocp_token
+
 Authentication token for direct login.
 
 - **Required** (unless `cluster_name` and `cluster_type` are set)
@@ -93,6 +103,7 @@ Authentication token for direct login.
 **Purpose**: Provides the authentication token for direct cluster login without provider API lookup.
 
 **When to use**:
+
 - Use with `ocp_server` for direct login
 - When cluster is not managed by supported providers
 - For service account tokens or manually obtained tokens
@@ -103,14 +114,16 @@ Authentication token for direct login.
 **Impact**: Used directly for `oc login --token` command. Bypasses provider API credential lookup.
 
 **Related variables**:
+
 - `ocp_server`: Required with this variable
 - `cluster_name`/`cluster_type`: Alternative automatic lookup method
 
 **Note**: **SECURITY** - Both `ocp_server` and `ocp_token` must be provided together. Token should be kept secure and not committed to version control. This method works with any Kubernetes cluster.
 
-
 ## Role Variables - IBMCloud ROKS
+
 ### ibmcloud_apikey
+
 IBM Cloud API key for ROKS authentication.
 
 - **Required** (when `cluster_type=roks`)
@@ -120,6 +133,7 @@ IBM Cloud API key for ROKS authentication.
 **Purpose**: Provides IBM Cloud API key for authenticating with IBM Cloud to retrieve ROKS cluster credentials.
 
 **When to use**:
+
 - Required when `cluster_type=roks`
 - Used to authenticate with IBM Cloud API
 - Enables automatic cluster credential lookup
@@ -129,6 +143,7 @@ IBM Cloud API key for ROKS authentication.
 **Impact**: Used to authenticate with IBM Cloud and retrieve cluster server URL and login token for ROKS clusters.
 
 **Related variables**:
+
 - `cluster_type`: Must be `roks`
 - `cluster_name`: ROKS cluster name to lookup
 - `ibmcloud_endpoint`: Optional API endpoint override
@@ -136,6 +151,7 @@ IBM Cloud API key for ROKS authentication.
 **Note**: **SECURITY** - API key should be kept secure and not committed to version control. Obtain from IBM Cloud IAM.
 
 ### ibmcloud_endpoint
+
 IBM Cloud API endpoint URL.
 
 - **Optional**
@@ -145,6 +161,7 @@ IBM Cloud API endpoint URL.
 **Purpose**: Overrides the default IBM Cloud API endpoint for ROKS cluster credential lookup.
 
 **When to use**:
+
 - Use default for public IBM Cloud
 - Override for private or regional endpoints
 - Only applies when `cluster_type=roks`
@@ -154,14 +171,16 @@ IBM Cloud API endpoint URL.
 **Impact**: Determines which IBM Cloud API endpoint is used for authentication and cluster lookup.
 
 **Related variables**:
+
 - `cluster_type`: Must be `roks`
 - `ibmcloud_apikey`: Required for authentication
 
 **Note**: The default public endpoint works for most deployments. Override only for specific regional or private cloud requirements.
 
-
 ## Role Variables - IBM DevIT Fyre
+
 ### fyre_username
+
 IBM DevIT Fyre username.
 
 - **Required** (when `cluster_type=fyre`)
@@ -171,6 +190,7 @@ IBM DevIT Fyre username.
 **Purpose**: Provides Fyre username for authenticating with IBM DevIT Fyre to retrieve cluster credentials.
 
 **When to use**:
+
 - Required when `cluster_type=fyre`
 - Used with `fyre_apikey` for Fyre authentication
 - Enables automatic cluster credential lookup
@@ -180,6 +200,7 @@ IBM DevIT Fyre username.
 **Impact**: Used to authenticate with Fyre API and retrieve cluster server URL and login token.
 
 **Related variables**:
+
 - `cluster_type`: Must be `fyre`
 - `fyre_apikey`: Required for authentication
 - `cluster_name`: Fyre cluster name to lookup
@@ -188,6 +209,7 @@ IBM DevIT Fyre username.
 **Note**: Fyre is IBM's internal development and test infrastructure. Requires IBM internal credentials.
 
 ### fyre_apikey
+
 IBM DevIT Fyre API key.
 
 - **Required** (when `cluster_type=fyre`)
@@ -197,6 +219,7 @@ IBM DevIT Fyre API key.
 **Purpose**: Provides Fyre API key for authenticating with IBM DevIT Fyre to retrieve cluster credentials.
 
 **When to use**:
+
 - Required when `cluster_type=fyre`
 - Used with `fyre_username` for Fyre authentication
 - Enables automatic cluster credential lookup
@@ -206,6 +229,7 @@ IBM DevIT Fyre API key.
 **Impact**: Used to authenticate with Fyre API and retrieve cluster server URL and login token.
 
 **Related variables**:
+
 - `cluster_type`: Must be `fyre`
 - `fyre_username`: Required for authentication
 - `cluster_name`: Fyre cluster name to lookup
@@ -214,6 +238,7 @@ IBM DevIT Fyre API key.
 **Note**: **SECURITY** - API key should be kept secure. Fyre is IBM's internal development and test infrastructure.
 
 ### fyre_site
+
 Fyre site location for cluster.
 
 - **Optional**
@@ -223,6 +248,7 @@ Fyre site location for cluster.
 **Purpose**: Specifies which Fyre site the cluster was provisioned in for proper API routing.
 
 **When to use**:
+
 - Use default (`svl`) for most Fyre clusters
 - Override for clusters in other sites (e.g., `rtp`)
 - Only applies when `cluster_type=fyre`
@@ -232,37 +258,13 @@ Fyre site location for cluster.
 **Impact**: Determines which Fyre site API endpoint is used for cluster lookup.
 
 **Related variables**:
+
 - `cluster_type`: Must be `fyre`
-- `enable_ipv6`: Required for RTP site
-
-**Note**: SVL (San Jose Valley) is the default site. RTP (Research Triangle Park) requires IPv6 enablement.
-
-### enable_ipv6
-Enable IPv6 for Fyre RTP site.
-
-- **Optional**
-- Environment Variable: `ENABLE_IPV6`
-- Default: `false`
-
-**Purpose**: Enables IPv6 networking for Fyre clusters at the RTP (Research Triangle Park) site.
-
-**When to use**:
-- Set to `true` only for Fyre RTP site clusters
-- Leave as `false` for all other sites (including SVL)
-- Only applies when `cluster_type=fyre`
-
-**Valid values**: `true`, `false`
-
-**Impact**: Configures network settings for IPv6 connectivity to RTP site clusters.
-
-**Related variables**:
-- `cluster_type`: Must be `fyre`
-- `fyre_site`: Should be `rtp` when this is `true`
-
-**Note**: Only required for Fyre RTP site. SVL and other sites use IPv4.
 
 ## Role Variables - AWS ROSA
+
 ### rosa_token
+
 AWS ROSA authentication token.
 
 - **Required** (when `cluster_type=rosa`)
@@ -272,6 +274,7 @@ AWS ROSA authentication token.
 **Purpose**: Provides ROSA (Red Hat OpenShift Service on AWS) authentication token for retrieving cluster credentials.
 
 **When to use**:
+
 - Required when `cluster_type=rosa`
 - Used to authenticate with ROSA API
 - Enables automatic cluster credential lookup
@@ -281,6 +284,7 @@ AWS ROSA authentication token.
 **Impact**: Used to authenticate with ROSA API and retrieve cluster server URL and login credentials.
 
 **Related variables**:
+
 - `cluster_type`: Must be `rosa`
 - `cluster_name`: ROSA cluster name to lookup
 - `rosa_cluster_admin_password`: Required for cluster-admin login
@@ -288,6 +292,7 @@ AWS ROSA authentication token.
 **Note**: **SECURITY** - Token should be kept secure and not committed to version control. Obtain from Red Hat Hybrid Cloud Console.
 
 ### rosa_cluster_admin_password
+
 ROSA cluster-admin account password.
 
 - **Required** (when `cluster_type=rosa`)
@@ -297,6 +302,7 @@ ROSA cluster-admin account password.
 **Purpose**: Provides the password for the cluster-admin account to login to ROSA clusters.
 
 **When to use**:
+
 - Required when `cluster_type=rosa`
 - Password created during cluster provisioning
 - Used for cluster-admin level access
@@ -306,6 +312,7 @@ ROSA cluster-admin account password.
 **Impact**: Used to authenticate as cluster-admin user on ROSA clusters.
 
 **Related variables**:
+
 - `cluster_type`: Must be `rosa`
 - `rosa_token`: Required for ROSA API authentication
 - `cluster_name`: ROSA cluster name to login to
@@ -315,6 +322,7 @@ ROSA cluster-admin account password.
 Example Playbooks
 
 ### Direct Login
+
 ```yaml
 - hosts: localhost
   vars:
@@ -325,6 +333,7 @@ Example Playbooks
 ```
 
 ### IBMCloud ROKS
+
 ```yaml
 - hosts: localhost
   vars:
@@ -337,6 +346,7 @@ Example Playbooks
 ```
 
 ### AWS ROSA
+
 ```yaml
 - hosts: localhost
   vars:
@@ -349,6 +359,7 @@ Example Playbooks
 ```
 
 ### IBM DevIT Fyre
+
 ```yaml
 - hosts: localhost
   vars:
@@ -359,7 +370,6 @@ Example Playbooks
   roles:
     - ibm.mas_devops.ocp_login
 ```
-
 
 ## Example Playbook
 

--- a/ibm/mas_devops/roles/ocp_login/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_login/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-
 cluster_name: "{{ lookup('env', 'CLUSTER_NAME')}}"
 cluster_type: "{{ lookup('env', 'CLUSTER_TYPE')}}"
 
@@ -29,6 +28,3 @@ supported_cluster_types:
   - aws
 
 k8s_auth_host: "{{ lookup('env', 'K8S_AUTH_HOST') | default('', True) }}"
-
-# Enable ipv6?
-enable_ipv6: "{{ lookup('env', 'ENABLE_IPV6') | default('false', true) | bool }}"

--- a/ibm/mas_devops/roles/ocp_login/tasks/login-fyre.yml
+++ b/ibm/mas_devops/roles/ocp_login/tasks/login-fyre.yml
@@ -41,36 +41,3 @@
   retries: 10
   delay: 30 # seconds
   until: login_result.rc == 0
-
-# 6. For IPv6 testing, lookup network
-- name: Lookup network for IPv6 testing
-  kubernetes.core.k8s:
-    api_version: config.openshift.io/v1
-    kind: Network
-    name: "cluster"
-  when:
-    - enable_ipv6 == true
-  register: _network
-
-- name: "fyre : Debug network"
-  debug:
-    var: _network
-
-# 7. For IPv6 testing, enable dual stack networking
-- name: "Enable dual stack networking"
-  kubernetes.core.k8s_json_patch:
-    kind: Network
-    name: "cluster"
-    api_version: config.openshift.io/v1
-    patch:
-      - op: add
-        path: /spec/clusterNetwork/-
-        value:
-          cidr: fd01::/48
-          hostPrefix: 64
-      - op: add
-        path: /spec/serviceNetwork/-
-        value: fd02::/112
-  register: _dualstackNetworkAddr
-  when:
-    - enable_ipv6 == true

--- a/ibm/mas_devops/roles/ocp_provision/README.md
+++ b/ibm/mas_devops/roles/ocp_provision/README.md
@@ -604,7 +604,7 @@ Fyre datacenter site location.
 **Impact**: Determines cluster location, which affects network latency and available resources.
 
 **Related variables**:
-- `enable_ipv6`: IPv6 only available at RTP site
+- `ocp_enable_ipv6`: IPv6 only available at RTP site
 
 **Note**: Not all sites support all features. SVL is the default and most commonly used site.
 
@@ -800,11 +800,11 @@ NFS storage size for OpenShift image registry.
 
 **Note**: Size is limited by available storage on the Fyre infrastructure node. Image registry stores all container images used in the cluster.
 
-### enable_ipv6
+### ocp_enable_ipv6
 Enable IPv6 networking for Fyre cluster.
 
 - **Optional**
-- Environment Variable: `ENABLE_IPV6`
+- Environment Variable: `OCP_ENABLE_IPV6`
 - Default: `false`
 
 **Purpose**: Enables IPv6 networking for the Fyre cluster. Only supported at the RTP (Raleigh) Fyre site.

--- a/ibm/mas_devops/roles/ocp_provision/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/defaults/main.yml
@@ -66,7 +66,6 @@ fyre_nfs_image_registry_size: "{{ lookup('env', 'FYRE_NFS_IMAGE_REGISTRY_SIZE') 
 # Deprecated
 fyre_nfs_setup: "{{ lookup('env', 'FYRE_NFS_SETUP') | default('false', True) | bool }}"
 
-
 # ROSA
 # -----------------------------------------------------------------------------
 rosa_token: "{{ lookup('env', 'ROSA_TOKEN') }}"
@@ -108,4 +107,4 @@ ocp_installer_dir: "{{ ipi_dir }}/installer/{{ ocp_version }}"
 ocp_installer_exe: "{{ ipi_dir }}/installer/{{ ocp_version }}/openshift-install"
 
 # Enable IPv6?
-enable_ipv6: "{{ lookup('env', 'ENABLE_IPV6') | default('false', true) | bool }}"
+ocp_enable_ipv6: "{{ lookup('env', 'OCP_ENABLE_IPV6') | default('false', true) | bool }}"

--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/fyre/provision_fyre.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/fyre/provision_fyre.yml
@@ -17,7 +17,6 @@
   assert:
     that: fyre_cluster_size is defined and fyre_cluster_size != ""
 
-
 # 2. Debug Info
 # -----------------------------------------------------------------------------
 - name: "fyre : Debug information"
@@ -37,7 +36,7 @@
       - "Fyre Quota Type .............. {{ fyre_quota_type }}"
       - "Fyre product ID .............. {{ fyre_product_id }}"
       - "FIPS enabled ................. {{ ocp_fips_enabled }}"
-      - "IPv6 enabled ................. {{ enable_ipv6 }}"
+      - "IPv6 enabled ................. {{ ocp_enable_ipv6 }}"
 
       # Quickburn specific
       - "Fyre cluster size ............ {{ fyre_cluster_size | default('<undefined>', true) }}"
@@ -47,7 +46,6 @@
       - "Worker CPU ................... {{ fyre_worker_cpu | default('<undefined>', true) }}"
       - "Worker memory ................ {{ fyre_worker_memory | default('<undefined>', true) }}"
       - "Worker additional disks ...... {{ fyre_worker_additional_disks | default('<undefined>', true) }}"
-
 
 # 3. Determine whether there is already an environment running
 # -----------------------------------------------------------------------------
@@ -89,13 +87,12 @@
     status_code: [200, 201, 429]
   register: _cluster_create
   until: _cluster_create.status != 429
-  delay: 120  # Every 2 minutes
+  delay: 120 # Every 2 minutes
   retries: 10
 
 - name: "fyre : Debug cluster provision"
   debug:
     var: _cluster_create
-
 
 # 5. Track the progress of the deployment
 # -----------------------------------------------------------------------------
@@ -105,7 +102,6 @@
     apikey: "{{ fyre_password }}"
     cluster_name: "{{ cluster_name }}"
     fyre_site: "{{ fyre_site }}"
-
 
 # 6. Reconfigure the cluster for NFS
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/ocp_provision/templates/fyre/product_group.json.j2
+++ b/ibm/mas_devops/roles/ocp_provision/templates/fyre/product_group.json.j2
@@ -6,7 +6,7 @@
    "site": {{ fyre_site | to_json }},
    "product_group_id": {{ fyre_product_id | to_json }},
    "ocp_version": {{ ocp_version | to_json }},
-   "ipv6_test": {{ enable_ipv6 | default(false) | to_json }},
+   "ipv6_test": {{ ocp_enable_ipv6 | default(false) | to_json }},
    "haproxy": {
      "timeout": {
        "http-request": "10s",

--- a/ibm/mas_devops/roles/suite_install/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_install/defaults/main.yml
@@ -113,7 +113,7 @@ mas_annotation_valid_entries:
 #gcp      |  ibm     |byol
 
 mas_annotation_valid_combinations:
-  ibm:  # Provider
+  ibm: # Provider
     ibm: [byol] # Channel: [Possible Formats]
   aws:
     aws: [byol, saas, privatepublic]
@@ -140,14 +140,13 @@ mas_img_pull_policy: "{{ lookup('env', 'MAS_IMG_PULL_POLICY') }}"
 custom_labels: "{{ lookup('env', 'CUSTOM_LABELS') | default(None, true) | string | ibm.mas_devops.string2dict() }}"
 
 # Enable IPv6?
-enable_ipv6: "{{ lookup('env', 'ENABLE_IPV6') | default('false', true) | bool }}"
+ocp_enable_ipv6: "{{ lookup('env', 'OCP_ENABLE_IPV6') | default('false', true) | bool }}"
 
 # Configure logs to go to Logstash instead of pod logs
 # -----------------------------------------------------------------------------
 # For now this only supports the use of the logstash set up by the eck role,
 # which will be available at "mas-ls-beats.eck.svc:5044"
 eck_enable_logstash: "{{ lookup('env', 'ECK_ENABLE_LOGSTASH') | default('false', true) | bool }}"
-
 
 # Configure superuser username & password
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/suite_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_install/tasks/main.yml
@@ -16,7 +16,6 @@
       - "Must start with a lowercase letter"
       - "Must end with a lowercase letter or a number"
 
-
 # 2. Set facts for mas_annotations_dict, HyperscalerFormat, HyperscalerChannel
 # -----------------------------------------------------------------------------
 - name: "Set facts : mas_annotations_dict"
@@ -55,7 +54,6 @@
       - "Hyperscaler Format ..................... {{ input_hyperscalerFormat | default('<undefined>', true) }}"
       - "mas_annotations_dict ................... {{ mas_annotations_dict }}"
 
-
 # 3. Validate annotations: Check for Hyperscaler flag partially set
 # -----------------------------------------------------------------------------
 - name: "Check for Hyperscaler flag partially set"
@@ -66,7 +64,6 @@
       - (input_hyperscalerProvider is undefined and input_hyperscalerChannel is undefined and input_hyperscalerFormat is undefined) or (input_hyperscalerProvider is defined and input_hyperscalerChannel is defined )
     fail_msg: "Assertion Failed! Invalid HyperScalerFlag combination in {{mas_annotations}} "
     success_msg: "Assertion Passed!  Valid HyperScalerFlag combination in {{mas_annotations}} "
-
 
 # 4. Validate annotations: Check if mas_annotations has valid allowed values
 # -----------------------------------------------------------------------------
@@ -81,7 +78,6 @@
     success_msg: "Assertion Passed!  Annotation {{item.key}}={{item.value}} is valid "
   with_dict:
     - "{{  mas_annotations_dict  }}"
-
 
 # 5. Check if mas_annotations value has invalid combinations
 # -----------------------------------------------------------------------------
@@ -99,7 +95,6 @@
   with_dict:
     - "{{  mas_annotations_dict  }}"
 
-
 # 6. Check if hyperscalerFormat is set to saas incase if hyperscalerTier is set with valid values
 # -----------------------------------------------------------------------------
 - name: "Fail if hyperscalerTier is set with valid value but hyperscalerFormat is other than saas"
@@ -112,7 +107,6 @@
     success_msg: "Assertion Passed!  Annotation {{item.key}}={{item.value}} is valid as mas.ibm.com/hyperscalerFormat is set to {{input_hyperscalerFormat}}"
   with_dict:
     - "{{  mas_annotations_dict  }}"
-
 
 # 7. Load PodTemplates configuration
 # -----------------------------------------------------------------------------
@@ -130,7 +124,6 @@
     config_files:
       - "ibm-data-dictionary-assetdatadictionary.yml"
 
-
 # 8. Set up the domain name for MAS
 # -----------------------------------------------------------------------------
 - name: "Get cluster subdomain"
@@ -145,7 +138,6 @@
   set_fact:
     mas_domain: "{{ mas_instance_id }}.{{ _cluster_subdomain.resources[0].spec.domain }}"
 
-
 # 9. Determine version of cert-manager in use on the cluster
 # -----------------------------------------------------------------------------
 # if cert_manager_cluster_resource_namespace is not set then
@@ -153,7 +145,6 @@
 - name: Detect Certificate Manager installation
   include_tasks: "{{ role_path }}/../../common_tasks/detect_cert_manager.yml"
   when: cert_manager_cluster_resource_namespace is not defined or cert_manager_cluster_resource_namespace == ''
-
 
 # 10. Provide debug information
 # -----------------------------------------------------------------------------
@@ -173,8 +164,7 @@
       - "MAS ICR cpopen content ........ {{ mas_icr_cpopen }}"
       - "Cert Manager namespace ........ {{ cert_manager_cluster_resource_namespace }}"
       - "MAS Cluster Issuer ............ {{ mas_cluster_issuer }}"
-      - "IPv6 Enabled .................. {{ enable_ipv6 }}"
-
+      - "IPv6 Enabled .................. {{ ocp_enable_ipv6 }}"
 
 # 11. Create entitlement secret and install the operator
 # -----------------------------------------------------------------------------
@@ -206,14 +196,12 @@
     catalog_source: "{{ mas_catalog_source }}"
   register: subscription
 
-
 # 12. Wait until the Suite CRD is available
 # -----------------------------------------------------------------------------
 - name: "Wait until the Suite CRD is available"
   include_tasks: "{{ role_path }}/../../common_tasks/wait_for_crd.yml"
   vars:
     crd_name: suites.core.mas.ibm.com
-
 
 # 13. Before we install the suite create the optional filebeat and superuser secrets
 # -----------------------------------------------------------------------------
@@ -234,7 +222,6 @@
     namespace: "{{ mas_namespace }}"
     template: templates/secret-superuser.yml.j2
 
-
 # 14. Suite installation
 # -----------------------------------------------------------------------------
 - name: Create suite.ibm.com/v1 CR
@@ -249,7 +236,6 @@
 - name: debug suiteResult
   debug:
     msg: "{{ suiteResult }}"
-
 
 # 15. Set up OCP ConsoleLink for MAS Admin Dashboard
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
+++ b/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
@@ -128,7 +128,7 @@ spec:
 {% if mas_ingress_controller_name is defined and mas_ingress_controller_name != '' %}
     ingressControllerName: {{ mas_ingress_controller_name }}
 {% endif %}
-{% if enable_ipv6 is defined and enable_ipv6 == true %}
+{% if ocp_enable_ipv6 is defined and ocp_enable_ipv6 == true %}
     services:
       ipFamilyPolicy: "SingleStack"
       ipFamilies: ["IPv6"]


### PR DESCRIPTION
## Description
to move code of ipv6 configuration from ocp_login to ocp_config, also to overcome duplicate entry
## Test Results
](https://cloud.ibm.com/devops/pipelines/tekton/3612e317-4d13-42a4-b798-d7db422549f8/runs/14efa1ae-3d5b-4656-b773-c3591ee1bc81/fvt-init?env_id=ibm:yp:us-south&view=logs)
<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
