### PR TITLE
[patch] Handle missing status fields on verify

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 160

--- a/ibm/mas_devops/plugins/action/verify_catalogsources.py
+++ b/ibm/mas_devops/plugins/action/verify_catalogsources.py
@@ -8,53 +8,65 @@ from ansible.utils.display import Display
 
 import time
 
+
 class ActionModule(ActionBase):
     def run(self, tmp=None, task_vars=None):
         super(ActionModule, self).run(tmp, task_vars)
         display = Display()
 
         # Initialize DynamicClient and grab the task args
-        host = self._task.args.get('host', None)
-        api_key = self._task.args.get('api_key', None)
+        host = self._task.args.get("host", None)
+        api_key = self._task.args.get("api_key", None)
 
         dynClient = get_api_client(api_key=api_key, host=host)
-        retries = self._task.args['retries']
-        delay = self._task.args['delay']
+        retries = self._task.args["retries"]
+        delay = self._task.args["delay"]
 
         display.v(f"Checking CatalogSources are ready ({retries} retries with a {delay} second delay)")
-        catalogSources = dynClient.resources.get(api_version="operators.coreos.com/v1alpha1", kind='CatalogSource')
+        catalogSources = dynClient.resources.get(api_version="operators.coreos.com/v1alpha1", kind="CatalogSource")
 
         allReady = False
         attempts = 0
         while attempts < retries and not allReady:
-          catalogs = catalogSources.get()
-          attempts += 1
-          allReadyThisLoop = True
-          ready = []
-          notReady = []
+            catalogs = catalogSources.get()
+            attempts += 1
+            allReadyThisLoop = True
+            ready = []
+            notReady = []
 
-          for catalogSource in catalogs.items:
-            message = f"{catalogSource.metadata.namespace}/{catalogSource.metadata.name} = {catalogSource.status.connectionState.lastObservedState}"
-            display.v(f"* {message}")
-            if catalogSource.status.connectionState.lastObservedState != "READY":
-              allReadyThisLoop = False
-              notReady.append(message)
+            for catalogSource in catalogs.items:
+                # Check if status fields exist before accessing them
+                if not hasattr(catalogSource, "status") or catalogSource.status is None:
+                    message = f"{catalogSource.metadata.namespace}/{catalogSource.metadata.name} = <status not initialized>"
+                    display.v(f"* {message}")
+                    allReadyThisLoop = False
+                    notReady.append(message)
+                elif not hasattr(catalogSource.status, "connectionState") or catalogSource.status.connectionState is None:
+                    message = f"{catalogSource.metadata.namespace}/{catalogSource.metadata.name} = <connectionState not initialized>"
+                    display.v(f"* {message}")
+                    allReadyThisLoop = False
+                    notReady.append(message)
+                elif not hasattr(catalogSource.status.connectionState, "lastObservedState") or catalogSource.status.connectionState.lastObservedState is None:
+                    message = f"{catalogSource.metadata.namespace}/{catalogSource.metadata.name} = <lastObservedState not initialized>"
+                    display.v(f"* {message}")
+                    allReadyThisLoop = False
+                    notReady.append(message)
+                else:
+                    message = f"{catalogSource.metadata.namespace}/{catalogSource.metadata.name} = {catalogSource.status.connectionState.lastObservedState}"
+                    display.v(f"* {message}")
+                    if catalogSource.status.connectionState.lastObservedState != "READY":
+                        allReadyThisLoop = False
+                        notReady.append(message)
+                    else:
+                        ready.append(message)
+
+            if allReadyThisLoop:
+                allReady = True
             else:
-              ready.append(message)
-
-          if allReadyThisLoop:
-            allReady = True
-          else:
-            display.v(f"Delaying {delay} seconds before next check")
-            time.sleep(delay)
+                display.v(f"Delaying {delay} seconds before next check")
+                time.sleep(delay)
 
         if allReady:
-          return dict(
-            message="All CatalogSources are ready",
-            failed=False,
-            changed=False,
-            ready=ready,
-            notReady=notReady
-          )
+            return dict(message="All CatalogSources are ready", failed=False, changed=False, ready=ready, notReady=notReady)
         else:
-          raise AnsibleError(f"Error: One or more CatalogSources are not ready")
+            raise AnsibleError("Error: One or more CatalogSources are not ready")

