### PR TITLE
[patch] Version Control on IoT DNS Entries as we are removing these from 9.2

### DIFF
--- a/ibm/mas_devops/roles/suite_certs/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_certs/defaults/main.yml
@@ -3,6 +3,7 @@ mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
 mas_config_dir: "{{ lookup('env', 'MAS_CONFIG_DIR') }}"
 mas_suite_certs_dir: "{{ mas_config_dir }}/certs"
 mas_manual_cert_mgmt: "{{ lookup('env', 'MAS_MANUAL_CERT_MGMT') | default('False', true) | bool }}"
+mas_channel: "{{ lookup('env', 'MAS_CHANNEL') }}"
 gitops: "{{ lookup('env', 'GITOPS') | default(False, true) }}"
 
 # Optional parameters when using CIS as DNS Provider

--- a/ibm/mas_devops/roles/suite_certs/tasks/run.yml
+++ b/ibm/mas_devops/roles/suite_certs/tasks/run.yml
@@ -1,6 +1,24 @@
 ---
 
-# 1. Check for undefined properties that do not have a default
+# 1. Parse MAS version from channel
+# -----------------------------------------------------------------------------
+- name: "Set default for mas_version_lt_92"
+  when: mas_version_lt_92 is not defined
+  set_fact:
+    mas_version_lt_92: true
+
+- name: "Override mas_version_lt_92 based on mas_channel if provided"
+  when: mas_channel is defined and mas_channel != ""
+  set_fact:
+    mas_version_lt_92: "{{ mas_channel.split('.')[:2] | join('.') is version('9.2', '<') }}"
+
+- name: "Debug version comparison result"
+  debug:
+    msg:
+      - "MAS Channel ......................... {{ mas_channel | default('not set') }}"
+      - "Version < 9.2 ...................... {{ mas_version_lt_92 }}"
+
+# 2. Check for undefined properties that do not have a default
 # -----------------------------------------------------------------------------
 - name: "Fail if mas_instance_id is not provided"
   assert:

--- a/ibm/mas_devops/roles/suite_certs/templates/dnsentries.yml.j2
+++ b/ibm/mas_devops/roles/suite_certs/templates/dnsentries.yml.j2
@@ -49,14 +49,16 @@ nowildcard:
   -  {{ mas_workspace_id }}-cron.health
   -  {{ mas_workspace_id }}-jms.health
   - maxinst.health
-  - iot
-  -  {{ mas_workspace_id }}.iot
   - messaging.iot
   -  {{ mas_workspace_id }}.messaging.iot
+{% if mas_version_lt_92 %}
+  - iot
+  -  {{ mas_workspace_id }}.iot
   - edgeconfig.iot
   -  {{ mas_workspace_id }}.edgeconfig.iot
   - edgeconfigapi.iot
   -  {{ mas_workspace_id }}.edgeconfigapi.iot
+{% endif %}
   - monitor
   -  {{ mas_workspace_id }}.monitor
   - admin.monitor
@@ -83,12 +85,14 @@ wildcard:
 {% endif %}
   - "*.api.monitor"
   - "*.assist"
-  - "*.edgeconfig.iot"
-  - "*.edgeconfigapi.iot"
   - "*.health"
   - "*.home"
-  - "*.iot"
   - "*.messaging.iot"
+{% if mas_version_lt_92 %}
+  - "*.edgeconfig.iot"
+  - "*.edgeconfigapi.iot"
+  - "*.iot"
+{% endif %}
   - "*.monitor"
   - "*.predict"
   - "*.visualinspection"

--- a/ibm/mas_devops/roles/suite_dns/defaults/main.yaml
+++ b/ibm/mas_devops/roles/suite_dns/defaults/main.yaml
@@ -23,7 +23,7 @@ mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') }}"
 mas_namespace: "mas-{{ mas_instance_id }}-core"
 mas_domain: "{{ lookup('env', 'MAS_DOMAIN') }}"
 mas_routing_mode: "{{ lookup('env', 'MAS_ROUTING_MODE') | default('subdomain', true) }}"
