### PR TITLE
[patch] update Db2 storage requirements and fix access mode configurations

### DIFF
--- a/ibm/mas_devops/roles/db2/README.md
+++ b/ibm/mas_devops/roles/db2/README.md
@@ -536,7 +536,7 @@ Rotates the password for an **existing** Db2 LDAP user.
 **Note**: When enabled, the auto-generated password is stored securely in Kubernetes secrets and MAS configuration.
 
 ### Storage Variables
-We recommend reviewing the Db2 documentation about the certified storage options for Db2 on Red Hat OpenShift. Please ensure your storage class meets the specified deployment requirements for Db2. [https://www.ibm.com/docs/en/db2/11.5?topic=storage-certified-options](https://www.ibm.com/docs/en/db2/11.5?topic=storage-certified-options)
+We recommend reviewing the Db2 documentation about the certified storage options for Db2 on Red Hat OpenShift. Please ensure your storage class meets the specified deployment requirements for [Db2uInstance](https://www.ibm.com/docs/en/db2/11.5.x?topic=resource-deploying-db2-using-db2uinstance-custom) and for [Db2uCluster](https://www.ibm.com/docs/en/db2/11.5.x?topic=resource-deploying-db2-using-db2ucluster-custom).
 
 #### db2_meta_storage_class
 Storage class for Db2 metadata storage (must support ReadWriteMany).
@@ -780,7 +780,7 @@ The access mode for the storage.
 - Default: `ReadWriteOnce`
 
 #### db2_temp_storage_class
-Storage class used for temporary data. This must support ReadWriteMany(RWX) access mode.
+Storage class used for temporary data. This must support ReadWriteOnce(RWO) access mode.
 
 - **Optional**
 - Environment Variable: `DB2_TEMP_STORAGE_CLASS`
@@ -802,7 +802,7 @@ The access mode for the storage. This must support ReadWriteOnce(RWO) access mod
 
 ### Resource Request Variables
 ### db2_audit_logs_storage_class
-Storage class used for audit logs. This must support ReadWriteMany(RWX) access mode.
+Storage class used for audit logs. This must support ReadWriteOnce(RWO) access mode.
 
 - Optional
 - Environment Variable: `DB2_AUDIT_LOGS_STORAGE_CLASS`
@@ -823,11 +823,11 @@ The access mode for the storage. This must support ReadWriteOnce(RWO) access mod
 - Default: `ReadWriteOnce`
 
 ### db2_archivelogs_storage_class
-Storage class used for archive logs. This must support ReadWriteMany(RWX) access mode.
+Storage class used for archive logs. This must support ReadWriteMany(RWX) access mode for `Db2uInstance` and ReadWriteOnce(RWO) access mode for `Db2uCluster`.
 
 - Optional
 - Environment Variable: `DB2_ARCHIVELOGS_STORAGE_CLASS`
-- Default: Defaults to `ibmc-block-gold` if the storage class is available in the cluster. Set to `None` will drop the tempts storage on Db2uInstace CR.
+- Default: Defaults to `ibmc-block-gold` or `ibmc-file-gold` if the storage class is available in the cluster. Set to `None` will drop the tempts storage on Db2uInstace CR.
 
 ### db2_archivelogs_storage_size
 Size of audit logs persistent volume.
@@ -837,54 +837,11 @@ Size of audit logs persistent volume.
 - Default: `10Gi`
 
 ### db2_archivelogs_storage_accessmode
-The access mode for the storage. This must support ReadWriteOnce(RWO) access mode.
+The access mode for the storage. This must support ReadWriteMany(RWX) access mode for `Db2uInstance` and ReadWriteOnce(RWO) access mode for `Db2uCluster`.
 
 - Optional
 - Environment Variable: `DB2_ARCHIVELOGS_STORAGE_ACCESSMODE`
-- Default: `ReadWriteOnce`
-
-### db2_audit_logs_storage_class
-Storage class used for audit logs. This must support ReadWriteMany(RWX) access mode.
-
-- Optional
-- Environment Variable: `DB2_AUDIT_LOGS_STORAGE_CLASS`
-- Default: Defaults to `ibmc-block-gold` if the storage class is available in the cluster. Set to `None` will drop the tempts storage on Db2uInstace CR.
-
-### db2_audit_logs_storage_size
-Size of audit logs persistent volume.
-
-- Optional
-- Environment Variable: `DB2_AUDIT_LOGS_STORAGE_SIZE`
-- Default: `10Gi`
-
-### db2_audit_logs_storage_accessmode
-The access mode for the storage. This must support ReadWriteOnce(RWO) access mode.
-
-- Optional
-- Environment Variable: `DB2_AUDIT_LOGS_STORAGE_ACCESSMODE`
-- Default: `ReadWriteOnce`
-
-### db2_archivelogs_storage_class
-Storage class used for archive logs. This must support ReadWriteMany(RWX) access mode.
-
-- Optional
-- Environment Variable: `DB2_ARCHIVELOGS_STORAGE_CLASS`
-- Default: Defaults to `ibmc-block-gold` if the storage class is available in the cluster. Set to `None` will drop the tempts storage on Db2uInstace CR.
-
-### db2_archivelogs_storage_size
-Size of audit logs persistent volume.
-
-- Optional
-- Environment Variable: `DB2_ARCHIVELOGS_STORAGE_SIZE`
-- Default: `10Gi`
-
-### db2_archivelogs_storage_accessmode
-The access mode for the storage. This must support ReadWriteOnce(RWO) access mode.
-
-- Optional
-- Environment Variable: `DB2_ARCHIVELOGS_STORAGE_ACCESSMODE`
-- Default: `ReadWriteOnce`
-
+- Default: Dynamically set according with kind of Db2 (`Db2uInstance` or `Db2uCluster`)
 
 Role Variables - Resource Requests
 -----------------------------------------------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/db2/defaults/main.yml
+++ b/ibm/mas_devops/roles/db2/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # db2 action
 # ---------------------------------------------------------------------------
-# Supported actions: install, uninstall, backup, backup-database, restore, restore-database
+# Supported actions: install, uninstall, backup, backup-database, restore, restore-database and upgrade
 db2_action: "{{ lookup('env', 'DB2_ACTION') | default('install', true) }}"
 
 # Configure Db2 instance

--- a/ibm/mas_devops/roles/db2/defaults/main.yml
+++ b/ibm/mas_devops/roles/db2/defaults/main.yml
@@ -56,7 +56,7 @@ db2_temp_storage_accessmode: "{{ lookup('env', 'DB2_TEMP_STORAGE_ACCESSMODE') | 
 # Configure archive storage for db2u
 db2_archivelogs_storage_class: "{{ lookup('env', 'DB2_ARCHIVELOGS_STORAGE_CLASS') }}"
 db2_archivelogs_storage_size: "{{ lookup('env', 'DB2_ARCHIVELOGS_STORAGE_SIZE') | default('10Gi', true) }}"
-db2_archivelogs_storage_accessmode: "{{ lookup('env', 'DB2_ARCHIVELOGS_STORAGE_ACCESSMODE') | default('ReadWriteOnce', true) }}"
+db2_archivelogs_storage_accessmode: "{{ lookup('env', 'DB2_ARCHIVELOGS_STORAGE_ACCESSMODE') }}"
 
 # Configure audit_logs logs for db2u
 db2_audit_logs_storage_class: "{{ lookup('env', 'DB2_AUDIT_LOGS_STORAGE_CLASS') }}"

--- a/ibm/mas_devops/roles/db2/tasks/install/determine-storage-classes.yml
+++ b/ibm/mas_devops/roles/db2/tasks/install/determine-storage-classes.yml
@@ -64,6 +64,8 @@
 # -----------------------------------------------------------------------------
 # Reference: https://www.ibm.com/docs/en/db2/11.5.x?topic=logs-new-deployments#taskarch-log_new_deploy__steps__1
 - name: Dynamically set the Db2 ArchiveLogs storage access mode
+  when:
+    - db2_archivelogs_storage_accessmode is not defined or db2_archivelogs_storage_accessmode == ""
   ansible.builtin.set_fact:
     db2_archivelogs_storage_accessmode: "{{ 'ReadWriteMany' if db2u_kind == 'db2uinstance' else 'ReadWriteOnce' }}"
 

--- a/ibm/mas_devops/roles/db2/tasks/install/determine-storage-classes.yml
+++ b/ibm/mas_devops/roles/db2/tasks/install/determine-storage-classes.yml
@@ -45,7 +45,9 @@
 # 5. Backup Storage (Optional)
 # -----------------------------------------------------------------------------
 - name: Default Backup Storage for ROKS if not set by user (ReadWriteMany)
-  when: db2_backup_storage_class is not defined or db2_backup_storage_class == ""
+  when: 
+    - db2_backup_storage_class is not defined or db2_backup_storage_class == ""
+    - defaultStorageClasses.success
   set_fact:
     db2_backup_storage_class: "{{ defaultStorageClasses.rwx }}"
 
@@ -60,12 +62,17 @@
 
 # 7. Archive Logs Storage (Optional)
 # -----------------------------------------------------------------------------
-- name: Default Archive Logs Storage for ROKS if not set by user (ReadWriteOnce)
+# Reference: https://www.ibm.com/docs/en/db2/11.5.x?topic=logs-new-deployments#taskarch-log_new_deploy__steps__1
+- name: Dynamically set the Db2 ArchiveLogs storage access mode
+  ansible.builtin.set_fact:
+    db2_archivelogs_storage_accessmode: "{{ 'ReadWriteMany' if db2u_kind == 'db2uinstance' else 'ReadWriteOnce' }}"
+
+- name: Default Archive Logs Storage for ROKS if not set by user
   when:
     - db2_archivelogs_storage_class is not defined or db2_archivelogs_storage_class == ""
     - defaultStorageClasses.success
   set_fact:
-    db2_archivelogs_storage_class: "{{ defaultStorageClasses.rwo }}"
+    db2_archivelogs_storage_class: "{{ defaultStorageClasses.rwx if db2u_kind == 'db2uinstance' else defaultStorageClasses.rwo }}"
 
 # 8. Audit Logs Storage (Optional)
 # -----------------------------------------------------------------------------
@@ -86,5 +93,5 @@
       - "Storage class (backup) ................. {{ db2_backup_storage_class | default('<undefined>', true) }}"
       - "Storage class (logs) ................... {{ db2_logs_storage_class | default('<undefined>', true) }}"
       - "Storage class (temp) ................... {{ db2_temp_storage_class | default('<undefined>', true) }}"
-      - "Storage class (archive lgos) ........... {{ db2_archivelogs_storage_class | default('<undefined>', true) }}"
+      - "Storage class (archive logs) ........... {{ db2_archivelogs_storage_class | default('<undefined>', true) }}"
       - "Storage class (audit logs) ............. {{ db2_audit_logs_storage_class | default('<undefined>', true) }}"

--- a/ibm/mas_devops/roles/db2/tasks/install/determine-storage-classes.yml
+++ b/ibm/mas_devops/roles/db2/tasks/install/determine-storage-classes.yml
@@ -45,7 +45,7 @@
 # 5. Backup Storage (Optional)
 # -----------------------------------------------------------------------------
 - name: Default Backup Storage for ROKS if not set by user (ReadWriteMany)
-  when: 
+  when:
     - db2_backup_storage_class is not defined or db2_backup_storage_class == ""
     - defaultStorageClasses.success
   set_fact:

--- a/ibm/mas_devops/roles/db2/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/db2/tasks/install/main.yml
@@ -32,8 +32,6 @@
 - name: "Debug - MAS"
   debug:
     msg:
-      - "MAS Instance ID ........................ {{ mas_instance_id }}"
-      - "MAS Config directory ................... {{ mas_config_dir }}"
       - "MAS Instance ID ........................ {{ mas_instance_id | default('<undefined>', true) }}"
       - "MAS Workspace ID ....................... {{ mas_workspace_id | default('<undefined>', true) }}"
       - "MAS Application ID ..................... {{ mas_application_id | default('<undefined>', true) }}"
@@ -527,10 +525,11 @@
     - db2_ldap_password != ""
     - db2_rotate_password == false
 
-- debug:
+- name: "Debug - LDAP Configuration"
+  debug:
     msg:
-      - "{{db2_ldap_username}}"
-      - "{{db2_rotate_password}}"
+      - "LDAP Username .......................... {{ db2_ldap_username | default('<undefined>', true) }}"
+      - "Rotate Password ........................ {{ db2_rotate_password | ternary('*********', '<undefined>') }}"
 
 # 20. Rotate db2 ldap password
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Description
The configuration for some of the storage class and storage access mode were incoherent with the official documentation. Therefore, the code has been update to met the criteria in the IBM documentation. References:

- https://www.ibm.com/docs/en/db2/11.5.x?topic=resource-deploying-db2-using-db2ucluster-custom
- https://www.ibm.com/docs/en/db2/11.5.x?topic=resource-deploying-db2-using-db2uinstance-custom
- https://www.ibm.com/docs/en/db2/11.5.x?topic=logs-new-deployments#taskarch-log_new_deploy__steps__1

## Test Results
Tested with `Db2uCluster` and `Db2uInstance`

<img width="626" height="594" alt="image" src="https://github.com/user-attachments/assets/012763bd-b2ad-4883-afd5-12ee5955c714" />
<img width="636" height="653" alt="image" src="https://github.com/user-attachments/assets/4f1d138c-1377-4c8c-b8b4-301d7c8d68b6" />
<img width="1577" height="204" alt="image" src="https://github.com/user-attachments/assets/6352c43d-704a-47d1-a856-f55e4b08d3fb" />


<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
