### PR TITLE
[minor] Support Civil's Kafka Image Processor (MAS 9.2+)

### DIFF
--- a/.bob/plans/2026-05-10-ansible-devops-kafka-image-processor-pvc.md
+++ b/.bob/plans/2026-05-10-ansible-devops-kafka-image-processor-pvc.md
@@ -1,0 +1,264 @@
+# Ansible DevOps: Kafka Image Processor PVC Support
+
+## Objective
+Add support in the `suite_app_config` role for configuring Kafka Image Processor PVC settings that will be passed to the ManageWorkspace CR's `spec.components.civil.persistentVolumeClaims.kafkaImageProcessor` field.
+
+## Critical Rules
+- Use consistent environment variable naming: `MAS_MANAGE_KAFKAIMAGEPROCESSOR_PVC_SIZE` and `MAS_MANAGE_KAFKAIMAGEPROCESSOR_PVC_STORAGECLASS`
+- Follow existing PVC configuration patterns (JMS, doclinks, BIM)
+- Storage class auto-detection must use same logic as other Manage PVCs (RWX)
+- Only configure when civil component is enabled AND PVC variables are set
+- Default size: 10Gi
+- Access mode: ReadWriteMany (hardcoded in operator, not configurable here)
+
+## Execution Plan
+
+### Phase 1: Add Environment Variables and Defaults ✅
+
+#### 1.1 Update `ibm/mas_devops/roles/suite_app_config/defaults/main.yml` ✅
+Add after line 94 (after manage encryption secret variables):
+
+```yaml
+# Manage Kafka Image Processor PVC (Civil Component)
+# -----------------------------------------------------------------------------
+mas_manage_kafkaimageprocessor_pvc_storageclass: "{{ lookup('env', 'MAS_MANAGE_KAFKAIMAGEPROCESSOR_PVC_STORAGECLASS') }}"
+mas_manage_kafkaimageprocessor_pvc_size: "{{ lookup('env', 'MAS_MANAGE_KAFKAIMAGEPROCESSOR_PVC_SIZE') | default('10Gi', true) }}"
+```
+
+### Phase 2: Update Storage Class Determination ✅
+
+#### 2.1 Update `ibm/mas_devops/roles/suite_app_config/tasks/determine-storage-classes.yml` ✅
+
+Add after line 35 (after JMS queue storage class):
+
+```yaml
+- name: "determine-storage-classes : Set kafka image processor default pvc storage class"
+  when: mas_manage_kafkaimageprocessor_pvc_storageclass is not defined or mas_manage_kafkaimageprocessor_pvc_storageclass == ""
+  set_fact:
+    mas_manage_kafkaimageprocessor_pvc_storageclass: "{{ mas_app_settings_default_pvc_storage_class }}"
+```
+
+Update assertion section (after line 48) to include:
+
+```yaml
+- name: "determine-storage-classes : Assert Manage related storage classes are defined"
+  assert:
+    that:
+      - mas_app_settings_doclinks_pvc_storage_class is defined
+      - mas_app_settings_doclinks_pvc_storage_class != ''
+      - mas_app_settings_bim_pvc_storage_class is defined
+      - mas_app_settings_bim_pvc_storage_class != ''
+      - mas_app_settings_jms_queue_pvc_storage_class is defined
+      - mas_app_settings_jms_queue_pvc_storage_class != ''
+      - mas_manage_kafkaimageprocessor_pvc_storageclass is defined
+      - mas_manage_kafkaimageprocessor_pvc_storageclass != ''
+    fail_msg:
+      - "Failed: One of more storage classes are not defined for Manage"
+      - ""
+      - "Doclinks PVC Storage Class .............. {{ mas_app_settings_doclinks_pvc_storage_class | default('<undefined>', true) }}"
+      - "BIM PVC Storage Class  .................. {{ mas_app_settings_bim_pvc_storage_class | default('<undefined>', true) }}"
+      - "JMS Queue Storage Class ................. {{ mas_app_settings_jms_queue_pvc_storage_class | default('<undefined>', true) }}"
+      - "Kafka Image Processor Storage Class .... {{ mas_manage_kafkaimageprocessor_pvc_storageclass | default('<undefined>', true) }}"
+```
+
+### Phase 3: Check Manage Version and Create Kafka Image Processor PVC Setup Task ✅
+
+#### 3.1 Create `ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/check-manage-version.yml` ✅
+
+```yaml
+---
+# Check Manage application version to determine if Kafka Image Processor PVC is required
+# ------------------------------------------------------------------------
+- name: "Get ManageApp CR to check version"
+  kubernetes.core.k8s_info:
+    api_version: apps.mas.ibm.com/v1
+    kind: ManageApp
+    name: "{{ mas_instance_id }}"
+    namespace: "mas-{{ mas_instance_id }}-manage"
+  register: manage_app_info
+
+- name: "Fail if ManageApp CR not found"
+  assert:
+    that:
+      - manage_app_info.resources is defined
+      - manage_app_info.resources | length > 0
+    fail_msg: "ManageApp CR '{{ mas_instance_id }}' not found in namespace 'mas-{{ mas_instance_id }}-manage'. Cannot determine if Kafka Image Processor PVC configuration is required for Civil component."
+
+- name: "Fail if ManageApp version information not available"
+  assert:
+    that:
+      - manage_app_info.resources[0].status is defined
+      - manage_app_info.resources[0].status.versions is defined
+      - manage_app_info.resources[0].status.versions.reconciled is defined
+    fail_msg: "ManageApp CR '{{ mas_instance_id }}' does not have version information in status.versions.reconciled. Cannot determine if Kafka Image Processor PVC configuration is required for Civil component."
+
+- name: "Extract Manage version"
+  set_fact:
+    manage_reconciled_version: "{{ manage_app_info.resources[0].status.versions.reconciled }}"
+
+- name: "Extract major.minor version from reconciled version"
+  set_fact:
+    manage_major_minor: "{{ manage_reconciled_version.split('.')[0] }}.{{ manage_reconciled_version.split('.')[1] }}"
+
+- name: "Debug Manage version information"
+  debug:
+    msg:
+      - "Manage reconciled version ............. {{ manage_reconciled_version }}"
+      - "Manage major.minor version ............ {{ manage_major_minor }}"
+
+- name: "Determine if Kafka Image Processor PVC is required (Manage >= 9.2)"
+  when:
+    - manage_major_minor is version('9.2', '>=')
+  set_fact:
+    manage_requires_kafka_image_processor_pvc: true
+
+- name: "Set flag when Kafka Image Processor PVC is not required"
+  when: manage_requires_kafka_image_processor_pvc is not defined
+  set_fact:
+    manage_requires_kafka_image_processor_pvc: false
+
+- name: "Debug Kafka Image Processor PVC requirement"
+  debug:
+    msg: "Kafka Image Processor PVC required: {{ manage_requires_kafka_image_processor_pvc }}"
+```
+
+#### 3.2 Create `ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/setup-kafka-image-processor-pvc.yml` ✅
+
+```yaml
+---
+# Manage specific steps to configure Kafka Image Processor PVC for Civil component
+# ------------------------------------------------------------------------
+- name: "Debug Kafka Image Processor PVC configuration"
+  debug:
+    msg:
+      - "Kafka Image Processor PVC Size ............ {{ mas_manage_kafkaimageprocessor_pvc_size }}"
+      - "Kafka Image Processor PVC Storage Class ... {{ mas_manage_kafkaimageprocessor_pvc_storageclass }}"
+
+- name: "Set Kafka Image Processor PVC configuration for civil component"
+  set_fact:
+    mas_manage_civil_kafka_image_processor_pvc:
+      kafkaImageProcessor:
+        size: "{{ mas_manage_kafkaimageprocessor_pvc_size }}"
+        storageClassName: "{{ mas_manage_kafkaimageprocessor_pvc_storageclass }}"
+```
+
+#### 3.3 Update `ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/main.yml` ✅
+
+Add after line 51 (after encryption secret setup):
+
+```yaml
+# Manage pre-configuration: Check Manage version for Kafka Image Processor PVC requirement
+- name: "Run Manage specific pre-configuration: Check Manage version"
+  when:
+    - manageWorkspaceComponents is defined
+    - manageWorkspaceComponents.civil is defined
+    - manageWorkspaceComponents.civil.version is defined
+  include_tasks: "tasks/manage/pre-config/check-manage-version.yml"
+
+# Manage pre-configuration: Kafka Image Processor PVC setup (Civil component)
+- name: "Run Manage specific pre-configuration: Set up Kafka Image Processor PVC"
+  when:
+    - manageWorkspaceComponents is defined
+    - manageWorkspaceComponents.civil is defined
+    - manageWorkspaceComponents.civil.version is defined
+    - manage_requires_kafka_image_processor_pvc is defined
+    - manage_requires_kafka_image_processor_pvc | bool
+  include_tasks: "tasks/manage/pre-config/setup-kafka-image-processor-pvc.yml"
+```
+
+### Phase 4: Update Component Template ✅
+
+#### 4.1 Update `ibm/mas_devops/roles/suite_app_config/vars/customspecs/manage_components.yml.j2` ✅
+
+Replace lines 96-102 (civil component section) with:
+
+```jinja2
+{% if manageWorkspaceComponents['civil'] is defined and manageWorkspaceComponents['civil']['version'] is defined %}
+civil:
+{% if ibm_mas_manage_imagestitching_pod_templates is defined %}
+  podTemplates: {{ ibm_mas_manage_imagestitching_pod_templates }}
+{% endif %}
+{% if mas_manage_civil_kafka_image_processor_pvc is defined %}
+  persistentVolumeClaims: {{ mas_manage_civil_kafka_image_processor_pvc }}
+{% endif %}
+  version: {{ manageWorkspaceComponents['civil']['version'] }}
+{% endif %}
+```
+
+### Phase 5: Update Documentation ✅
+
+#### 5.1 Add documentation in `ibm/mas_devops/roles/suite_app_config/README.md` ✅
+
+Add new section after line 680 (after Doclinks/Attachments section, before BIM section):
+
+```markdown
+### Kafka Image Processor (Civil Component)
+
+The following properties can be defined to configure the persistent volume for the Kafka Image Processor component when the Civil Infrastructure component is enabled.
+
+**Important:** As of Manage 9.2, these properties are **required** when the Civil Infrastructure component is enabled. They are not supported in earlier releases. The role automatically detects the Manage version and only includes these settings when Manage >= 9.2.
+
+#### mas_manage_kafkaimageprocessor_pvc_storageclass
+Provide the persistent volume storage class to be used for Kafka Image Processor configuration. The PVC will be created with `ReadWriteMany` access mode as it must be shared between Manage/Civil and KafkaImageProcessor deployments.
+
+- **Optional** (automatically included when Civil component is enabled in Manage 9.2+)
+- Environment Variable: `MAS_MANAGE_KAFKAIMAGEPROCESSOR_PVC_STORAGECLASS`
+- Default: None - If not set, a default storage class will be auto-defined according to your cluster's available storage classes
+
+#### mas_manage_kafkaimageprocessor_pvc_size
+Provide the persistent volume claim size to be used for Kafka Image Processor configuration.
+
+- **Optional** (automatically included when Civil component is enabled in Manage 9.2+)
+- Environment Variable: `MAS_MANAGE_KAFKAIMAGEPROCESSOR_PVC_SIZE`
+- Default: `10Gi`
+```
+
+### Phase 6: Validation ✅
+
+#### 6.1 Verify version detection logic ✅
+- [x] Version detection correctly extracts major.minor from reconciled version using split()
+- [x] Version comparison works with extended semver strings (e.g., "9.2.0-pre.feature+123")
+- [x] Handles case when ManageApp CR doesn't exist or version not available (fails with clear error)
+
+#### 6.2 Review all changes for consistency ✅
+- [x] Variable naming follows consistent pattern (`MAS_MANAGE_*` not `MAS_APP_SETTINGS_*`)
+- [x] Default values match requirements (10Gi)
+- [x] Storage class logic matches other Manage PVCs
+- [x] Conditional logic checks for civil component enablement AND version >= 9.2
+
+#### 6.3 Verify variable naming conventions ✅
+- [x] Environment variables use `MAS_MANAGE_KAFKAIMAGEPROCESSOR_PVC_*` format
+- [x] Internal variables use `mas_manage_kafkaimageprocessor_pvc_storageclass` and `mas_manage_kafkaimageprocessor_pvc_size` format
+- [x] Template variables use `mas_manage_civil_kafka_image_processor_pvc` format
+
+#### 6.4 Ensure storage class logic matches other PVC configurations ✅
+- [x] Uses same `mas_app_settings_default_pvc_storage_class` (RWX)
+- [x] Includes in storage class assertion checks
+- [x] Auto-detection only when not user-provided
+
+## Testing Checklist
+
+After implementation:
+1. Test with civil component enabled and PVC variables set
+2. Test with civil component enabled but PVC variables not set (should use defaults)
+3. Test with civil component disabled (should not configure PVC)
+4. Test storage class auto-detection when not specified
+5. Verify ManageWorkspace CR contains correct `spec.components.civil.persistentVolumeClaims.kafkaImageProcessor` structure
+
+## Integration with Operator
+
+This ansible-devops work integrates with the operator changes in:
+`C:\Users\097891866\Documents\GitHub\maximoappsuite\ibm-mas-manage\.bob\plans\2026-05-10-kafka-image-processor-pvc-management.md`
+
+The operator expects:
+```yaml
+spec:
+  components:
+    civil:
+      persistentVolumeClaims:
+        kafkaImageProcessor:
+          size: "10Gi"
+          storageClassName: "ibmc-file-gold"
+```
+
+This ansible role will generate that structure when the environment variables are set.