--- a/ibm/mas_devops/tests/unit/plugins/action/test_verify_catalogsources.py
+++ b/ibm/mas_devops/tests/unit/plugins/action/test_verify_catalogsources.py
@@ -6,11 +6,12 @@ are ready with retry logic.
 """
 
 import pytest
-from unittest.mock import Mock, MagicMock, patch
+from unittest.mock import Mock, patch
 from ansible.errors import AnsibleError
 
 # Import the action module
 import verify_catalogsources
+
 ActionModule = verify_catalogsources.ActionModule
 
 
@@ -26,23 +27,18 @@ class TestVerifyCatalogSources:
     def test_all_catalogsources_ready_first_attempt(self, action_module, mock_display):
         """Test when all CatalogSources are ready on first attempt."""
         # Arrange
-        action_module._task.args = {
-            'host': 'https://api.example.com',
-            'api_key': 'test-key',
-            'retries': 3,
-            'delay': 5
-        }
+        action_module._task.args = {"host": "https://api.example.com", "api_key": "test-key", "retries": 3, "delay": 5}
 
         # Create mock catalog sources
         mock_catalog1 = Mock()
-        mock_catalog1.metadata.namespace = 'openshift-marketplace'
-        mock_catalog1.metadata.name = 'ibm-operator-catalog'
-        mock_catalog1.status.connectionState.lastObservedState = 'READY'
+        mock_catalog1.metadata.namespace = "openshift-marketplace"
+        mock_catalog1.metadata.name = "ibm-operator-catalog"
+        mock_catalog1.status.connectionState.lastObservedState = "READY"
 
         mock_catalog2 = Mock()
-        mock_catalog2.metadata.namespace = 'openshift-marketplace'
-        mock_catalog2.metadata.name = 'certified-operators'
-        mock_catalog2.status.connectionState.lastObservedState = 'READY'
+        mock_catalog2.metadata.namespace = "openshift-marketplace"
+        mock_catalog2.metadata.name = "certified-operators"
+        mock_catalog2.status.connectionState.lastObservedState = "READY"
 
         mock_catalogs = Mock()
         mock_catalogs.items = [mock_catalog1, mock_catalog2]
@@ -57,44 +53,39 @@ class TestVerifyCatalogSources:
         mock_client.resources = mock_resources
 
         # Act
-        with patch('verify_catalogsources.get_api_client', return_value=mock_client):
+        with patch("verify_catalogsources.get_api_client", return_value=mock_client):
             result = action_module.run()
 
         # Assert
-        assert result['failed'] is False
-        assert result['changed'] is False
-        assert result['message'] == "All CatalogSources are ready"
-        assert len(result['ready']) == 2
-        assert len(result['notReady']) == 0
-        assert 'openshift-marketplace/ibm-operator-catalog = READY' in result['ready']
-        assert 'openshift-marketplace/certified-operators = READY' in result['ready']
+        assert result["failed"] is False
+        assert result["changed"] is False
+        assert result["message"] == "All CatalogSources are ready"
+        assert len(result["ready"]) == 2
+        assert len(result["notReady"]) == 0
+        assert "openshift-marketplace/ibm-operator-catalog = READY" in result["ready"]
+        assert "openshift-marketplace/certified-operators = READY" in result["ready"]
 
     def test_catalogsources_ready_after_retry(self, action_module, mock_display):
         """Test when CatalogSources become ready after retry."""
         # Arrange
-        action_module._task.args = {
-            'host': 'https://api.example.com',
-            'api_key': 'test-key',
-            'retries': 3,
-            'delay': 1
-        }
+        action_module._task.args = {"host": "https://api.example.com", "api_key": "test-key", "retries": 3, "delay": 1}
 
         # Create mock catalog that transitions from CONNECTING to READY
         mock_catalog = Mock()
-        mock_catalog.metadata.namespace = 'openshift-marketplace'
-        mock_catalog.metadata.name = 'ibm-operator-catalog'
+        mock_catalog.metadata.namespace = "openshift-marketplace"
+        mock_catalog.metadata.name = "ibm-operator-catalog"
 
         # First call: CONNECTING, second call: READY
-        mock_catalog.status.connectionState.lastObservedState = 'CONNECTING'
+        mock_catalog.status.connectionState.lastObservedState = "CONNECTING"
 
         mock_catalogs_first = Mock()
         mock_catalogs_first.items = [mock_catalog]
 
         # Create second catalog state
         mock_catalog_ready = Mock()
-        mock_catalog_ready.metadata.namespace = 'openshift-marketplace'
-        mock_catalog_ready.metadata.name = 'ibm-operator-catalog'
-        mock_catalog_ready.status.connectionState.lastObservedState = 'READY'
+        mock_catalog_ready.metadata.namespace = "openshift-marketplace"
+        mock_catalog_ready.metadata.name = "ibm-operator-catalog"
+        mock_catalog_ready.status.connectionState.lastObservedState = "READY"
 
         mock_catalogs_second = Mock()
         mock_catalogs_second.items = [mock_catalog_ready]
@@ -109,33 +100,28 @@ class TestVerifyCatalogSources:
         mock_client.resources = mock_resources
 
         # Act
-        with patch('verify_catalogsources.get_api_client', return_value=mock_client):
-            with patch('verify_catalogsources.time.sleep') as mock_sleep:
+        with patch("verify_catalogsources.get_api_client", return_value=mock_client):
+            with patch("verify_catalogsources.time.sleep") as mock_sleep:
                 result = action_module.run()
 
         # Assert
-        assert result['failed'] is False
-        assert result['changed'] is False
-        assert result['message'] == "All CatalogSources are ready"
-        assert len(result['ready']) == 1
-        assert len(result['notReady']) == 0
+        assert result["failed"] is False
+        assert result["changed"] is False
+        assert result["message"] == "All CatalogSources are ready"
+        assert len(result["ready"]) == 1
+        assert len(result["notReady"]) == 0
         mock_sleep.assert_called_once_with(1)
 
     def test_catalogsources_not_ready_after_retries(self, action_module, mock_display):
         """Test when CatalogSources remain not ready after all retries."""
         # Arrange
-        action_module._task.args = {
-            'host': 'https://api.example.com',
-            'api_key': 'test-key',
-            'retries': 2,
-            'delay': 1
-        }
+        action_module._task.args = {"host": "https://api.example.com", "api_key": "test-key", "retries": 2, "delay": 1}
 
         # Create mock catalog that stays CONNECTING
         mock_catalog = Mock()
-        mock_catalog.metadata.namespace = 'openshift-marketplace'
-        mock_catalog.metadata.name = 'ibm-operator-catalog'
-        mock_catalog.status.connectionState.lastObservedState = 'CONNECTING'
+        mock_catalog.metadata.namespace = "openshift-marketplace"
+        mock_catalog.metadata.name = "ibm-operator-catalog"
+        mock_catalog.status.connectionState.lastObservedState = "CONNECTING"
 
         mock_catalogs = Mock()
         mock_catalogs.items = [mock_catalog]
@@ -150,32 +136,27 @@ class TestVerifyCatalogSources:
         mock_client.resources = mock_resources
 
         # Act & Assert
-        with patch('verify_catalogsources.get_api_client', return_value=mock_client):
-            with patch('verify_catalogsources.time.sleep'):
+        with patch("verify_catalogsources.get_api_client", return_value=mock_client):
+            with patch("verify_catalogsources.time.sleep"):
                 with pytest.raises(AnsibleError, match="One or more CatalogSources are not ready"):
                     action_module.run()
 
     def test_mixed_catalogsources_states(self, action_module, mock_display):
         """Test with mix of ready and not ready CatalogSources."""
         # Arrange
-        action_module._task.args = {
-            'host': 'https://api.example.com',
-            'api_key': 'test-key',
-            'retries': 1,
-            'delay': 1
-        }
+        action_module._task.args = {"host": "https://api.example.com", "api_key": "test-key", "retries": 1, "delay": 1}
 
         # Create ready catalog
         mock_catalog1 = Mock()
-        mock_catalog1.metadata.namespace = 'openshift-marketplace'
-        mock_catalog1.metadata.name = 'certified-operators'
-        mock_catalog1.status.connectionState.lastObservedState = 'READY'
+        mock_catalog1.metadata.namespace = "openshift-marketplace"
+        mock_catalog1.metadata.name = "certified-operators"
+        mock_catalog1.status.connectionState.lastObservedState = "READY"
 
         # Create not ready catalog
         mock_catalog2 = Mock()
-        mock_catalog2.metadata.namespace = 'openshift-marketplace'
-        mock_catalog2.metadata.name = 'ibm-operator-catalog'
-        mock_catalog2.status.connectionState.lastObservedState = 'CONNECTING'
+        mock_catalog2.metadata.namespace = "openshift-marketplace"
+        mock_catalog2.metadata.name = "ibm-operator-catalog"
+        mock_catalog2.status.connectionState.lastObservedState = "CONNECTING"
 
         mock_catalogs = Mock()
         mock_catalogs.items = [mock_catalog1, mock_catalog2]
@@ -190,20 +171,15 @@ class TestVerifyCatalogSources:
         mock_client.resources = mock_resources
 
         # Act & Assert
-        with patch('verify_catalogsources.get_api_client', return_value=mock_client):
-            with patch('verify_catalogsources.time.sleep'):
+        with patch("verify_catalogsources.get_api_client", return_value=mock_client):
+            with patch("verify_catalogsources.time.sleep"):
                 with pytest.raises(AnsibleError, match="One or more CatalogSources are not ready"):
                     action_module.run()
 
     def test_no_catalogsources_found(self, action_module, mock_display):
         """Test when no CatalogSources are found."""
         # Arrange
-        action_module._task.args = {
-            'host': 'https://api.example.com',
-            'api_key': 'test-key',
-            'retries': 1,
-            'delay': 1
-        }
+        action_module._task.args = {"host": "https://api.example.com", "api_key": "test-key", "retries": 1, "delay": 1}
 
         mock_catalogs = Mock()
         mock_catalogs.items = []
@@ -218,33 +194,28 @@ class TestVerifyCatalogSources:
         mock_client.resources = mock_resources
 
         # Act
-        with patch('verify_catalogsources.get_api_client', return_value=mock_client):
+        with patch("verify_catalogsources.get_api_client", return_value=mock_client):
             result = action_module.run()
 
         # Assert
-        assert result['failed'] is False
-        assert result['changed'] is False
-        assert result['message'] == "All CatalogSources are ready"
-        assert len(result['ready']) == 0
-        assert len(result['notReady']) == 0
+        assert result["failed"] is False
+        assert result["changed"] is False
+        assert result["message"] == "All CatalogSources are ready"
+        assert len(result["ready"]) == 0
+        assert len(result["notReady"]) == 0
 
     def test_with_custom_host_and_api_key(self, action_module, mock_display):
         """Test with custom host and API key."""
         # Arrange
-        custom_host = 'https://custom.api.com:6443'
-        custom_api_key = 'custom-key-123'
+        custom_host = "https://custom.api.com:6443"
+        custom_api_key = "custom-key-123"
 
-        action_module._task.args = {
-            'host': custom_host,
-            'api_key': custom_api_key,
-            'retries': 1,
-            'delay': 1
-        }
+        action_module._task.args = {"host": custom_host, "api_key": custom_api_key, "retries": 1, "delay": 1}
 
         mock_catalog = Mock()
-        mock_catalog.metadata.namespace = 'openshift-marketplace'
-        mock_catalog.metadata.name = 'test-catalog'
-        mock_catalog.status.connectionState.lastObservedState = 'READY'
+        mock_catalog.metadata.namespace = "openshift-marketplace"
+        mock_catalog.metadata.name = "test-catalog"
+        mock_catalog.status.connectionState.lastObservedState = "READY"
 
         mock_catalogs = Mock()
         mock_catalogs.items = [mock_catalog]
@@ -259,31 +230,26 @@ class TestVerifyCatalogSources:
         mock_client.resources = mock_resources
 
         # Act
-        with patch('verify_catalogsources.get_api_client', return_value=mock_client) as mock_get_client:
+        with patch("verify_catalogsources.get_api_client", return_value=mock_client) as mock_get_client:
             result = action_module.run()
 
         # Assert
         mock_get_client.assert_called_once_with(api_key=custom_api_key, host=custom_host)
-        assert result['failed'] is False
+        assert result["failed"] is False
 
     def test_catalogsource_with_different_states(self, action_module, mock_display):
         """Test CatalogSources with various connection states."""
         # Arrange
-        action_module._task.args = {
-            'host': 'https://api.example.com',
-            'api_key': 'test-key',
-            'retries': 1,
-            'delay': 1
-        }
+        action_module._task.args = {"host": "https://api.example.com", "api_key": "test-key", "retries": 1, "delay": 1}
 
         # Create catalogs with different states
-        states = ['READY', 'CONNECTING', 'TRANSIENT_FAILURE', 'IDLE']
+        states = ["READY", "CONNECTING", "TRANSIENT_FAILURE", "IDLE"]
         mock_catalogs_list = []
 
         for i, state in enumerate(states):
             mock_catalog = Mock()
-            mock_catalog.metadata.namespace = 'openshift-marketplace'
-            mock_catalog.metadata.name = f'catalog-{i}'
+            mock_catalog.metadata.namespace = "openshift-marketplace"
+            mock_catalog.metadata.name = f"catalog-{i}"
             mock_catalog.status.connectionState.lastObservedState = state
             mock_catalogs_list.append(mock_catalog)
 
@@ -300,9 +266,229 @@ class TestVerifyCatalogSources:
         mock_client.resources = mock_resources
 
         # Act & Assert
-        with patch('verify_catalogsources.get_api_client', return_value=mock_client):
-            with patch('verify_catalogsources.time.sleep'):
+        with patch("verify_catalogsources.get_api_client", return_value=mock_client):
+            with patch("verify_catalogsources.time.sleep"):
                 with pytest.raises(AnsibleError, match="One or more CatalogSources are not ready"):
                     action_module.run()
+
+    def test_catalogsource_without_status_field(self, action_module, mock_display):
+        """Test CatalogSource without status field initialized."""
+        # Arrange
+        action_module._task.args = {"host": "https://api.example.com", "api_key": "test-key", "retries": 2, "delay": 1}
+
+        # Create catalog without status attribute
+        mock_catalog_no_status = Mock(spec=["metadata"])
+        mock_catalog_no_status.metadata.namespace = "openshift-marketplace"
+        mock_catalog_no_status.metadata.name = "uninitialized-catalog"
+        # Explicitly ensure status doesn't exist
+        del mock_catalog_no_status.status
+
+        # Create ready catalog for second attempt
+        mock_catalog_ready = Mock()
+        mock_catalog_ready.metadata.namespace = "openshift-marketplace"
+        mock_catalog_ready.metadata.name = "uninitialized-catalog"
+        mock_catalog_ready.status.connectionState.lastObservedState = "READY"
+
+        mock_catalogs_first = Mock()
+        mock_catalogs_first.items = [mock_catalog_no_status]
+
+        mock_catalogs_second = Mock()
+        mock_catalogs_second.items = [mock_catalog_ready]
+
+        mock_catalog_resource = Mock()
+        mock_catalog_resource.get.side_effect = [mock_catalogs_first, mock_catalogs_second]
+
+        mock_resources = Mock()
+        mock_resources.get.return_value = mock_catalog_resource
+
+        mock_client = Mock()
+        mock_client.resources = mock_resources
+
+        # Act
+        with patch("verify_catalogsources.get_api_client", return_value=mock_client):
+            with patch("verify_catalogsources.time.sleep") as mock_sleep:
+                result = action_module.run()
+
+        # Assert
+        assert result["failed"] is False
+        assert result["changed"] is False
+        assert result["message"] == "All CatalogSources are ready"
+        assert len(result["ready"]) == 1
+        assert len(result["notReady"]) == 0
+        mock_sleep.assert_called_once_with(1)
+
+    def test_catalogsource_without_connectionState_field(self, action_module, mock_display):
+        """Test CatalogSource with status but no connectionState field."""
+        # Arrange
+        action_module._task.args = {"host": "https://api.example.com", "api_key": "test-key", "retries": 2, "delay": 1}
+
+        # Create catalog with status but no connectionState
+        mock_catalog_no_connection = Mock()
+        mock_catalog_no_connection.metadata.namespace = "openshift-marketplace"
+        mock_catalog_no_connection.metadata.name = "partial-catalog"
+        mock_catalog_no_connection.status = Mock(spec=[])
+        del mock_catalog_no_connection.status.connectionState
+
+        # Create ready catalog for second attempt
+        mock_catalog_ready = Mock()
+        mock_catalog_ready.metadata.namespace = "openshift-marketplace"
+        mock_catalog_ready.metadata.name = "partial-catalog"
+        mock_catalog_ready.status.connectionState.lastObservedState = "READY"
+
+        mock_catalogs_first = Mock()
+        mock_catalogs_first.items = [mock_catalog_no_connection]
+
+        mock_catalogs_second = Mock()
+        mock_catalogs_second.items = [mock_catalog_ready]
+
+        mock_catalog_resource = Mock()
+        mock_catalog_resource.get.side_effect = [mock_catalogs_first, mock_catalogs_second]
+
+        mock_resources = Mock()
+        mock_resources.get.return_value = mock_catalog_resource
+
+        mock_client = Mock()
+        mock_client.resources = mock_resources
+
+        # Act
+        with patch("verify_catalogsources.get_api_client", return_value=mock_client):
+            with patch("verify_catalogsources.time.sleep") as mock_sleep:
+                result = action_module.run()
+
+        # Assert
+        assert result["failed"] is False
+        assert result["changed"] is False
+        assert result["message"] == "All CatalogSources are ready"
+        assert len(result["ready"]) == 1
+        assert len(result["notReady"]) == 0
+        mock_sleep.assert_called_once_with(1)
+
+    def test_catalogsource_without_lastObservedState_field(self, action_module, mock_display):
+        """Test CatalogSource with connectionState but no lastObservedState field."""
+        # Arrange
+        action_module._task.args = {"host": "https://api.example.com", "api_key": "test-key", "retries": 2, "delay": 1}
+
+        # Create catalog with connectionState but no lastObservedState
+        mock_catalog_no_state = Mock()
+        mock_catalog_no_state.metadata.namespace = "openshift-marketplace"
+        mock_catalog_no_state.metadata.name = "incomplete-catalog"
+        mock_catalog_no_state.status.connectionState = Mock(spec=[])
+        del mock_catalog_no_state.status.connectionState.lastObservedState
+
+        # Create ready catalog for second attempt
+        mock_catalog_ready = Mock()
+        mock_catalog_ready.metadata.namespace = "openshift-marketplace"
+        mock_catalog_ready.metadata.name = "incomplete-catalog"
+        mock_catalog_ready.status.connectionState.lastObservedState = "READY"
+
+        mock_catalogs_first = Mock()
+        mock_catalogs_first.items = [mock_catalog_no_state]
+
+        mock_catalogs_second = Mock()
+        mock_catalogs_second.items = [mock_catalog_ready]
+
+        mock_catalog_resource = Mock()
+        mock_catalog_resource.get.side_effect = [mock_catalogs_first, mock_catalogs_second]
+
+        mock_resources = Mock()
+        mock_resources.get.return_value = mock_catalog_resource
+
+        mock_client = Mock()
+        mock_client.resources = mock_resources
+
+        # Act
+        with patch("verify_catalogsources.get_api_client", return_value=mock_client):
+            with patch("verify_catalogsources.time.sleep") as mock_sleep:
+                result = action_module.run()
+
+        # Assert
+        assert result["failed"] is False
+        assert result["changed"] is False
+        assert result["message"] == "All CatalogSources are ready"
+        assert len(result["ready"]) == 1
+        assert len(result["notReady"]) == 0
+        mock_sleep.assert_called_once_with(1)
+
+    def test_catalogsource_status_none(self, action_module, mock_display):
+        """Test CatalogSource with status explicitly set to None."""
+        # Arrange
+        action_module._task.args = {"host": "https://api.example.com", "api_key": "test-key", "retries": 1, "delay": 1}
+
+        # Create catalog with status = None
+        mock_catalog = Mock()
+        mock_catalog.metadata.namespace = "openshift-marketplace"
+        mock_catalog.metadata.name = "null-status-catalog"
+        mock_catalog.status = None
+
+        mock_catalogs = Mock()
+        mock_catalogs.items = [mock_catalog]
+
+        mock_catalog_resource = Mock()
+        mock_catalog_resource.get.return_value = mock_catalogs
+
+        mock_resources = Mock()
+        mock_resources.get.return_value = mock_catalog_resource
+
+        mock_client = Mock()
+        mock_client.resources = mock_resources
+
+        # Act & Assert
+        with patch("verify_catalogsources.get_api_client", return_value=mock_client):
+            with patch("verify_catalogsources.time.sleep"):
+                with pytest.raises(AnsibleError, match="One or more CatalogSources are not ready"):
+                    action_module.run()
+
+    def test_mixed_initialized_and_uninitialized_catalogsources(self, action_module, mock_display):
+        """Test mix of fully initialized and partially initialized CatalogSources."""
+        # Arrange
+        action_module._task.args = {"host": "https://api.example.com", "api_key": "test-key", "retries": 2, "delay": 1}
+
+        # Create ready catalog
+        mock_catalog_ready = Mock()
+        mock_catalog_ready.metadata.namespace = "openshift-marketplace"
+        mock_catalog_ready.metadata.name = "ready-catalog"
+        mock_catalog_ready.status.connectionState.lastObservedState = "READY"
+
+        # Create catalog without status
+        mock_catalog_no_status = Mock(spec=["metadata"])
+        mock_catalog_no_status.metadata.namespace = "openshift-marketplace"
+        mock_catalog_no_status.metadata.name = "uninitialized-catalog"
+        del mock_catalog_no_status.status
+
+        # First attempt: one ready, one uninitialized
+        mock_catalogs_first = Mock()
+        mock_catalogs_first.items = [mock_catalog_ready, mock_catalog_no_status]
+
+        # Second attempt: both ready
+        mock_catalog_now_ready = Mock()
+        mock_catalog_now_ready.metadata.namespace = "openshift-marketplace"
+        mock_catalog_now_ready.metadata.name = "uninitialized-catalog"
+        mock_catalog_now_ready.status.connectionState.lastObservedState = "READY"
+
+        mock_catalogs_second = Mock()
+        mock_catalogs_second.items = [mock_catalog_ready, mock_catalog_now_ready]
+
+        mock_catalog_resource = Mock()
+        mock_catalog_resource.get.side_effect = [mock_catalogs_first, mock_catalogs_second]
+
+        mock_resources = Mock()
+        mock_resources.get.return_value = mock_catalog_resource
+
+        mock_client = Mock()
+        mock_client.resources = mock_resources
+
+        # Act
+        with patch("verify_catalogsources.get_api_client", return_value=mock_client):
+            with patch("verify_catalogsources.time.sleep") as mock_sleep:
+                result = action_module.run()
+
+        # Assert
+        assert result["failed"] is False
+        assert result["changed"] is False
+        assert result["message"] == "All CatalogSources are ready"
+        assert len(result["ready"]) == 2
+        assert len(result["notReady"]) == 0
+        mock_sleep.assert_called_once_with(1)
+
 
 # Made with Bob

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.black]
+line-length = 160
+
+[tool.flake8]
+max-line-length = 160


### PR DESCRIPTION
## Description

Fixes timing window where status resource is not fully initialized yet:
```
15 May, 14:23:46 TASK [ibm.mas_devops.ocp_verify : Check if cluster is ready] *******************
15 May, 14:23:48 FAILED - RETRYING: [localhost]: Check if cluster is ready (60 retries left).
15 May, 14:24:49 FAILED - RETRYING: [localhost]: Check if cluster is ready (59 retries left).
15 May, 14:25:50 FAILED - RETRYING: [localhost]: Check if cluster is ready (58 retries left).
15 May, 14:26:51 FAILED - RETRYING: [localhost]: Check if cluster is ready (57 retries left).
15 May, 14:27:52 FAILED - RETRYING: [localhost]: Check if cluster is ready (56 retries left).
15 May, 14:28:54 FAILED - RETRYING: [localhost]: Check if cluster is ready (55 retries left).
15 May, 14:29:55 FAILED - RETRYING: [localhost]: Check if cluster is ready (54 retries left).
15 May, 14:30:56 FAILED - RETRYING: [localhost]: Check if cluster is ready (53 retries left).
15 May, 14:31:57 FAILED - RETRYING: [localhost]: Check if cluster is ready (52 retries left).
15 May, 14:32:58 FAILED - RETRYING: [localhost]: Check if cluster is ready (51 retries left).
15 May, 14:33:59 FAILED - RETRYING: [localhost]: Check if cluster is ready (50 retries left).
15 May, 14:35:00 FAILED - RETRYING: [localhost]: Check if cluster is ready (49 retries left).
15 May, 14:36:01 ok: [localhost] => {"api_found": true, "attempts": 13, "changed": false, "resources": [{"apiVersion": "[config.openshift.io/v1](http://config.openshift.io/v1)", "kind": "ClusterVersion", "metadata": {"annotations": {"[kubectl.kubernetes.io/last-applied-configuration](http://kubectl.kubernetes.io/last-applied-configuration)": "{\"apiVersion\":\"[config.openshift.io/v1\",\"kind\":\"ClusterVersion\",\"metadata\":{\"annotations\":{},\"creationTimestamp\":null,\"name\":\"version\"},\"spec\":{\"capabilities\":{\"additionalEnabledCapabilities\":[\"Build\",\"CSISnapshot\",\"CloudControllerManager\",\"CloudCredential\",\"Console\",\"DeploymentConfig\",\"ImageRegistry\",\"Ingress\",\"Insights\",\"MachineAPI\",\"NodeTuning\",\"OperatorLifecycleManager\",\"OperatorLifecycleManagerV1\",\"Storage\",\"marketplace\",\"openshift-samples\"],\"baselineCapabilitySet\":\"None\"},\"clusterID\":\"4c0d484b-bb73-4c44-b17a-f135a74b7785\",\"signatureStores\":null},\"status\":{\"availableUpdates\":null,\"capabilities\":{},\"desired\":{\"image\":\"\",\"version\":\"\"},\"observedGeneration\":0,\"versionHash\":\"\"}}\n"](http://config.openshift.io/v1/%22,/%22kind/%22:/%22ClusterVersion/%22,/%22metadata/%22:%7B/%22annotations/%22:%7B%7D,/%22creationTimestamp/%22:null,/%22name/%22:/%22version/%22%7D,/%22spec/%22:%7B/%22capabilities/%22:%7B/%22additionalEnabledCapabilities/%22:[/%22Build/%22,/%22CSISnapshot/%22,/%22CloudControllerManager/%22,/%22CloudCredential/%22,/%22Console/%22,/%22DeploymentConfig/%22,/%22ImageRegistry/%22,/%22Ingress/%22,/%22Insights/%22,/%22MachineAPI/%22,/%22NodeTuning/%22,/%22OperatorLifecycleManager/%22,/%22OperatorLifecycleManagerV1/%22,/%22Storage/%22,/%22marketplace/%22,/%22openshift-samples/%22],/%22baselineCapabilitySet/%22:/%22None/%22%7D,/%22clusterID/%22:/%224c0d484b-bb73-4c44-b17a-f135a74b7785/%22,/%22signatureStores/%22:null%7D,/%22status/%22:%7B/%22availableUpdates/%22:null,/%22capabilities/%22:%7B%7D,/%22desired/%22:%7B/%22image/%22:/%22/%22,/%22version/%22:/%22/%22%7D,/%22observedGeneration/%22:0,/%22versionHash/%22:/%22/%22%7D%7D/n%22)}, "creationTimestamp": "2026-05-15T13:05:04Z", "generation": 1, "managedFields": [{"apiVersion": "[config.openshift.io/v1](http://config.openshift.io/v1)", "fieldsType": "FieldsV1", "fieldsV1": {"f:metadata": {"f:annotations": {".": {}, "f:kubectl.kubernetes.io/last-applied-configuration": {}}}, "f:spec": {".": {}, "f:capabilities": {".": {}, "f:additionalEnabledCapabilities": {}, "f:baselineCapabilitySet": {}}, "f:clusterID": {}}}, "manager": "kubectl-client-side-apply", "operation": "Update", "time": "2026-05-15T13:05:04Z"}, {"apiVersion": "[config.openshift.io/v1](http://config.openshift.io/v1)", "fieldsType": "FieldsV1", "fieldsV1": {"f:status": {".": {}, "f:availableUpdates": {}, "f:capabilities": {".": {}, "f:enabledCapabilities": {}, "f:knownCapabilities": {}}, "f:conditions": {".": {}, "k:{\"type\":\"Available\"}": {".": {}, "f:lastTransitionTime": {}, "f:message": {}, "f:status": {}, "f:type": {}}, "k:{\"type\":\"Failing\"}": {".": {}, "f:lastTransitionTime": {}, "f:status": {}, "f:type": {}}, "k:{\"type\":\"ImplicitlyEnabledCapabilities\"}": {".": {}, "f:lastTransitionTime": {}, "f:message": {}, "f:reason": {}, "f:status": {}, "f:type": {}}, "k:{\"type\":\"Progressing\"}": {".": {}, "f:lastTransitionTime": {}, "f:message": {}, "f:status": {}, "f:type": {}}, "k:{\"type\":\"ReleaseAccepted\"}": {".": {}, "f:lastTransitionTime": {}, "f:message": {}, "f:reason": {}, "f:status": {}, "f:type": {}}, "k:{\"type\":\"RetrievedUpdates\"}": {".": {}, "f:lastTransitionTime": {}, "f:message": {}, "f:reason": {}, "f:status": {}, "f:type": {}}, "k:{\"type\":\"Upgradeable\"}": {".": {}, "f:lastTransitionTime": {}, "f:message": {}, "f:reason": {}, "f:status": {}, "f:type": {}}}, "f:desired": {".": {}, "f:image": {}, "f:url": {}, "f:version": {}}, "f:history": {}, "f:observedGeneration": {}, "f:versionHash": {}}}, "manager": "cluster-version-operator", "operation": "Update", "subresource": "status", "time": "2026-05-15T13:35:27Z"}], "name": "version", "resourceVersion": "14716", "uid": "0f292752-7d6e-4397-890a-095af016bc40"}, "spec": {"capabilities": {"additionalEnabledCapabilities": ["Build", "CSISnapshot", "CloudControllerManager", "CloudCredential", "Console", "DeploymentConfig", "ImageRegistry", "Ingress", "Insights", "MachineAPI", "NodeTuning", "OperatorLifecycleManager", "OperatorLifecycleManagerV1", "Storage", "marketplace", "openshift-samples"], "baselineCapabilitySet": "None"}, "clusterID": "4c0d484b-bb73-4c44-b17a-f135a74b7785"}, "status": {"availableUpdates": null, "capabilities": {"enabledCapabilities": ["Build", "CSISnapshot", "CloudControllerManager", "CloudCredential", "Console", "DeploymentConfig", "ImageRegistry", "Ingress", "Insights", "MachineAPI", "NodeTuning", "OperatorLifecycleManager", "OperatorLifecycleManagerV1", "Storage", "marketplace", "openshift-samples"], "knownCapabilities": ["Build", "CSISnapshot", "CloudControllerManager", "CloudCredential", "Console", "DeploymentConfig", "ImageRegistry", "Ingress", "Insights", "MachineAPI", "NodeTuning", "OperatorLifecycleManager", "OperatorLifecycleManagerV1", "Storage", "baremetal", "marketplace", "openshift-samples"]}, "conditions": [{"lastTransitionTime": "2026-05-15T13:05:12Z", "message": "The update channel has not been configured.", "reason": "NoChannel", "status": "False", "type": "RetrievedUpdates"}, {"lastTransitionTime": "2026-05-15T13:05:12Z", "message": "Capabilities match configured spec", "reason": "AsExpected", "status": "False", "type": "ImplicitlyEnabledCapabilities"}, {"lastTransitionTime": "2026-05-15T13:05:12Z", "message": "Payload loaded version=\"4.20.18\" image=\"[us.icr.io/armada-****/ocp-release@sha256:2dab927fd20984e247301b2483083b71f942a1f550f5d8a1db42897edc042e39\](http://us.icr.io/armada-****/ocp-release@sha256:2dab927fd20984e247301b2483083b71f942a1f550f5d8a1db42897edc042e39/)" architecture=\"amd64\"", "reason": "PayloadLoaded", "status": "True", "type": "ReleaseAccepted"}, {"lastTransitionTime": "2026-05-15T13:35:27Z", "message": "Done applying 4.20.18", "status": "True", "type": "Available"}, {"lastTransitionTime": "2026-05-15T13:35:23Z", "status": "False", "type": "Failing"}, {"lastTransitionTime": "2026-05-15T13:35:27Z", "message": "Cluster version is 4.20.18", "status": "False", "type": "Progressing"}, {"lastTransitionTime": "2026-05-15T13:05:27Z", "message": "An update is already in progress and the details are in the Progressing condition", "reason": "UpdateInProgress", "status": "False", "type": "Upgradeable"}], "desired": {"image": "[us.icr.io/armada-****/ocp-release@sha256:2dab927fd20984e247301b2483083b71f942a1f550f5d8a1db42897edc042e39](http://us.icr.io/armada-****/ocp-release@sha256:2dab927fd20984e247301b2483083b71f942a1f550f5d8a1db42897edc042e39)", "url": "https://access.redhat.com/errata/RHSA-2026:6564", "version": "4.20.18"}, "history": [{"completionTime": "2026-05-15T13:35:27Z", "image": "[us.icr.io/armada-****/ocp-release@sha256:2dab927fd20984e247301b2483083b71f942a1f550f5d8a1db42897edc042e39](http://us.icr.io/armada-****/ocp-release@sha256:2dab927fd20984e247301b2483083b71f942a1f550f5d8a1db42897edc042e39)", "startedTime": "2026-05-15T13:05:12Z", "state": "Completed", "verified": false, "version": "4.20.18"}], "observedGeneration": 1, "versionHash": "JO42CFE49AQ="}}]}
15 May, 14:36:02 
15 May, 14:36:02 TASK [ibm.mas_devops.ocp_verify : Check CatalogSource Status] ******************
15 May, 14:36:02 Checking CatalogSources are ready (30 retries with a 60 second delay)
15 May, 14:36:02 [ERROR]: Task failed: 'NoneType' object has no attribute 'lastObservedState'
15 May, 14:36:02 Origin: /opt/app-root/lib64/python3.12/site-packages/ansible_collections/ibm/mas_devops/roles/ocp_verify/tasks/main.yml:19:3
15 May, 14:36:02 
15 May, 14:36:02 17 # 2. Wait for all catalogsources to be healthy
15 May, 14:36:02 18 # -----------------------------------------------------------------------------
15 May, 14:36:02 19 - name: Check CatalogSource Status
15 May, 14:36:02      ^ column 3
15 May, 14:36:02 
15 May, 14:36:02 fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task failed: 'NoneType' object has no attribute 'lastObservedState'"}
15 May, 14:36:02 
15 May, 14:36:02 PLAY RECAP *********************************************************************
15 May, 14:36:02 localhost                  : ok=36   changed=10   unreachable=0    failed=1    skipped=25   rescued=0    ignored=0
```

## Test Results
New unit tests delivered

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
