### PR TITLE
[patch] increase NFD worker daemonset readiness check timeout

### DIFF
--- a/ibm/mas_devops/roles/nvidia_gpu/tasks/nfd_setup.yml
+++ b/ibm/mas_devops/roles/nvidia_gpu/tasks/nfd_setup.yml
@@ -123,7 +123,7 @@
         - nfd_worker_daemonset.resources | length > 0
         - nfd_worker_daemonset.resources[0].status.numberReady > 0
         - nfd_worker_daemonset.resources[0].status.numberReady == nfd_worker_daemonset.resources[0].status.desiredNumberScheduled
-      retries: 30 # approx 30 minutes before we give up
-      delay: 60 # 1 minute
+      retries: 60 # approx 30 minutes before we give up
+      delay: 90 # 1 minute
   when:
     - nfd_worker_daemonset_result.resources | length == 0

--- a/ibm/mas_devops/roles/nvidia_gpu/tasks/nfd_setup.yml
+++ b/ibm/mas_devops/roles/nvidia_gpu/tasks/nfd_setup.yml
@@ -123,7 +123,7 @@
         - nfd_worker_daemonset.resources | length > 0
         - nfd_worker_daemonset.resources[0].status.numberReady > 0
         - nfd_worker_daemonset.resources[0].status.numberReady == nfd_worker_daemonset.resources[0].status.desiredNumberScheduled
-      retries: 60 # approx 30 minutes before we give up
-      delay: 90 # 1 minute
+      retries: 60 # approx 90 minutes before we give up
+      delay: 90 # 1.5 minutes
   when:
     - nfd_worker_daemonset_result.resources | length == 0


### PR DESCRIPTION
## Description
nfd-worker daemon set is taking too long to stabilize in our FVTs. After checking the cluster, it was identified that rather than a problem with the nfd-worker itself, it was an issue with the timing since it was getting deployed after around 60 minutes. Therefore, the timeout has been increased to 90 minutes to guarantee that will not fail.

## Test Results
It will require run in actual FVT to test. 

## Related issues
- MASCORE-13873

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