--- a/.bob/rules/general-guidelines.md
+++ b/.bob/rules/general-guidelines.md
@@ -1,0 +1,86 @@
+# General Guidelines
+
+## Core Principles
+- Keep responses concise to minimize token usage
+- Focus token usage primarily on code changes and technical content
+- Avoid unnecessary explanations while maintaining technical accuracy
+- Use direct, efficient language in all communications
+
+
+## Token Usage
+1. **Eliminate Verbose Introductions**
+    - Remove phrases like "I'll help you with that" or "Let me explain" and "You're absolutely right!"
+    - Start directly with the relevant information or action
+
+2. **Code-First Approach**
+    - Prioritize showing code solutions over lengthy explanations
+    - When code changes are involved, allocate 70%+ tokens to code and technical details
+
+3. **Concise Technical Communication**
+    - Use bullet points for multi-step processes instead of paragraphs
+    - Include only essential context that impacts implementation decisions
+    - Omit obvious information that experienced developers would know
+    - Use inline comments and docstrings as the primary means of communicating how code works
+
+4. **Direct Response Format**
+    - For questions: Answer directly in first sentence, then provide minimal supporting details
+    - For tasks: Acknowledge with single line, then proceed immediately to solution
+    - For errors: State issue, cause, and solution without unnecessary background
+
+5. **Avoid Redundant Information**
+    - **Never repeat checklists or detailed plans** that have been committed to plan files (e.g. `2026-04-30-design-review.md`)
+    - Reference plan files by path instead of duplicating content
+    - In completion messages, provide only:
+        - Summary of what was created/updated (file paths)
+        - Key outcomes or next steps (2-3 bullets max)
+        - Links to detailed documentation
+
+
+## Windows Development with WSL
+Check `environment_details` for the operating system, if `operating system: windows` then wrap Linux commands with WSL:
+
+```bash
+# `wsl` launches with the current directory already set to the project root
+wsl bash -lc "ls -l"
+```
+
+
+## Planning
+
+### Naming
+- Use `.bob/plans/` for planning documents
+- Name files descriptively using a timestamp, e.g. `2026-04-30-design-review.md`
+
+### Structure
+1. **Objective** - Brief summary of what we are trying to achieve (1-2 sentences)
+
+2. **Critical Rules** - Bullet point list of key rules for agents to obey
+   - Use when there are specific constraints or requirements that must not be violated
+   - Examples: "Introduce no functional changes", "Preserve all existing tests", "Perform validation after every change"
+   - Keep concise and actionable
+
+3. **Execution Plan** - Checklist of actions to be taken
+   - Break down into phases for complex plans
+   - Each phase should have:
+     - Clear objective and scope
+     - Numbered checkboxes for all actions (e.g., `[ ] **1.1** Create file X`)
+     - Sub-checkboxes for detailed steps within actions
+     - Validation step at end of phase
+   - When ordering actions, prioritize easy wins and small tasks before complex tasks
+   - Do not defer validation until the end - include validation in each phase
+
+4. **Validation** - Details on how to perform validation
+   - Specify commands to run
+   - Define success criteria (e.g., "exactly 73 tests passed")
+   - Include troubleshooting guidance if applicable
+
+### Requirements
+- Plans must be **definitive** and **actionable**
+- Do not leave open questions in the plan, prompt the developer to make decisions and provide answers where necessary
+
+### Tracking Progress
+**Critical:** Update the plan document to reflect progress in real-time
+- **For iterative tasks** (migrating multiple tests, processing multiple files): Update the checklist immediately after each successful iteration/validation
+- **For multi-step phases**: Update after completing each major step within the phase
+- **Before using `attempt_completion`**: Ensure the plan reflects all completed work
+- The plan document should always show current progress, not just final completion