-mas_version: "{{ lookup('env', 'MAS_CHANNEL') }}"
+mas_channel: "{{ lookup('env', 'MAS_CHANNEL') }}"
 
 # Ouput Directory
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/suite_dns/defaults/main.yaml
+++ b/ibm/mas_devops/roles/suite_dns/defaults/main.yaml
@@ -23,6 +23,7 @@ mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') }}"
 mas_namespace: "mas-{{ mas_instance_id }}-core"
 mas_domain: "{{ lookup('env', 'MAS_DOMAIN') }}"
 mas_routing_mode: "{{ lookup('env', 'MAS_ROUTING_MODE') | default('subdomain', true) }}"
+mas_app_channel_iot: "{{ lookup('env', 'MAS_APP_CHANNEL_IOT') }}"
 
 # Ouput Directory
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/suite_dns/defaults/main.yaml
+++ b/ibm/mas_devops/roles/suite_dns/defaults/main.yaml
@@ -23,7 +23,7 @@ mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') }}"
 mas_namespace: "mas-{{ mas_instance_id }}-core"
 mas_domain: "{{ lookup('env', 'MAS_DOMAIN') }}"
 mas_routing_mode: "{{ lookup('env', 'MAS_ROUTING_MODE') | default('subdomain', true) }}"
-mas_app_channel_iot: "{{ lookup('env', 'MAS_APP_CHANNEL_IOT') }}"
+mas_version: "{{ lookup('env', 'MAS_CHANNEL') }}"
 
 # Ouput Directory
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/suite_dns/tasks/run.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/run.yml
@@ -1,5 +1,52 @@
 ---
-# 1. Check cert-manager installation
+# 1. Parse MAS version from channel
+# -----------------------------------------------------------------------------
+- name: "Parse MAS version and set IS_POST_92 flag"
+  shell: |
+    #!/bin/bash
+    set -e
+    
+    echo "DEBUG: Parsing MAS version from channel"
+    echo "DEBUG: Input mas_channel: {{ mas_channel | default('') }}"
+    
+    # Default to false if mas_channel is not set
+    IS_POST_92="false"
+    echo "DEBUG: Initial IS_POST_92 value: $IS_POST_92"
+    
+    if [ -n "{{ mas_channel | default('') }}" ]; then
+      echo "DEBUG: mas_channel is not empty, parsing version"
+      # Extract major, minor versions
+      MAJOR=$(echo "{{ mas_channel }}" | cut -d. -f1)
+      MINOR=$(echo "{{ mas_channel }}" | cut -d. -f2 | sed 's/[^0-9].*$//')
+      echo "DEBUG: Parsed version - MAJOR: $MAJOR, MINOR: $MINOR"
+      
+      # Check if version is >= 9.2
+      if [ "$MAJOR" -gt 9 ] || ([ "$MAJOR" -eq 9 ] && [ "$MINOR" -ge 2 ]); then
+        IS_POST_92="true"
+        echo "DEBUG: Version is >= 9.2, setting IS_POST_92 to true"
+      else
+        echo "DEBUG: Version is < 9.2, keeping IS_POST_92 as false"
+      fi
+    else
+      echo "DEBUG: mas_channel is empty, keeping IS_POST_92 as false"
+    fi
+    
+    echo "DEBUG: Final IS_POST_92 value: $IS_POST_92"
+    echo "$IS_POST_92"
+  register: _is_post_92_result
+  changed_when: false
+
+- name: "Set mas_version_lt_92 fact"
+  set_fact:
+    mas_version_lt_92: "{{ _is_post_92_result.stdout.strip() == 'false' }}"
+
+- name: "Debug version comparison result"
+  debug:
+    msg:
+      - "MAS Channel ......................... {{ mas_channel | default('not set') }}"
+      - "Version < 9.2 ...................... {{ mas_version_lt_92 }}"
+
+# 2. Check cert-manager installation
 # -----------------------------------------------------------------------------
 # Ensure cert manager is installed prior continuing as this role will install
 # v1alpha1.acme.cis.ibm.com apiservice which requires cert manager to be running
