### PR TITLE
[patch] fix kubeturbo variable kubeturbo_sub_name not being defined

### DIFF
--- a/ibm/mas_devops/roles/turbonomic/tasks/main.yml
+++ b/ibm/mas_devops/roles/turbonomic/tasks/main.yml
@@ -105,7 +105,7 @@
 
 # 7. Wait until Kubeturbo Operator is ready
 # -----------------------------------------------------------------------------
-- name: "Wait for {{ kubeturbo_sub_name }} to be ready (60s delay)"
+- name: "Wait for kubeturbo operator to be ready (60s delay)"
   kubernetes.core.k8s_info:
     api_version: apps/v1
     name: "kubeturbo-operator"


### PR DESCRIPTION
## Description
<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->
Fix warning in turbonomic role due to invalid variable name:

```
May 11, 8:12:29 AM [WARNING]: Encountered 1 template error.
May 11, 8:12:29 AM error 1 - 'kubeturbo_sub_name' is undefined
May 11, 8:12:29 AM Origin: /opt/app-root/lib64/python3.12/site-packages/ansible_collections/ibm/mas_devops/roles/turbonomic/tasks/main.yml:108:9
May 11, 8:12:29 AM 
May 11, 8:12:29 AM 106 # 7. Wait until Kubeturbo Operator is ready
May 11, 8:12:29 AM 107 # -----------------------------------------------------------------------------
May 11, 8:12:29 AM 108 - name: "Wait for {{ kubeturbo_sub_name }} to be ready (60s delay)"
May 11, 8:12:29 AM             ^ column 9
```

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->
No testing, just a string replacement.

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