--- a/.bob/rules/python/development-guide.md
+++ b/.bob/rules/python/development-guide.md
@@ -1,0 +1,131 @@
+# Python Code Development Guide
+
+## Black and Flake8
+All changes made to Python code must be validated by running `black` and `flake8` against the changed files:
+
+```bash
+black src/mas/toolchain/github/issues.py src/mas/toolchain/github/utils.py && \
+flake8 src/mas/toolchain/github/issues.py src/mas/toolchain/github/utils.py
+```
+
+**If either of these tools are unavailable you must refuse to continue until the developer makes them available in your environment**
+
+
+## Variable, Function, and Class Naming
+Use `camelCase` for variable and function names, and `PascalCase` for class names.
+
+
+## Copyright Headers
+**Product Code** must carry a copyright header as follows:
+
+```python
+# -----------------------------------------------------------
+# Licensed Materials - Property of IBM
+# <PID1>, <PID2>
+# (C) Copyright IBM Corp. <YEAR> All Rights Reserved.
+# US Government Users Restricted Rights - Use, duplication, or disclosure
+# restricted by GSA ADP Schedule Contract with IBM Corp.
+# -----------------------------------------------------------
+```
+
+Where `<PID>` is an IBM product ID, and `<YEAR>` is one of the following:
+- If the file was created in the current year, use the current year, e.g. `2026`
+- If the file was created and updated in different years, record both e.g. `2020, 2026`
+
+**Important:** When updating any source file, update the copyright year if it does not match the current year - otherwise it will result in a build error in the CI/CD pipeline.
+
+Use the `.copyright.yml` configuration file to determine the PID(s) for copyright headers, and guide where copyright headers are required.
+
+```yaml
+copyright:
+  validate: true
+  pid: 5737-M66, 5900-AAA
+  ignore:
+    - tests/*
+```
+
+Note:
+- In most cases copyright headers are not required for test files, and will be listed in the `.copyright.yml` file's `ignore` list.
+- In non-product code copyright headers are not required, in this case validate will be set to `false` in the `.copyright.yml` file.
+- Never modify the `.copyright.yml` file without explicit instruction to do so.
+- This file must always exist in the repository root directory. If it is missing, help the developer create it.
+
+
+## Import Organization
+Organize imports in three groups:
+
+```python
+# 1. Standard library
+import logging
+import os
+from datetime import datetime
+from typing import Optional, Dict, List
+
+# 2. Third-party packages
+import requests
+from kubernetes import client
+from pymongo import MongoClient
+
+# 3. Local imports
+from mas.utils import exceptions
+from mas.utils import violations
+```
+
+**Do not use inline imports**, all imports must be listed at the top of the file.
+
+
+## Logger Declaration
+Declare logger after imports:
+
+```python
+import logging
+
+from mas.utils import exceptions
+
+logger = logging.getLogger(__name__)
+```
+
+
+## Type Hints
+Always include type hints in function signatures:
+
+```python
+# ✅ CORRECT
+def process_user(
+    user_id: str,
+    options: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    """Process user data."""
+    pass
+
+# ❌ INCORRECT - Missing type hints
+def process_user(user_id, options=None):
+    """Process user data."""
+    pass
+```
+
+## Constants
+Use uppercase for constants:
+
+```python
+# ✅ CORRECT
+DEFAULT_TIMEOUT = 30
+MAX_RETRIES = 3
+API_VERSION = "v1"
+
+# ❌ INCORRECT
+default_timeout = 30
+maxRetries = 3
+```
+
+
+## No Sensitive Data in Logs
+```python
+# ✅ CORRECT
+logger.info(f"User {user_id} authenticated successfully")
+logger.debug(f"Processing request for user {user_id}")
+
+# ❌ INCORRECT - Logging sensitive data
+logger.info(f"User password: {password}")
+logger.debug(f"API key: {api_key}")
+```