@@ -11,13 +58,13 @@
     msg:
       - "Certificate Manager Namespace .......... {{ cert_manager_namespace }}"
 
-# 2. Run provider task
+# 3. Run provider task
 # -----------------------------------------------------------------------------
 - name: "Run the provider specific task"
   when: dns_provider != ""
   include_tasks: tasks/providers/{{ dns_provider }}/main.yml
 
-# 3. Set custom cp4d route based on the custom cluster issuer
+# 4. Set custom cp4d route based on the custom cluster issuer
 # -----------------------------------------------------------------------------
 - block:
     - name: Check if custom CP4D route is already configured # if it is, then we skip it to avoid override

--- a/ibm/mas_devops/roles/suite_dns/tasks/run.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/run.yml
@@ -1,44 +1,15 @@
 ---
 # 1. Parse MAS version from channel
 # -----------------------------------------------------------------------------
-- name: "Parse MAS version and set IS_POST_92 flag"
-  shell: |
-    #!/bin/bash
-    set -e
-    
-    echo "DEBUG: Parsing MAS version from channel"
-    echo "DEBUG: Input mas_channel: {{ mas_channel | default('') }}"
-    
-    # Default to false if mas_channel is not set
-    IS_POST_92="false"
-    echo "DEBUG: Initial IS_POST_92 value: $IS_POST_92"
-    
-    if [ -n "{{ mas_channel | default('') }}" ]; then
-      echo "DEBUG: mas_channel is not empty, parsing version"
-      # Extract major, minor versions
-      MAJOR=$(echo "{{ mas_channel }}" | cut -d. -f1)
-      MINOR=$(echo "{{ mas_channel }}" | cut -d. -f2 | sed 's/[^0-9].*$//')
-      echo "DEBUG: Parsed version - MAJOR: $MAJOR, MINOR: $MINOR"
-      
-      # Check if version is >= 9.2
-      if [ "$MAJOR" -gt 9 ] || ([ "$MAJOR" -eq 9 ] && [ "$MINOR" -ge 2 ]); then
-        IS_POST_92="true"
-        echo "DEBUG: Version is >= 9.2, setting IS_POST_92 to true"
-      else
-        echo "DEBUG: Version is < 9.2, keeping IS_POST_92 as false"
-      fi
-    else
-      echo "DEBUG: mas_channel is empty, keeping IS_POST_92 as false"
-    fi
-    
-    echo "DEBUG: Final IS_POST_92 value: $IS_POST_92"
-    echo "$IS_POST_92"
-  register: _is_post_92_result
-  changed_when: false
-
-- name: "Set mas_version_lt_92 fact"
+- name: "Set mas_version_lt_92 fact based on mas_channel"
+  when: mas_channel is defined and mas_channel != ""
   set_fact:
-    mas_version_lt_92: "{{ _is_post_92_result.stdout.strip() == 'false' }}"
+    mas_version_lt_92: "{{ mas_channel.split('.')[:2] | join('.') is version('9.2', '<') }}"
+
+- name: "Set default for mas_version_lt_92 when mas_channel is not defined"
+  when: mas_channel is not defined or mas_channel == ""
+  set_fact:
+    mas_version_lt_92: true
 
 - name: "Debug version comparison result"
   debug:

--- a/ibm/mas_devops/roles/suite_dns/tasks/run.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/run.yml
@@ -1,15 +1,15 @@
 ---
 # 1. Parse MAS version from channel
 # -----------------------------------------------------------------------------
-- name: "Set mas_version_lt_92 fact based on mas_channel"
+- name: "Set default for mas_version_lt_92"
+  when: mas_version_lt_92 is not defined
+  set_fact:
+    mas_version_lt_92: true
+
+- name: "Override mas_version_lt_92 based on mas_channel if provided"
   when: mas_channel is defined and mas_channel != ""
   set_fact:
     mas_version_lt_92: "{{ mas_channel.split('.')[:2] | join('.') is version('9.2', '<') }}"
