### PR TITLE
[patch] Fix the suite-verify role for mas_manual_route_mgmt parameter

### DIFF
--- a/ibm/mas_devops/roles/suite_install/README.md
+++ b/ibm/mas_devops/roles/suite_install/README.md
@@ -280,6 +280,23 @@ Defines the URL routing strategy for MAS applications and services.
 
 **Note**: Choose carefully as this cannot be changed after installation. Subdomain routing is recommended for production environments.
 
+#### mas_manual_route_mgmt
+Enables manual route management mode, disabling automatic route generation.
+
+- **Optional**
+- Environment Variable: `MAS_MANUAL_ROUTE_MGMT`
+- Default: `false`
+
+**Purpose**: Allows you to disable automatic routes creation and management if alternative routing is required.
+
+**When to use**:
+- Use `false` (default) for MAS to automatically manage routes.
+- Use `true` to manage routes in an alternative way. 
+
+**Valid values**: `true`, `false`
+
+**Impact**: When `true`, you must manually create and manage all routes required by MAS.
+
 #### mas_trust_default_cas
 Controls whether default system Certificate Authorities are included in MAS trust stores.
 

--- a/ibm/mas_devops/roles/suite_verify/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_verify/tasks/main.yml
@@ -97,6 +97,6 @@
   debug:
     msg:
       - "Maximo Application Suite is Ready, use the superuser credentials to authenticate"
-      - "Admin Dashboard ... https://{{ admin_route.resources[0].spec.host }}"
+      - "Admin Dashboard ... https://{{ admin_route.resources[0].spec.host | default ('UNDEFINED')}}"
       - "Username .......... {{ superuser_username }}"
       - "Password .......... {{ superuser_password }}"


### PR DESCRIPTION
## Description
Fix the suite-verify role to pass when the admin dashboard route is not available in manual route management mode

### Related Issues
https://jsw.ibm.com/browse/MASCORE-14060

### Testing
Tested by running suite-verify role in the servicemesh development cluster