--- a/.bob/rules/python/docstrings.md
+++ b/.bob/rules/python/docstrings.md
@@ -1,0 +1,136 @@
+# Python Docstrings Guidelines
+Docstrings are inline documentation for Python modules, classes, and functions. They are:
+
+- Embedded directly in the source code
+- Used to generate API documentation automatically
+- Essential for code maintainability and usability
+
+
+## Writing Style
+
+1. **Be Concise**: Use clear, direct language
+2. **Be Specific**: Provide concrete details, not vague descriptions
+3. **Be Consistent**: Use the same terminology throughout
+4. **Be Complete**: Document all parameters, returns, and exceptions
+5. **Be Accurate**: Keep documentation in sync with code, and do not make assumptions when generating documentation
+
+
+## Google Style Docstrings
+All Python code MUST use **Google-style docstrings**. This style is:
+
+- Human-readable in source code
+- Well-supported by documentation tools (mkdocstrings, Sphinx)
+- Clear and consistent
+- Easy to parse and validate
+
+
+## Required Docstring Structure
+A complete docstring includes these sections **in order**:
+
+1. **Summary Line**:
+   - One line describing what the function does
+   - Use imperative mood ("Create" not "Creates")
+   - No period at the end
+
+2. **Extended Description**:
+   - Provide additional context about behavior
+   - Explain complex logic or side effects
+   - Can span multiple paragraphs
+   - Separate from summary with blank line
+
+3. **Args Section**:
+   - Use `Args:` as the section header
+   - Format: `param_name (type): Description`
+   - For optional parameters: `param_name (type, optional): Description. Defaults to value.`
+   - Multi-line descriptions should be indented to align with the first line
+   - Include type in parentheses after parameter name
+   - Always specify "Defaults to X" for optional parameters
+
+4. **Returns Section**:
+   - Format: `type: Description of return value`
+   - Be specific about what is returned
+
+5. **Raises Section**:
+   - Format: `ExceptionType: When this exception occurs`
+   - List all exceptions that may be raised
+   - Explain the conditions that trigger each exception
+
+Do **NOT** include these sections: `Note`, `Warning`, or `Example`; any notes or warnings should be part of the extended description.
+
+
+## Module Docstrings
+Every Python module MUST have a module-level docstring.
+
+```python
+"""Brief module description in one line.
+
+Extended description providing more context about what this module
+provides, its key components, and how it fits into the larger system.
+Can span multiple paragraphs if needed.
+"""
+```
+
+
+## Class Docstrings
+Every class MUST have a docstring describing its purpose.
+
+```python
+class ClassName:
+    """Brief class description.
+
+    Extended description explaining the class purpose, key responsibilities,
+    and important usage patterns.
+
+    Attributes:
+        attribute_name: Description of class or instance attribute.
+        another_attribute: Description of another attribute.
+    """
+```
+
+
+## Function and Method Docstrings
+All public functions and methods MUST have docstrings following this exact format.
+
+```python
+def create_subscription(
+    dynClient: DynamicClient,
+    namespace: str,
+    packageName: str,
+    packageChannel: Optional[str] = None,
+    catalogSource: Optional[str] = None,
+    catalogSourceNamespace: str = "openshift-marketplace",
+    config: Optional[dict] = None,
+    installMode: str = "OwnNamespace",
+    installPlanApproval: Optional[str] = None,
+    startingCSV: Optional[str] = None
+) -> Subscription:
+    """Create or update an operator subscription in a namespace.
+
+    Automatically detects default channel and catalog source from PackageManifest if not provided.
+    Ensures an OperatorGroup exists before creating the subscription.
+
+    When installPlanApproval is set to "Manual" and a startingCSV is specified, this function will
+    automatically approve the InstallPlan for the first-time installation to move to that startingCSV.
+    Subsequent upgrades will still require manual approval.
+
+    Args:
+        dynClient (DynamicClient): OpenShift Dynamic Client
+        namespace (str): The namespace to create the subscription in
+        packageName (str): Name of the operator package (e.g., "ibm-mas-operator")
+        packageChannel (str, optional): Subscription channel. Auto-detected if None. Defaults to None.
+        catalogSource (str, optional): Catalog source name. Auto-detected if None. Defaults to None.
+        catalogSourceNamespace (str, optional): Namespace of the catalog source. Defaults to "openshift-marketplace".
+        config (dict, optional): Additional subscription configuration. Defaults to None.
+        installMode (str, optional): Install mode for the OperatorGroup. Defaults to "OwnNamespace".
+        installPlanApproval (str, optional): Install plan approval mode ("Automatic" or "Manual"). Defaults to None.
+        startingCSV (str, optional): The specific CSV version to install. When combined with Manual approval,
+            the first InstallPlan to this CSV will be automatically approved. Required when installPlanApproval is "Manual". Defaults to None.
+
+    Returns:
+        Subscription: The created or updated subscription resource
+
+    Raises:
+        OLMException: If the package is not available in any catalog, or if installPlanApproval is "Manual" without a startingCSV
+        NotFoundError: If resources cannot be created
+    """
+```