-
-- name: "Set default for mas_version_lt_92 when mas_channel is not defined"
-  when: mas_channel is not defined or mas_channel == ""
-  set_fact:
-    mas_version_lt_92: true
 
 - name: "Debug version comparison result"
   debug:

--- a/ibm/mas_devops/roles/suite_dns/templates/dnsentries.yml.j2
+++ b/ibm/mas_devops/roles/suite_dns/templates/dnsentries.yml.j2
@@ -51,7 +51,7 @@ nowildcard:
   - maxinst.health
   - messaging.iot
   -  {{ mas_workspace_id }}.messaging.iot
-{% if mas_app_channel_iot is not defined or mas_app_channel_iot == "" or (mas_app_channel_iot | regex_replace('[^0-9.].*$', '')) is version('9.2', '<') %}
+{% if mas_version_lt_92 %}
   - iot
   -  {{ mas_workspace_id }}.iot
   - edgeconfig.iot
@@ -88,7 +88,7 @@ wildcard:
   - "*.assist"
   - "*.appconfig"
   - "*.arcgis"
-{% if mas_app_channel_iot is not defined or mas_app_channel_iot == "" or (mas_app_channel_iot | regex_replace('[^0-9.].*$', '')) is version('9.2', '<') %}
+{% if mas_version_lt_92 %}
   - "*.edgeconfig.iot"
   - "*.edgeconfigapi.iot"
   - "*.iot"

--- a/ibm/mas_devops/roles/suite_dns/templates/dnsentries.yml.j2
+++ b/ibm/mas_devops/roles/suite_dns/templates/dnsentries.yml.j2
@@ -49,14 +49,16 @@ nowildcard:
   -  {{ mas_workspace_id }}-cron.health
   -  {{ mas_workspace_id }}-jms.health
   - maxinst.health
-  - iot
-  -  {{ mas_workspace_id }}.iot
   - messaging.iot
   -  {{ mas_workspace_id }}.messaging.iot
+{% if mas_app_channel_iot is not defined or mas_app_channel_iot == "" or (mas_app_channel_iot | regex_replace('[^0-9.].*$', '')) is version('9.2', '<') %}
+  - iot
+  -  {{ mas_workspace_id }}.iot
   - edgeconfig.iot
   -  {{ mas_workspace_id }}.edgeconfig.iot
   - edgeconfigapi.iot
   -  {{ mas_workspace_id }}.edgeconfigapi.iot
+{% endif %}
   - monitor
   -  {{ mas_workspace_id }}.monitor
   - admin.monitor
@@ -86,11 +88,13 @@ wildcard:
   - "*.assist"
   - "*.appconfig"
   - "*.arcgis"
+{% if mas_app_channel_iot is not defined or mas_app_channel_iot == "" or (mas_app_channel_iot | regex_replace('[^0-9.].*$', '')) is version('9.2', '<') %}
   - "*.edgeconfig.iot"
   - "*.edgeconfigapi.iot"
+  - "*.iot"
+{% endif %}
   - "*.health"
   - "*.home"
-  - "*.iot"
   - "*.messaging.iot"
   - "*.monitor"
   - "*.predict"


### PR DESCRIPTION
## Description
Adding version control condition for DNS entries as we are moving edgeconfig to monitor from 9.2 release.

## Test Results

9.1.x where edgeconfig DNS entries available

<img width="1397" height="747" alt="image" src="https://github.com/user-attachments/assets/438ad1f2-5f2e-4190-964f-3f03f675a9b1" />

<img width="2336" height="1418" alt="image" src="https://github.com/user-attachments/assets/ae08001c-b16f-4247-924e-2205f81d6313" />


9.2.x where edgeconfig entries not updated

<img width="1397" height="718" alt="image" src="https://github.com/user-attachments/assets/ca554eba-c6a6-4d28-bcb6-6c4e14b78371" />

<img width="2336" height="1418" alt="image" src="https://github.com/user-attachments/assets/b741045d-728b-4084-b59e-eef9aec32dea" />



<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
