### PR TITLE
[patch] Add AppConfig DNS and edge certificate support

### DIFF
--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_dns_mgmt.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_dns_mgmt.yml
@@ -80,6 +80,7 @@
     edge_certs_reportdb: "{{ (cis_entries_to_add|split(',')) | select('search', 'reportdb') | length > 0 }}"
     edge_certs_facilities: "{{ (cis_entries_to_add|split(',')) | select('search', 'facilities') | length > 0 }}"
     edge_certs_aibroker: "{{ (cis_entries_to_add|split(',')) | select('search', 'aibroker') | length > 0 }}"
+    edge_certs_appconfig: "{{ (cis_entries_to_add|split(',')) | select('search', 'appconfig') | length > 0 }}"
 
 - name: "cis : Debug edge_certs variables"
   debug:
@@ -98,6 +99,7 @@
       - "edge_certs_reportdb is {{ edge_certs_reportdb }}"
       - "edge_certs_facilities is {{ edge_certs_facilities }}"
       - "edge_certs_aibroker is {{ edge_certs_aibroker }}"
+      - "edge_certs_appconfig is {{ edge_certs_appconfig }}"
 
 - name: "cis : Read Edge Certificate Routes"
   set_fact:

--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cloudflare/main.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cloudflare/main.yml
@@ -90,6 +90,8 @@
       - "*.predict"
       # Visual Inspection
       - "*.visualinspection"
+      # AppConfig
+      - "*.appconfig"
 
 - name: "cloudflare : Create MAS DNS record in Cloudflare"
   vars:

--- a/ibm/mas_devops/roles/suite_dns/templates/edge_certificate_routes.yml.j2
+++ b/ibm/mas_devops/roles/suite_dns/templates/edge_certificate_routes.yml.j2
@@ -1,7 +1,7 @@
 ---
 edge_cert_routes:
 {% if mas_routing_mode is defined and mas_routing_mode == 'path' %}
-{% if edge_certs_core or edge_certs_all or edge_certs_health or edge_certs_manage or edge_certs_monitor or edge_certs_predict or edge_certs_visualinspection or edge_certs_optimizer or edge_certs_assist or edge_certs_arcgis or edge_certs_aibroker or edge_certs_reportdb or edge_certs_facilities %}
+{% if edge_certs_core or edge_certs_all or edge_certs_health or edge_certs_manage or edge_certs_monitor or edge_certs_predict or edge_certs_visualinspection or edge_certs_optimizer or edge_certs_assist or edge_certs_arcgis or edge_certs_aibroker or edge_certs_reportdb or edge_certs_facilities or edge_certs_appconfig %}
   - "{{mas_domain}}"
 {% endif %}
 {% else %}
@@ -93,6 +93,9 @@ edge_cert_routes:
   -  wfagent.{{ mas_workspace_id }}.facilities.{{mas_domain}}
   -  wffutureagent.{{ mas_workspace_id }}.facilities.{{mas_domain}}
   -  wfnotificationagent.{{ mas_workspace_id }}.facilities.{{mas_domain}}
+{% endif %}
+{% if edge_certs_appconfig | bool or edge_certs_all | bool %}
+  - appconfig.{{mas_domain}}
 {% endif %}
 {% endif %}
 {% if edge_certs_iot | bool or edge_certs_all | bool %}


### PR DESCRIPTION
## Description
<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->

This pull request adds support for the AppConfig application in the MAS suite DNS configuration. The changes enable proper DNS and edge certificate management for AppConfig across multiple DNS providers.

**Key Changes:**
- Added `edge_certs_appconfig` variable to track AppConfig certificate requirements in CIS DNS management
- Added AppConfig wildcard DNS entry (`*.appconfig`) to Cloudflare DNS provider configuration
- Updated edge certificate routes template to include AppConfig domain (`appconfig.{{mas_domain}}`) when AppConfig certificates are required
- Added debug logging for the new `edge_certs_appconfig` variable for troubleshooting purposes

**Impact:**
These changes ensure that when AppConfig is deployed as part of a MAS installation, the necessary DNS records and edge certificates are automatically provisioned, enabling proper routing and secure communication for the AppConfig application.

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->


<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
* Please verify that the AppConfig domain pattern is consistent with other MAS application domains
* Confirm that the conditional logic for `edge_certs_appconfig` follows the same pattern as other applications
* Validate that both path-based and subdomain-based routing modes are properly supported