--- a/.bob/rules/python/virtual-environments.md
+++ b/.bob/rules/python/virtual-environments.md
@@ -1,0 +1,5 @@
+# Python Virtual Environments
+
+- Assume that the developer has already set up a working virtual environment in `.venv` and that any python commands should be performed in the context of this venv
+- If this virtual environment is not set up, refuse to proceed with any code changes until the developer provides the expected development environment required to validate any changes
+- Do not attempt to set this environment up on behalf of the developer, this is something they are expected to manage

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ ibm/mas_devops/runAnsibl*.sh
 build/bin/downloads/*.tgz
 .pyenv
 cpd-cli-workspace/*
+
+/.bob/notes
 /tmp
 /node_modules
 package-lock.json
@@ -34,4 +36,4 @@ pandoc-*-amd64.deb
 pandoc-*-windows-x86_64.msi
 pandoc-*-x86_64-macOS.pkg
 README.rst
-/.bob
+

--- a/ibm/mas_devops/roles/suite_app_config/README.md
+++ b/ibm/mas_devops/roles/suite_app_config/README.md
@@ -684,18 +684,18 @@ The following properties can be defined to configure the persistent volume for t
 
 **Important:** As of Manage 9.2, these properties are **required** when the Civil Infrastructure component is enabled. They are not supported in earlier releases. The role automatically detects the Manage version and only includes these settings when Manage >= 9.2.
 
-#### manage_kafkaimageprocessor_pvc_storageclass
+#### mas_manage_kafkaimageprocessor_pvc_storageclass
 Provide the persistent volume storage class to be used for Kafka Image Processor configuration. The PVC will be created with `ReadWriteMany` access mode as it must be shared between Manage/Civil and KafkaImageProcessor deployments.
 
 - **Optional** (automatically included when Civil component is enabled in Manage 9.2+)
-- Environment Variable: `MANAGE_KAFKAIMAGEPROCESSOR_PVC_STORAGECLASS`
+- Environment Variable: `MAS_MANAGE_KAFKAIMAGEPROCESSOR_PVC_STORAGECLASS`
 - Default: None - If not set, a default storage class will be auto-defined according to your cluster's available storage classes
 
-#### manage_kafkaimageprocessor_pvc_size
+#### mas_manage_kafkaimageprocessor_pvc_size
 Provide the persistent volume claim size to be used for Kafka Image Processor configuration.
 
 - **Optional** (automatically included when Civil component is enabled in Manage 9.2+)
-- Environment Variable: `MANAGE_KAFKAIMAGEPROCESSOR_PVC_SIZE`
+- Environment Variable: `MAS_MANAGE_KAFKAIMAGEPROCESSOR_PVC_SIZE`
 - Default: `10Gi`
 
 ### BIM (Building Information Models)

--- a/ibm/mas_devops/roles/suite_app_config/README.md
+++ b/ibm/mas_devops/roles/suite_app_config/README.md
@@ -201,7 +201,7 @@ JDBC binding scope for the workspace.
 
 **Valid values**: `system`, `application`, `workspace`, `workspace-application`
 
-**Impact**: 
+**Impact**:
 - `system`: Uses system-level JDBC configuration (shared across all workspaces)
 - `application`: Uses application-level JDBC configuration
 - `workspace`: Uses workspace-specific JDBC configuration
@@ -287,7 +287,7 @@ Workload size for Predict containers (Predict only).
 
 **Valid values**: `developer`, `small`, `medium`, `large`
 
-**Impact**: 
+**Impact**:
 - `developer`: 1 replica (no high availability)
 - `small`: 2 replicas (basic high availability)
 - `medium`: 3 replicas (enhanced high availability)
@@ -678,6 +678,26 @@ Provide the persistent volume storage access-mode to be used for doclinks/attach
 - Environment Variable: `MAS_APP_SETTINGS_DOCLINKS_PVC_ACCESSMODE`
 - Default: `ReadWriteMany`
 
+### Kafka Image Processor (Civil Component)
+
+The following properties can be defined to configure the persistent volume for the Kafka Image Processor component when the Civil Infrastructure component is enabled.
+
+**Important:** As of Manage 9.2, these properties are **required** when the Civil Infrastructure component is enabled. They are not supported in earlier releases. The role automatically detects the Manage version and only includes these settings when Manage >= 9.2.
+
+#### manage_kafkaimageprocessor_pvc_storageclass
+Provide the persistent volume storage class to be used for Kafka Image Processor configuration. The PVC will be created with `ReadWriteMany` access mode as it must be shared between Manage/Civil and KafkaImageProcessor deployments.
+
+- **Optional** (automatically included when Civil component is enabled in Manage 9.2+)
+- Environment Variable: `MANAGE_KAFKAIMAGEPROCESSOR_PVC_STORAGECLASS`
+- Default: None - If not set, a default storage class will be auto-defined according to your cluster's available storage classes
+
+#### manage_kafkaimageprocessor_pvc_size
+Provide the persistent volume claim size to be used for Kafka Image Processor configuration.
+
+- **Optional** (automatically included when Civil component is enabled in Manage 9.2+)
+- Environment Variable: `MANAGE_KAFKAIMAGEPROCESSOR_PVC_SIZE`
+- Default: `10Gi`
+
 ### BIM (Building Information Models)
 
 The following properties can be defined to customize the persistent volumes for the Building Information Models setup for Manage.
@@ -847,8 +867,8 @@ Sets the size of deployment.
 - Default: `small` Available options are `small`, `medium` and `large`
 
 #### mas_ws_facilities_app_om_upgrade_mode
-**Note**: 
-- **WARNING** Application upgrades can overwrite your custom changes. Do not select Automatic if you have customized your application. 
+**Note**:
+- **WARNING** Application upgrades can overwrite your custom changes. Do not select Automatic if you have customized your application.
 - Currently supported `Maximo Real Estate and Facilities` release versions are: `9.2.x`
 
 Sets the Application Object Migration Mode.

--- a/ibm/mas_devops/roles/suite_app_config/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/defaults/main.yml
@@ -95,5 +95,5 @@ mas_manage_encryptionsecret_aiservice_fqn: "{{ lookup('env', 'MAS_MANAGE_ENCRYPT
 
 # Manage Kafka Image Processor PVC (Civil Component)
 # -----------------------------------------------------------------------------
-manage_kafkaimageprocessor_pvc_storageclass: "{{ lookup('env', 'MANAGE_KAFKAIMAGEPROCESSOR_PVC_STORAGECLASS') }}"
-manage_kafkaimageprocessor_pvc_size: "{{ lookup('env', 'MANAGE_KAFKAIMAGEPROCESSOR_PVC_SIZE') | default('10Gi', true) }}"
+mas_manage_kafkaimageprocessor_pvc_storageclass: "{{ lookup('env', 'MAS_MANAGE_KAFKAIMAGEPROCESSOR_PVC_STORAGECLASS') }}"
+mas_manage_kafkaimageprocessor_pvc_size: "{{ lookup('env', 'MAS_MANAGE_KAFKAIMAGEPROCESSOR_PVC_SIZE') | default('10Gi', true) }}"

--- a/ibm/mas_devops/roles/suite_app_config/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/defaults/main.yml
@@ -92,3 +92,8 @@ mas_manage_encryptionsecret_old_cryptox_key: "{{ lookup('env', 'MAS_MANAGE_ENCRY
 mas_manage_encryptionsecret_aiservice_apikey: "{{ lookup('env', 'MAS_MANAGE_ENCRYPTIONSECRET_AISERVICE_APIKEY') }}"
 mas_manage_encryptionsecret_aiservice_url: "{{ lookup('env', 'MAS_MANAGE_ENCRYPTIONSECRET_AISERVICE_URL') }}"
 mas_manage_encryptionsecret_aiservice_fqn: "{{ lookup('env', 'MAS_MANAGE_ENCRYPTIONSECRET_AISERVICE_FQN') }}"
+
+# Manage Kafka Image Processor PVC (Civil Component)
+# -----------------------------------------------------------------------------
+manage_kafkaimageprocessor_pvc_storageclass: "{{ lookup('env', 'MANAGE_KAFKAIMAGEPROCESSOR_PVC_STORAGECLASS') }}"
+manage_kafkaimageprocessor_pvc_size: "{{ lookup('env', 'MANAGE_KAFKAIMAGEPROCESSOR_PVC_SIZE') | default('10Gi', true) }}"

--- a/ibm/mas_devops/roles/suite_app_config/tasks/determine-storage-classes.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/determine-storage-classes.yml
@@ -34,6 +34,11 @@
   set_fact:
     mas_app_settings_jms_queue_pvc_storage_class: "{{ mas_app_settings_default_pvc_storage_class }}"
 
+- name: "determine-storage-classes : Set kafka image processor default pvc storage class"
+  when: manage_kafkaimageprocessor_pvc_storageclass is not defined or manage_kafkaimageprocessor_pvc_storageclass == ""
+  set_fact:
+    manage_kafkaimageprocessor_pvc_storageclass: "{{ mas_app_settings_default_pvc_storage_class }}"
+
 
 # 4. Check that all storage classes are defined
 # -----------------------------------------------------------------------------
@@ -46,9 +51,12 @@
       - mas_app_settings_bim_pvc_storage_class != ''
       - mas_app_settings_jms_queue_pvc_storage_class is defined
       - mas_app_settings_jms_queue_pvc_storage_class != ''
+      - manage_kafkaimageprocessor_pvc_storageclass is defined
+      - manage_kafkaimageprocessor_pvc_storageclass != ''
     fail_msg:
       - "Failed: One of more storage classes are not defined for Manage"
       - ""
-      - Doclinks PVC Storage Class .............. {{ mas_app_settings_doclinks_pvc_storage_class | default('<undefined>', true) }}"
-      - BIM PVC Storage Class  .................. {{ mas_app_settings_bim_pvc_storage_class | default('<undefined>', true) }}"
-      - JMS Queue Storage Class ................. {{ mas_app_settings_jms_queue_pvc_storage_class | default('<undefined>', true) }}"
+      - "Doclinks PVC Storage Class .............. {{ mas_app_settings_doclinks_pvc_storage_class | default('<undefined>', true) }}"
+      - "BIM PVC Storage Class  .................. {{ mas_app_settings_bim_pvc_storage_class | default('<undefined>', true) }}"
+      - "JMS Queue Storage Class ................. {{ mas_app_settings_jms_queue_pvc_storage_class | default('<undefined>', true) }}"
+      - "Kafka Image Processor Storage Class .... {{ manage_kafkaimageprocessor_pvc_storageclass | default('<undefined>', true) }}"

--- a/ibm/mas_devops/roles/suite_app_config/tasks/determine-storage-classes.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/determine-storage-classes.yml
@@ -35,9 +35,9 @@
     mas_app_settings_jms_queue_pvc_storage_class: "{{ mas_app_settings_default_pvc_storage_class }}"
 
 - name: "determine-storage-classes : Set kafka image processor default pvc storage class"
-  when: manage_kafkaimageprocessor_pvc_storageclass is not defined or manage_kafkaimageprocessor_pvc_storageclass == ""
+  when: mas_manage_kafkaimageprocessor_pvc_storageclass is not defined or mas_manage_kafkaimageprocessor_pvc_storageclass == ""
   set_fact:
-    manage_kafkaimageprocessor_pvc_storageclass: "{{ mas_app_settings_default_pvc_storage_class }}"
+    mas_manage_kafkaimageprocessor_pvc_storageclass: "{{ mas_app_settings_default_pvc_storage_class }}"
 
 
 # 4. Check that all storage classes are defined
@@ -51,12 +51,12 @@
       - mas_app_settings_bim_pvc_storage_class != ''
       - mas_app_settings_jms_queue_pvc_storage_class is defined
       - mas_app_settings_jms_queue_pvc_storage_class != ''
-      - manage_kafkaimageprocessor_pvc_storageclass is defined
-      - manage_kafkaimageprocessor_pvc_storageclass != ''
+      - mas_manage_kafkaimageprocessor_pvc_storageclass is defined
+      - mas_manage_kafkaimageprocessor_pvc_storageclass != ''
     fail_msg:
       - "Failed: One of more storage classes are not defined for Manage"
       - ""
       - "Doclinks PVC Storage Class .............. {{ mas_app_settings_doclinks_pvc_storage_class | default('<undefined>', true) }}"
       - "BIM PVC Storage Class  .................. {{ mas_app_settings_bim_pvc_storage_class | default('<undefined>', true) }}"
       - "JMS Queue Storage Class ................. {{ mas_app_settings_jms_queue_pvc_storage_class | default('<undefined>', true) }}"
-      - "Kafka Image Processor Storage Class .... {{ manage_kafkaimageprocessor_pvc_storageclass | default('<undefined>', true) }}"
+      - "Kafka Image Processor Storage Class .... {{ mas_manage_kafkaimageprocessor_pvc_storageclass | default('<undefined>', true) }}"

--- a/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/check-manage-version.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/check-manage-version.yml
@@ -1,0 +1,56 @@
+---
+# Check Manage application version to determine if Kafka Image Processor PVC is required
+# ------------------------------------------------------------------------
+- name: "Get ManageApp CR to check version"
+  kubernetes.core.k8s_info:
+    api_version: apps.mas.ibm.com/v1
+    kind: ManageApp
+    name: "{{ mas_instance_id }}"
+    namespace: "mas-{{ mas_instance_id }}-manage"
+  register: manage_app_info
+
+- name: "Fail if ManageApp CR not found"
+  assert:
+    that:
+      - manage_app_info.resources is defined
+      - manage_app_info.resources | length > 0
+    fail_msg: "ManageApp CR '{{ mas_instance_id }}' not found in namespace 'mas-{{ mas_instance_id }}-manage'. Cannot determine if Kafka Image Processor PVC configuration is required for Civil component."
+
+- name: "Fail if ManageApp version information not available"
+  assert:
+    that:
+      - manage_app_info.resources[0].status is defined
+      - manage_app_info.resources[0].status.versions is defined
+      - manage_app_info.resources[0].status.versions.reconciled is defined
+    fail_msg: "ManageApp CR '{{ mas_instance_id }}' does not have version information in status.versions.reconciled. Cannot determine if Kafka Image Processor PVC configuration is required for Civil component."
+
+- name: "Extract Manage version"
+  set_fact:
+    manage_reconciled_version: "{{ manage_app_info.resources[0].status.versions.reconciled }}"
+
+- name: "Extract major.minor version from reconciled version"
+  set_fact:
+    manage_major_minor: "{{ manage_reconciled_version.split('.')[0] }}.{{ manage_reconciled_version.split('.')[1] }}"
+
+- name: "Debug Manage version information"
+  debug:
+    msg:
+      - "Manage reconciled version ............. {{ manage_reconciled_version }}"
+      - "Manage major.minor version ............ {{ manage_major_minor }}"
+
+- name: "Determine if Kafka Image Processor PVC is required (Manage >= 9.2)"
+  when:
+    - manage_major_minor is version('9.2', '>=')
+  set_fact:
+    manage_requires_kafka_image_processor_pvc: true
+
+- name: "Set flag when Kafka Image Processor PVC is not required"
+  when: manage_requires_kafka_image_processor_pvc is not defined
+  set_fact:
+    manage_requires_kafka_image_processor_pvc: false
+
+- name: "Debug Kafka Image Processor PVC requirement"
+  debug:
+    msg: "Kafka Image Processor PVC required: {{ manage_requires_kafka_image_processor_pvc }}"
+
+# Made with Bob

--- a/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/main.yml
@@ -1,28 +1,59 @@
 ---
-- name: Show Components to be installed
-  debug:
-    var: mas_appws_components
-
-# Manage pre-configuration: pod templates
+# 1. Configure pod templates
+# ------------------------------------------------------------------------
 - name: "Run Manage specific pre-configuration: Pod Templates"
   include_tasks: "tasks/manage/pre-config/setup-pod-templates.yml"
   when: is_full_manage
 
-# Manage pre-configuration: components
-- name: "Run Manage specific pre-configuration: Load components"
+# 2. Components
+# ------------------------------------------------------------------------
+- name: Show Components to be installed
+  debug:
+    var: mas_appws_components
+
+- name: "Run Manage specific pre-configuration: Check Manage version"
+  when:
+    - manageWorkspaceComponents is defined
+    - manageWorkspaceComponents.civil is defined
+    - manageWorkspaceComponents.civil.version is defined
+  include_tasks: "tasks/manage/pre-config/check-manage-version.yml"
+
+- name: "Run Manage specific pre-configuration: Set up Kafka Image Processor PVC"
+  when:
+    - manageWorkspaceComponents is defined
+    - manageWorkspaceComponents.civil is defined
+    - manageWorkspaceComponents.civil.version is defined
+    - manage_requires_kafka_image_processor_pvc is defined
+    - manage_requires_kafka_image_processor_pvc | bool
+  include_tasks: "tasks/manage/pre-config/setup-kafka-image-processor-pvc.yml"
+
+- name: "Debug pre-configuration: manageWorkspaceComponents"
+  when: mas_appws_spec is not defined
+  debug:
+    msg: "{{ manageWorkspaceComponents }}"
+
+- name: "Run pre-configuration: Components"
   when: mas_appws_spec is not defined
   set_fact:
-    "mas_app_components_{{ mas_app_id }}": "{{ lookup('ansible.builtin.template', 'vars/customspecs/{{ mas_app_id }}_components.yml.j2') | from_yaml }}"
+    "mas_app_components_{{ mas_app_id }}": "{{ lookup('ansible.builtin.template', 'vars/customspecs/' ~ mas_app_id ~ '_components.yml.j2') | from_yaml }}"
 
-# Build the incredibly complex Manage spec.settings from a set of env vars
+- name: "Debug pre-configuration: Components"
+  when: mas_appws_spec is not defined
+  debug:
+    msg: "{{ lookup('vars', 'mas_app_components_' ~ mas_app_id) }}"
+
+- fail:
+    msg: "HI DAVE!!"
+
+
+# 3. Settings
 # ------------------------------------------------------------------------
-
-# Manage pre-configuration: JMS setup
+# 3.1 Manage pre-configuration: JMS setup
 - name: "Run Manage specific pre-configuration: Set jms server"
   when: mas_app_settings_server_bundles_size in ['jms','snojms']
   include_tasks: "tasks/manage/pre-config/setup-jms.yml"
 
-# Manage pre-configuration: Customization archive setup
+# 3.2 Manage pre-configuration: Customization archive setup
 - name: "Run Manage specific pre-configuration: Set custom archive credentials"
   when:
     - mas_app_settings_customization_archive_username is defined
@@ -33,14 +64,14 @@
     - mas_app_settings_customization_archive_url | length > 0
   include_tasks: "tasks/manage/pre-config/setup-custom-archive.yml"
 
-# Manage pre-configuration: AI Service configuration setup
+# 3.3 Manage pre-configuration: AI Service configuration setup
 - name: "Run Manage specific pre-configuration: Set up AI Service integration"
   when:
     - aiservice_instance_id is defined
     - aiservice_instance_id != ""
   include_tasks: "tasks/manage/pre-config/setup-aiservice-config.yml"
 
-# Manage pre-configuration: Database encryption and AI Service secrets setup
+# 3.4 Manage pre-configuration: Database encryption and AI Service secrets setup
 - name: "Run Manage specific pre-configuration: Set database encryption keys and AI Service secrets"
   when: >
     (mas_manage_encryptionsecret_crypto_key is defined and mas_manage_encryptionsecret_crypto_key != '' and
@@ -50,20 +81,3 @@
     (mas_manage_encryptionsecret_aiservice_apikey is defined and mas_manage_encryptionsecret_aiservice_apikey != '')
   include_tasks: "tasks/manage/pre-config/setup-encryption-secret.yml"
 
-# Manage pre-configuration: Check Manage version for Kafka Image Processor PVC requirement
-- name: "Run Manage specific pre-configuration: Check Manage version"
-  when:
-    - manageWorkspaceComponents is defined
-    - manageWorkspaceComponents.civil is defined
-    - manageWorkspaceComponents.civil.version is defined
-  include_tasks: "tasks/manage/pre-config/check-manage-version.yml"
-
-# Manage pre-configuration: Kafka Image Processor PVC setup (Civil component)
-- name: "Run Manage specific pre-configuration: Set up Kafka Image Processor PVC"
-  when:
-    - manageWorkspaceComponents is defined
-    - manageWorkspaceComponents.civil is defined
-    - manageWorkspaceComponents.civil.version is defined
-    - manage_requires_kafka_image_processor_pvc is defined
-    - manage_requires_kafka_image_processor_pvc | bool
-  include_tasks: "tasks/manage/pre-config/setup-kafka-image-processor-pvc.yml"

--- a/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/main.yml
@@ -49,3 +49,21 @@
      mas_manage_encryptionsecret_old_cryptox_key is defined and mas_manage_encryptionsecret_old_cryptox_key != '') or
     (mas_manage_encryptionsecret_aiservice_apikey is defined and mas_manage_encryptionsecret_aiservice_apikey != '')
   include_tasks: "tasks/manage/pre-config/setup-encryption-secret.yml"
+
+# Manage pre-configuration: Check Manage version for Kafka Image Processor PVC requirement
+- name: "Run Manage specific pre-configuration: Check Manage version"
+  when:
+    - manageWorkspaceComponents is defined
+    - manageWorkspaceComponents.civil is defined
+    - manageWorkspaceComponents.civil.version is defined
+  include_tasks: "tasks/manage/pre-config/check-manage-version.yml"
+
+# Manage pre-configuration: Kafka Image Processor PVC setup (Civil component)
+- name: "Run Manage specific pre-configuration: Set up Kafka Image Processor PVC"
+  when:
+    - manageWorkspaceComponents is defined
+    - manageWorkspaceComponents.civil is defined
+    - manageWorkspaceComponents.civil.version is defined
+    - manage_requires_kafka_image_processor_pvc is defined
+    - manage_requires_kafka_image_processor_pvc | bool
+  include_tasks: "tasks/manage/pre-config/setup-kafka-image-processor-pvc.yml"

--- a/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/main.yml
@@ -42,9 +42,6 @@
   debug:
     msg: "{{ lookup('vars', 'mas_app_components_' ~ mas_app_id) }}"
 
-- fail:
-    msg: "HI DAVE!!"
-
 
 # 3. Settings
 # ------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/setup-kafka-image-processor-pvc.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/setup-kafka-image-processor-pvc.yml
@@ -4,14 +4,14 @@
 - name: "Debug Kafka Image Processor PVC configuration"
   debug:
     msg:
-      - "Kafka Image Processor PVC Size ............ {{ manage_kafkaimageprocessor_pvc_size }}"
-      - "Kafka Image Processor PVC Storage Class ... {{ manage_kafkaimageprocessor_pvc_storageclass }}"
+      - "Kafka Image Processor PVC Size ............ {{ mas_manage_kafkaimageprocessor_pvc_size }}"
+      - "Kafka Image Processor PVC Storage Class ... {{ mas_manage_kafkaimageprocessor_pvc_storageclass }}"
 
 - name: "Set Kafka Image Processor PVC configuration for civil component"
   set_fact:
-    manage_civil_kafka_image_processor_pvc:
+    mas_manage_civil_kafka_image_processor_pvc:
       kafkaImageProcessor:
-        size: "{{ manage_kafkaimageprocessor_pvc_size }}"
-        storageClassName: "{{ manage_kafkaimageprocessor_pvc_storageclass }}"
+        size: "{{ mas_manage_kafkaimageprocessor_pvc_size }}"
+        storageClassName: "{{ mas_manage_kafkaimageprocessor_pvc_storageclass }}"
 
 # Made with Bob

--- a/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/setup-kafka-image-processor-pvc.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/setup-kafka-image-processor-pvc.yml
@@ -1,0 +1,17 @@
+---
+# Manage specific steps to configure Kafka Image Processor PVC for Civil component
+# ------------------------------------------------------------------------
+- name: "Debug Kafka Image Processor PVC configuration"
+  debug:
+    msg:
+      - "Kafka Image Processor PVC Size ............ {{ manage_kafkaimageprocessor_pvc_size }}"
+      - "Kafka Image Processor PVC Storage Class ... {{ manage_kafkaimageprocessor_pvc_storageclass }}"
+
+- name: "Set Kafka Image Processor PVC configuration for civil component"
+  set_fact:
+    manage_civil_kafka_image_processor_pvc:
+      kafkaImageProcessor:
+        size: "{{ manage_kafkaimageprocessor_pvc_size }}"
+        storageClassName: "{{ manage_kafkaimageprocessor_pvc_storageclass }}"
+
+# Made with Bob

--- a/ibm/mas_devops/roles/suite_app_config/vars/customspecs/README.md
+++ b/ibm/mas_devops/roles/suite_app_config/vars/customspecs/README.md
@@ -1,0 +1,40 @@
+# Custom Specifications Directory
+
+This directory contains Jinja2 templates that define application-specific component configurations for MAS applications.
+
+## Files
+
+### `manage_components.yml.j2`
+Defines the component configuration for IBM Maximo Manage application.
+
+## Usage
+
+These templates are loaded dynamically during application pre-configuration. The loading mechanism uses a variable-based path pattern:
+
+**Location:** [`tasks/manage/pre-config/main.yml`](../../tasks/manage/pre-config/main.yml)
+
+```yaml
+set_fact:
+  "mas_app_components_{{ mas_app_id }}": "{{ lookup('ansible.builtin.template', 'vars/customspecs/{{ mas_app_id }}_components.yml.j2') | from_yaml }}"
+```
+
+When `mas_app_id` is set to `"manage"`, this resolves to:
+- Template: `vars/customspecs/manage_components.yml.j2`
+- Fact created: `mas_app_components_manage`
+
+The template is rendered, parsed as YAML, and stored as an Ansible fact for use during application configuration.
+
+## Conditions
+
+The component loading only occurs when:
+- `mas_appws_spec` is not already defined
+- During Manage-specific pre-configuration phase
+
+## Adding New Application Components
+
+To add component specifications for other MAS applications, create a new template file following the naming pattern:
+```
+<app_id>_components.yml.j2
+```
+
+Where `<app_id>` matches the value of `mas_app_id` variable (e.g., `monitor`, `predict`, etc.).

--- a/ibm/mas_devops/roles/suite_app_config/vars/customspecs/manage_components.yml.j2
+++ b/ibm/mas_devops/roles/suite_app_config/vars/customspecs/manage_components.yml.j2
@@ -98,6 +98,9 @@ civil:
 {% if ibm_mas_manage_imagestitching_pod_templates is defined %}
   podTemplates: {{ ibm_mas_manage_imagestitching_pod_templates }}
 {% endif %}
+{% if manage_civil_kafka_image_processor_pvc is defined %}
+  persistentVolumeClaims: {{ manage_civil_kafka_image_processor_pvc }}
+{% endif %}
   version: {{ manageWorkspaceComponents['civil']['version'] }}
 {% endif %}
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/suite_app_config/vars/customspecs/manage_components.yml.j2
+++ b/ibm/mas_devops/roles/suite_app_config/vars/customspecs/manage_components.yml.j2
@@ -98,8 +98,8 @@ civil:
 {% if ibm_mas_manage_imagestitching_pod_templates is defined %}
   podTemplates: {{ ibm_mas_manage_imagestitching_pod_templates }}
 {% endif %}
-{% if manage_civil_kafka_image_processor_pvc is defined %}
-  persistentVolumeClaims: {{ manage_civil_kafka_image_processor_pvc }}
+{% if mas_manage_civil_kafka_image_processor_pvc is defined %}
+  persistentVolumeClaims: {{ mas_manage_civil_kafka_image_processor_pvc }}
 {% endif %}
   version: {{ manageWorkspaceComponents['civil']['version'] }}
 {% endif %}


### PR DESCRIPTION
## PR Body

### Summary
Enables automatic PVC management for the Kafka Image Processor component when deploying Manage with the Civil Infrastructure add-on in MAS 9.2+.

### Impact
- PVCs are automatically created and configured when deploying Civil Infrastructure in Manage 9.2+
- Storage class is auto-detected using the same logic as other Manage components (doclinks, BIM, JMS)
- Clear error messages if the Manage version cannot be determined
- Seamless upgrade path - only applies to Manage 9.2+ installations

### Configuration
Two new optional environment variables control the PVC configuration:

- `MAS_MANAGE_KAFKAIMAGEPROCESSOR_PVC_SIZE` - Default: `10Gi`
- `MAS_MANAGE_KAFKAIMAGEPROCESSOR_PVC_STORAGECLASS` - Default: Auto-detected RWX storage class

### Version Detection
The role automatically detects the installed Manage version from the ManageApp CR and only configures the Kafka Image Processor PVC when:
1. Civil Infrastructure component is enabled
2. Manage version is 9.2 or higher

This ensures backward compatibility with earlier Manage versions that don't support this feature.

### Integration
Works in conjunction with operator changes in `ibm-mas-manage` that add PVC creation logic to the ManageWorkspace controller. Together, these changes eliminate manual PVC management for Civil Infrastructure deployments.

### Documentation
Updated `suite_app_config` role README with configuration details and version requirements.