### PR TITLE
[minor] Add intelligent timeout for Manage configuration

### DIFF
--- a/.bob/plans/2026-05-16-manage-timeout-calculation.md
+++ b/.bob/plans/2026-05-16-manage-timeout-calculation.md
@@ -1,0 +1,75 @@
+# Dynamic Manage Configuration Timeout Implementation
+
+## Objective
+Implement a Python-based filter to calculate appropriate timeout values for Manage app configuration based on the components being installed, replacing the current fixed 18-hour timeout that causes slow failures.
+
+## Critical Rules
+- Must be implemented as an Ansible filter plugin in Python in a new dedicated file
+- Create `ibm/mas_devops/plugins/filter/manage_timeouts.py` for better organization
+- Must follow existing filter patterns and include `FilterModule` class
+- Must not introduce functional changes to existing timeout behavior for non-foundation installations
+- Must validate all changes with `black` and `flake8`
+- No copyright headers required (existing filters don't have them)
+
+## Context
+- Current timeout: `delay=360s * retries=180 = 64,800s (~18 hours)`
+- Foundation mode (empty components): Should use `~4 hours = 14,400s`
+- Full mode (with components): Should use current `~18 hours = 64,800s`
+- Variable `mas_appws_components` structure: `{'base': {'version': 'latest'}, 'health': {'version': 'latest'}}` or `None`/`{}`
+- Defined in [`ibm/mas_devops/roles/suite_app_config/defaults/main.yml:32`](ibm/mas_devops/roles/suite_app_config/defaults/main.yml:32)
+- Used in [`ibm/mas_devops/roles/suite_app_config/tasks/main.yml:138-139`](ibm/mas_devops/roles/suite_app_config/tasks/main.yml:138-139)
+
+## Execution Plan
+
+### Phase 1: Create New Filter Plugin File
+- [x] **1.1** Create `ibm/mas_devops/plugins/filter/manage_timeouts.py`
+  - [x] Add `calculate_manage_timeouts` filter function
+  - [x] Accept `mas_appws_components` parameter (dict or None)
+  - [x] Return dict with `delay` and `retries` keys
+  - [x] Foundation mode (empty/None): `delay=240, retries=60` (4 hours)
+  - [x] Full mode (has components): `delay=360, retries=180` (18 hours)
+  - [x] Include docstring following existing pattern in filters.py
+  - [x] Create `FilterModule` class with `filters()` method
+- [x] **1.2** Validate with `black` and `flake8`
+
+### Phase 2: Update Manage Variables
+- [x] **2.1** Modify [`ibm/mas_devops/roles/suite_app_config/vars/manage.yml:7-8`](ibm/mas_devops/roles/suite_app_config/vars/manage.yml:7-8)
+  - [x] Replace hardcoded values with filter call
+  - [x] Use pattern: `"{{ mas_appws_components | ibm.mas_devops.calculate_manage_timeouts }}"`
+  - [x] Extract `delay` and `retries` from returned dict
+  - [x] Preserve environment variable override capability
+
+### Phase 3: Create Unit Tests
+- [x] **3.1** Create test file `ibm/mas_devops/tests/unit/plugins/filter/test_calculate_manage_timeouts.py`
+  - [x] Test foundation mode (None, {}, empty dict)
+  - [x] Test full mode (with components)
+  - [x] Test return value structure
+  - [x] Follow existing test patterns from other filter tests
+- [x] **3.2** Run tests to validate implementation - All 7 tests passed
+
+### Phase 4: Validation
+- [x] **4.1** Run `black` on modified Python files
+- [x] **4.2** Run `flake8` on modified Python files
+- [x] **4.3** Verify no syntax errors in YAML files
+- [x] **4.4** Review changes ensure backward compatibility
+
+## Validation
+
+### Commands
+```bash
+# Format and lint Python changes
+black ibm/mas_devops/plugins/filter/manage_timeouts.py ibm/mas_devops/tests/unit/plugins/filter/test_calculate_manage_timeouts.py
+flake8 ibm/mas_devops/plugins/filter/manage_timeouts.py ibm/mas_devops/tests/unit/plugins/filter/test_calculate_manage_timeouts.py
+
+# Run unit tests
+cd ibm/mas_devops/tests
+pytest unit/plugins/filter/test_calculate_manage_timeouts.py -v
+```
+
+### Success Criteria
+- All Python files pass `black` and `flake8` validation
+- Unit tests pass with 100% coverage of the new filter
+- Foundation mode: timeout = 4 hours (14,400s)
+- Full mode: timeout = 18 hours (64,800s)
+- Environment variable overrides still work
+- No breaking changes to existing behavior

--- a/.bob/plans/2026-05-16-manage-timeout-calculation.md
+++ b/.bob/plans/2026-05-16-manage-timeout-calculation.md
@@ -16,8 +16,8 @@ Implement a Python-based filter to calculate appropriate timeout values for Mana
 - Foundation mode (empty components): Should use `~4 hours = 14,400s`
 - Full mode (with components): Should use current `~18 hours = 64,800s`
 - Variable `mas_appws_components` structure: `{'base': {'version': 'latest'}, 'health': {'version': 'latest'}}` or `None`/`{}`
-- Defined in [`ibm/mas_devops/roles/suite_app_config/defaults/main.yml:32`](ibm/mas_devops/roles/suite_app_config/defaults/main.yml:32)
-- Used in [`ibm/mas_devops/roles/suite_app_config/tasks/main.yml:138-139`](ibm/mas_devops/roles/suite_app_config/tasks/main.yml:138-139)
+- Defined in [../../ibm/mas_devops/roles/suite_app_config/defaults/main.yml:32](../../ibm/mas_devops/roles/suite_app_config/defaults/main.yml#L32)
+- Used in [../../ibm/mas_devops/roles/suite_app_config/tasks/main.yml:138-139](../../ibm/mas_devops/roles/suite_app_config/tasks/main.yml#L138-L139)
 
 ## Execution Plan
 
@@ -33,7 +33,7 @@ Implement a Python-based filter to calculate appropriate timeout values for Mana
 - [x] **1.2** Validate with `black` and `flake8`
 
 ### Phase 2: Update Manage Variables
-- [x] **2.1** Modify [`ibm/mas_devops/roles/suite_app_config/vars/manage.yml:7-8`](ibm/mas_devops/roles/suite_app_config/vars/manage.yml:7-8)
+- [x] **2.1** Modify [../../ibm/mas_devops/roles/suite_app_config/vars/manage.yml:7-8](../../ibm/mas_devops/roles/suite_app_config/vars/manage.yml#L7-L8)
   - [x] Replace hardcoded values with filter call
   - [x] Use pattern: `"{{ mas_appws_components | ibm.mas_devops.calculate_manage_timeouts }}"`
   - [x] Extract `delay` and `retries` from returned dict

--- a/.bob/rules/general-guidelines.md
+++ b/.bob/rules/general-guidelines.md
@@ -84,6 +84,15 @@ cd image/majel && wsl bash -lc "black majel-cli.py"
 - Plans must be **definitive** and **actionable**
 - Do not leave open questions in the plan, prompt the developer to make decisions and provide answers where necessary
 
+### File Links in Plan Documents
+When linking to files from plan documents in `.bob/plans/`:
+- Use relative paths with `../../` prefix to navigate from plan directory to project root
+- Include line numbers using GitHub-style anchors: `#L<line>` or `#L<start>-L<end>`
+- Examples:
+  - Single line: `[file.py:42](../../path/to/file.py#L42)`
+  - Line range: `[file.py:10-20](../../path/to/file.py#L10-L20)`
+- **Never** use paths without proper relative navigation (e.g., `ibm/mas_devops/file.py`)
+
 ### Tracking Progress
 **Critical:** Track progress ONLY in the plan document, NOT in chat
 - Do NOT use `update_todo_list` tool - it creates redundant tracking in chat

--- a/ibm/mas_devops/plugins/filter/manage_timeouts.py
+++ b/ibm/mas_devops/plugins/filter/manage_timeouts.py
@@ -1,0 +1,29 @@
+def calculateManageTimeouts(masAppwsComponents):
+    """Calculate appropriate timeout values for Manage app configuration.
+
+    Determines delay and retry values based on whether Manage is being configured
+    in foundation mode (no components) or full mode (with components). Foundation
+    mode uses shorter timeouts since configuration is faster, while full mode uses
+    longer timeouts to accommodate the additional time needed for component setup.
+
+    Args:
+        masAppwsComponents (dict, optional): Dictionary of Manage components to install.
+            Format: {'base': {'version': 'latest'}, 'health': {'version': 'latest'}}.
+            None or empty dict indicates foundation mode.
+
+    Returns:
+        dict: Dictionary containing 'delay' and 'retries' keys with integer values.
+            Foundation mode: delay=240, retries=60 (total ~4 hours)
+            Full mode: delay=360, retries=180 (total ~18 hours)
+    """
+    # Foundation mode: no components or empty dict
+    if not masAppwsComponents or len(masAppwsComponents) == 0:
+        return {"delay": 240, "retries": 60}
+
+    # Full mode: components are being installed
+    return {"delay": 360, "retries": 180}
+
+
+class FilterModule(object):
+    def filters(self):
+        return {"calculate_manage_timeouts": calculateManageTimeouts}

--- a/ibm/mas_devops/plugins/filter/manage_timeouts.py
+++ b/ibm/mas_devops/plugins/filter/manage_timeouts.py
@@ -1,3 +1,5 @@
+from ansible.utils.display import Display
+
 def calculateManageTimeouts(masAppwsComponents):
     """Calculate appropriate timeout values for Manage app configuration.
 
@@ -16,12 +18,37 @@ def calculateManageTimeouts(masAppwsComponents):
             Foundation mode: delay=240, retries=60 (total ~4 hours)
             Full mode: delay=360, retries=180 (total ~18 hours)
     """
-    # Foundation mode: no components or empty dict
-    if not masAppwsComponents or len(masAppwsComponents) == 0:
-        return {"delay": 240, "retries": 60}
 
-    # Full mode: components are being installed
-    return {"delay": 360, "retries": 180}
+    # Timing notes:
+    # - 240s = 4 minutes
+    # - 360s = 6 minutes
+    timeoutConfigs = {
+        "foundation": {"delay": 240, "retries": 60},  # ~4 hours total
+        "base": {"delay": 240, "retries": 60},  # ~4 hours total
+        "health": {"delay": 360, "retries": 60},  # ~6 hours total
+        "unknown": {"delay": 360, "retries": 180}  # ~18 hours total
+    }
+
+    display = Display()
+    display.v(f"Estimating configuration timeout for: {masAppwsComponents}")
+
+    if masAppwsComponents is not None and not isinstance(masAppwsComponents, dict):
+        raise ValueError("masAppwsComponents must be a dictionary or None")
+
+    if not masAppwsComponents or len(masAppwsComponents) == 0:
+        config = "foundation"
+    elif set(masAppwsComponents) == set(["base"]):
+        config = "base"
+    elif set(masAppwsComponents) == set(["base", "health"]):
+        config = "health"
+    else:
+        config = "unknown"
+
+    # Calculate and display timeout information
+    formattedDelay = f"{timeoutConfigs[config]['delay'] * timeoutConfigs[config]['retries'] / 3600:.1f}"
+    timeoutInfo = f"{timeoutConfigs[config]['retries']} retries with {timeoutConfigs[config]['delay']}s delay (approximately {formattedDelay} hrs)"
+    display.v(f"Setting timeout for Manage ({config}): {timeoutInfo}")
+    return timeoutConfigs[config]
 
 
 class FilterModule(object):

--- a/ibm/mas_devops/roles/suite_app_config/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/defaults/main.yml
@@ -29,7 +29,7 @@ mas_appws_bindings_kafka: "{{ lookup('env', 'MAS_APPWS_BINDINGS_KAFKA') }}"
 mas_appws_bindings_health_wsl_flag: "{{ lookup('env', 'MAS_APPWS_BINDINGS_HEALTH_WSL_FLAG') | default('false', true) | bool }}"
 
 # Components
-mas_appws_components: "{{ lookup('env', 'MAS_APPWS_COMPONENTS') | ibm.mas_devops.appws_components | default('{}', true) }}"
+mas_appws_components: "{{ lookup('env', 'MAS_APPWS_COMPONENTS') | ibm.mas_devops.appws_components | default({}, true) }}"
 
 # Only used by Predict currently - will be deprecated in favour of OM3.1 implementation
 mas_appws_settings_deployment_size: "{{ lookup('env', 'MAS_APPWS_SETTINGS_DEPLOYMENT_SIZE') | default('small', true) }}"

--- a/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
@@ -4,8 +4,10 @@ mas_app_ws_apiversion: apps.mas.ibm.com/v1
 mas_app_ws_kind: ManageWorkspace
 
 # Depending on the number of components being used the time to configure Manage can grow significantly
-mas_app_cfg_delay: "{{ lookup('env', 'MAS_APP_CFG_DELAY') | default(360, true)}}" # ~6 minutes
-mas_app_cfg_retries: "{{ lookup('env', 'MAS_APP_CFG_RETRIES') | default(180, true)}}" # ~18 hours
+# Calculate timeouts based on whether this is foundation mode (no components) or full mode (with components)
+mas_app_cfg_timeouts: "{{ mas_appws_components | ibm.mas_devops.calculate_manage_timeouts }}"
+mas_app_cfg_delay: "{{ lookup('env', 'MAS_APP_CFG_DELAY') | default(mas_app_cfg_timeouts.delay, true)}}"
+mas_app_cfg_retries: "{{ lookup('env', 'MAS_APP_CFG_RETRIES') | default(mas_app_cfg_timeouts.retries, true)}}"
 
 
 # Database Settings

--- a/ibm/mas_devops/tests/unit/plugins/filter/test_calculate_manage_timeouts.py
+++ b/ibm/mas_devops/tests/unit/plugins/filter/test_calculate_manage_timeouts.py
@@ -12,22 +12,26 @@ class TestCalculateManageTimeouts:
         """Test foundation mode when components is None."""
         result = calculateManageTimeouts(None)
         assert result == {"delay": 240, "retries": 60}
-        assert result["delay"] * result["retries"] == 14400  # 4 hours in seconds
 
     def test_foundation_mode_with_empty_dict(self):
         """Test foundation mode when components is an empty dict."""
         result = calculateManageTimeouts({})
         assert result == {"delay": 240, "retries": 60}
 
-    def test_full_mode_with_single_component(self):
-        """Test full mode with a single component."""
+    def test_base_mode(self):
+        """Test base mode"""
         components = {"base": {"version": "latest"}}
         result = calculateManageTimeouts(components)
-        assert result == {"delay": 360, "retries": 180}
-        assert result["delay"] * result["retries"] == 64800  # 18 hours in seconds
+        assert result == {"delay": 240, "retries": 60}
 
-    def test_full_mode_with_multiple_components(self):
-        """Test full mode with multiple components."""
+    def test_health_mode(self):
+        """Test health mode"""
+        components = {"base": {"version": "latest"}, "health": {"version": "latest"}}
+        result = calculateManageTimeouts(components)
+        assert result == {"delay": 360, "retries": 60}
+
+    def test_unknown_mode(self):
+        """Test unknown mode"""
         components = {
             "base": {"version": "latest"},
             "health": {"version": "8.8.0"},

--- a/ibm/mas_devops/tests/unit/plugins/filter/test_calculate_manage_timeouts.py
+++ b/ibm/mas_devops/tests/unit/plugins/filter/test_calculate_manage_timeouts.py
@@ -1,0 +1,64 @@
+"""
+Unit tests for calculate_manage_timeouts filter.
+"""
+
+from manage_timeouts import calculateManageTimeouts
+
+
+class TestCalculateManageTimeouts:
+    """Test suite for the calculateManageTimeouts filter function."""
+
+    def test_foundation_mode_with_none(self):
+        """Test foundation mode when components is None."""
+        result = calculateManageTimeouts(None)
+        assert result == {"delay": 240, "retries": 60}
+        assert result["delay"] * result["retries"] == 14400  # 4 hours in seconds
+
+    def test_foundation_mode_with_empty_dict(self):
+        """Test foundation mode when components is an empty dict."""
+        result = calculateManageTimeouts({})
+        assert result == {"delay": 240, "retries": 60}
+
+    def test_full_mode_with_single_component(self):
+        """Test full mode with a single component."""
+        components = {"base": {"version": "latest"}}
+        result = calculateManageTimeouts(components)
+        assert result == {"delay": 360, "retries": 180}
+        assert result["delay"] * result["retries"] == 64800  # 18 hours in seconds
+
+    def test_full_mode_with_multiple_components(self):
+        """Test full mode with multiple components."""
+        components = {
+            "base": {"version": "latest"},
+            "health": {"version": "8.8.0"},
+            "civil": {"version": "8.7.0"},
+        }
+        result = calculateManageTimeouts(components)
+        assert result == {"delay": 360, "retries": 180}
+
+    def test_return_type_is_dict(self):
+        """Test that the return type is always a dictionary."""
+        assert isinstance(calculateManageTimeouts(None), dict)
+        assert isinstance(calculateManageTimeouts({}), dict)
+        assert isinstance(
+            calculateManageTimeouts({"base": {"version": "latest"}}), dict
+        )
+
+    def test_return_keys_are_present(self):
+        """Test that both 'delay' and 'retries' keys are present in the result."""
+        result = calculateManageTimeouts(None)
+        assert "delay" in result
+        assert "retries" in result
+
+    def test_return_values_are_integers(self):
+        """Test that delay and retries values are integers."""
+        result = calculateManageTimeouts(None)
+        assert isinstance(result["delay"], int)
+        assert isinstance(result["retries"], int)
+
+        result = calculateManageTimeouts({"base": {"version": "latest"}})
+        assert isinstance(result["delay"], int)
+        assert isinstance(result["retries"], int)
+
+
+# Made with Bob


### PR DESCRIPTION
## Description
ibm/mas_devops/roles/suite_app_config/vars/manage.yml

```
# Depending on the number of components being used the time to configure Manage can grow significantly
mas_app_cfg_delay: "{{ lookup('env', 'MAS_APP_CFG_DELAY') | default(360, true)}}" # ~6 minutes
mas_app_cfg_retries: "{{ lookup('env', 'MAS_APP_CFG_RETRIES') | default(180, true)}}" # ~18 hours
```

It's time to do something about this ... we need to build a system that will configure appropriate timeouts based on the configuration of manage, because having an 18 hour timeout means we fail incredibly slow when manage configuration fails, and manage configuration fails often sadly.

We need to factor in the content of the `mas_appws_components` object ... initially focusing on enabling "fail fast" in Manage Foundation deployments:

```python
    timeoutConfigs = {
        "foundation": {"delay": 240, "retries": 60},  # ~4 hours total
        "base": {"delay": 240, "retries": 60},  # ~4 hours total
        "health": {"delay": 360, "retries": 60},  # ~6 hours total
        "unknown": {"delay": 360, "retries": 180}  # ~18 hours total
    }
```

We will want to enhance this to add smart timeouts for other component configurations over time, but this update is focused on Manage Foundation.

## Test Results
New unit tests added:

```
pytest unit/plugins/filter/test_calculate_manage_timeouts.py 
=============================================================================== test session starts ===============================================================================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0 -- /home/david/python312/bin/python3
cachedir: .pytest_cache
rootdir: /mnt/c/Users/097891866/Documents/GitHub/ibm-mas/ansible-devops/ibm/mas_devops/tests
configfile: pytest.ini
collected 7 items                                                                                                                                                                 

unit/plugins/filter/test_calculate_manage_timeouts.py::TestCalculateManageTimeouts::test_foundation_mode_with_none PASSED                                                   [ 14%]
unit/plugins/filter/test_calculate_manage_timeouts.py::TestCalculateManageTimeouts::test_foundation_mode_with_empty_dict PASSED                                             [ 28%] 
unit/plugins/filter/test_calculate_manage_timeouts.py::TestCalculateManageTimeouts::test_full_mode_with_single_component PASSED                                             [ 42%] 
unit/plugins/filter/test_calculate_manage_timeouts.py::TestCalculateManageTimeouts::test_full_mode_with_multiple_components PASSED                                          [ 57%] 
unit/plugins/filter/test_calculate_manage_timeouts.py::TestCalculateManageTimeouts::test_return_type_is_dict PASSED                                                         [ 71%] 
unit/plugins/filter/test_calculate_manage_timeouts.py::TestCalculateManageTimeouts::test_return_keys_are_present PASSED                                                     [ 85%] 
unit/plugins/filter/test_calculate_manage_timeouts.py::TestCalculateManageTimeouts::test_return_values_are_integers PASSED                                                  [100%] 

================================================================================ 7 passed in 0.36s ================================================================================
```

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
