### PR TITLE
[patch] set default routing mode and issuerkind value for mas 9.2+ 

### DIFF
--- a/ibm/mas_devops/roles/suite_certs/tasks/run.yml
+++ b/ibm/mas_devops/roles/suite_certs/tasks/run.yml
@@ -1,6 +1,6 @@
 ---
 
-# 1. Parse MAS version from channel
+# 1. Parse MAS version from channel and set defaults for MAS 9.2+
 # -----------------------------------------------------------------------------
 - name: "Set default for mas_version_lt_92"
   when: mas_version_lt_92 is not defined
@@ -18,7 +18,7 @@
       - "MAS Channel ......................... {{ mas_channel | default('not set') }}"
       - "Version < 9.2 ...................... {{ mas_version_lt_92 }}"
 
-- name: "Set default routing mode to 'path' for MAS 9.2+"
+- name: "Set default routing mode to 'path' for MAS 9.2+ if it's not defined"
   when:
     - mas_routing_mode is not defined or mas_routing_mode == ""
     - mas_channel is defined and mas_channel != ""

--- a/ibm/mas_devops/roles/suite_certs/tasks/run.yml
+++ b/ibm/mas_devops/roles/suite_certs/tasks/run.yml
@@ -18,6 +18,14 @@
       - "MAS Channel ......................... {{ mas_channel | default('not set') }}"
       - "Version < 9.2 ...................... {{ mas_version_lt_92 }}"
 
+- name: "Set default routing mode to 'path' for MAS 9.2+"
+  when:
+    - mas_routing_mode is not defined or mas_routing_mode == ""
+    - mas_channel is defined and mas_channel != ""
+    - mas_channel.split('.')[:2] | join('.') is version('9.2', '>=')
+  set_fact:
+    mas_routing_mode: "path"
+
 # 2. Check for undefined properties that do not have a default
 # -----------------------------------------------------------------------------
 - name: "Fail if mas_instance_id is not provided"

--- a/ibm/mas_devops/roles/suite_dns/tasks/run.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/run.yml
@@ -17,6 +17,14 @@
       - "MAS Channel ......................... {{ mas_channel | default('not set') }}"
       - "Version < 9.2 ...................... {{ mas_version_lt_92 }}"
 
+- name: "Set default routing mode to 'path' for MAS 9.2+"
+  when:
+    - mas_routing_mode is not defined or mas_routing_mode == ""
+    - mas_channel is defined and mas_channel != ""
+    - mas_channel.split('.')[:2] | join('.') is version('9.2', '>=')
+  set_fact:
+    mas_routing_mode: "path"
+
 # 2. Check cert-manager installation
 # -----------------------------------------------------------------------------
 # Ensure cert manager is installed prior continuing as this role will install

--- a/ibm/mas_devops/roles/suite_dns/tasks/run.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/run.yml
@@ -1,5 +1,5 @@
 ---
-# 1. Parse MAS version from channel
+# 1. Parse MAS version from channel and set defaults for MAS 9.2+
 # -----------------------------------------------------------------------------
 - name: "Set default for mas_version_lt_92"
   when: mas_version_lt_92 is not defined
@@ -17,7 +17,7 @@
       - "MAS Channel ......................... {{ mas_channel | default('not set') }}"
       - "Version < 9.2 ...................... {{ mas_version_lt_92 }}"
 
-- name: "Set default routing mode to 'path' for MAS 9.2+"
+- name: "Set default routing mode to 'path' for MAS 9.2+ if it's not defined"
   when:
     - mas_routing_mode is not defined or mas_routing_mode == ""
     - mas_channel is defined and mas_channel != ""

--- a/ibm/mas_devops/roles/suite_install/README.md
+++ b/ibm/mas_devops/roles/suite_install/README.md
@@ -257,7 +257,7 @@ Defines the URL routing strategy for MAS applications and services.
 
 - **Optional**
 - Environment Variable: `MAS_ROUTING_MODE`
-- Default: `subdomain`
+- Default: `path` for MAS 9.2+, otherwise not set
 
 **Purpose**: Controls how MAS constructs URLs for different applications and services. This affects the URL structure users see and how DNS must be configured.
 

--- a/ibm/mas_devops/roles/suite_install/README.md
+++ b/ibm/mas_devops/roles/suite_install/README.md
@@ -379,7 +379,7 @@ Specifies the issuer kind to configure for MAS certificates.
 
 - **Optional**
 - Environment Variable: `mas_issuer_kind`
-- Default: None
+- Default: `ClusterIssuer` for MAS 9.2+
 
 **Purpose**: Controls the value written to `spec.settings.issuerKind` in the MAS Suite custom resource. This determines whether MAS certificates use a namespace-scoped `Issuer` or a cluster-scoped `ClusterIssuer`.
 

--- a/ibm/mas_devops/roles/suite_install/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_install/defaults/main.yml
@@ -47,7 +47,6 @@ mas_trust_default_cas: "{{ lookup('env', 'MAS_TRUST_DEFAULT_CAS') }}"
 # Network Routing
 # -----------------------------------------------------------------------------
 mas_routing_mode: "{{ lookup('env', 'MAS_ROUTING_MODE') }}"
-mas_ingress_controller_name: "{{ lookup('env', 'MAS_INGRESS_CONTROLLER_NAME') }}"
 mas_use_service_mesh: "{{ lookup('env', 'MAS_USE_SERVICE_MESH') | default('false', true) | bool }}"
 mas_manual_route_mgmt: "{{ lookup('env', 'MAS_MANUAL_ROUTE_MGMT') | default('false', true) | bool }}"
 

--- a/ibm/mas_devops/roles/suite_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_install/tasks/main.yml
@@ -138,7 +138,17 @@
   set_fact:
     mas_domain: "{{ mas_instance_id }}.{{ _cluster_subdomain.resources[0].spec.domain }}"
 
-# 9. Determine version of cert-manager in use on the cluster
+# 9. Set default routing mode for MAS 9.2+ if not already set
+# -----------------------------------------------------------------------------
+- name: "Set default routing mode to 'path' for MAS 9.2+"
+  when:
+    - mas_routing_mode is not defined or mas_routing_mode == ""
+    - mas_channel is defined and mas_channel != ""
+    - mas_channel.split('.')[:2] | join('.') is version('9.2', '>=')
+  set_fact:
+    mas_routing_mode: "path"
+
+# 10. Determine version of cert-manager in use on the cluster
 # -----------------------------------------------------------------------------
 # if cert_manager_cluster_resource_namespace is not set then
 # run 'detect_cert_manager' task to set it as this will be needed to be set in Suite CR
@@ -146,7 +156,7 @@
   include_tasks: "{{ role_path }}/../../common_tasks/detect_cert_manager.yml"
   when: cert_manager_cluster_resource_namespace is not defined or cert_manager_cluster_resource_namespace == ''
 
-# 10. Provide debug information
+# 11. Provide debug information
 # -----------------------------------------------------------------------------
 - name: "Configure namespace"
   set_fact:
@@ -164,9 +174,10 @@
       - "MAS ICR cpopen content ........ {{ mas_icr_cpopen }}"
       - "Cert Manager namespace ........ {{ cert_manager_cluster_resource_namespace }}"
       - "MAS Cluster Issuer ............ {{ mas_cluster_issuer }}"
+      - "MAS Routing Mode .............. {{ mas_routing_mode | default('<not set>', true) }}"
       - "IPv6 Enabled .................. {{ ocp_enable_ipv6 }}"
 
-# 11. Create entitlement secret and install the operator
+# 12. Create entitlement secret and install the operator
 # -----------------------------------------------------------------------------
 - name: "Create IBM Entitlement Key"
   ibm.mas_devops.update_ibm_entitlement:
@@ -196,14 +207,14 @@
     catalog_source: "{{ mas_catalog_source }}"
   register: subscription
 
-# 12. Wait until the Suite CRD is available
+# 13. Wait until the Suite CRD is available
 # -----------------------------------------------------------------------------
 - name: "Wait until the Suite CRD is available"
   include_tasks: "{{ role_path }}/../../common_tasks/wait_for_crd.yml"
   vars:
     crd_name: suites.core.mas.ibm.com
 
-# 13. Before we install the suite create the optional filebeat and superuser secrets
+# 14. Before we install the suite create the optional filebeat and superuser secrets
 # -----------------------------------------------------------------------------
 # Note that this will have no effect on older version of MAS, but will do no harm
 - name: Configure Filebeat for Logstash
@@ -222,7 +233,7 @@
     namespace: "{{ mas_namespace }}"
     template: templates/secret-superuser.yml.j2
 
-# 14. Suite installation
+# 15. Suite installation
 # -----------------------------------------------------------------------------
 - name: Create suite.ibm.com/v1 CR
   vars:
@@ -237,7 +248,7 @@
   debug:
     msg: "{{ suiteResult }}"
 
-# 15. Set up OCP ConsoleLink for MAS Admin Dashboard
+# 16. Set up OCP ConsoleLink for MAS Admin Dashboard
 # -----------------------------------------------------------------------------
 - name: Create ConsoleLink for MAS Admin Dashbord
   kubernetes.core.k8s:

--- a/ibm/mas_devops/roles/suite_install/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_install/tasks/main.yml
@@ -138,15 +138,23 @@
   set_fact:
     mas_domain: "{{ mas_instance_id }}.{{ _cluster_subdomain.resources[0].spec.domain }}"
 
-# 9. Set default routing mode for MAS 9.2+ if not already set
+# 9. Set default routing mode and issuer kind for MAS 9.2+ if not already set
 # -----------------------------------------------------------------------------
-- name: "Set default routing mode to 'path' for MAS 9.2+"
+- name: "Set default routing mode to 'path' for MAS 9.2+ if it's not defined"
   when:
     - mas_routing_mode is not defined or mas_routing_mode == ""
     - mas_channel is defined and mas_channel != ""
     - mas_channel.split('.')[:2] | join('.') is version('9.2', '>=')
   set_fact:
     mas_routing_mode: "path"
+
+- name: "Set default issuer kind to 'ClusterIssuer' for MAS 9.2+ if it's not defined"
+  when:
+    - mas_issuer_kind is not defined or mas_issuer_kind == ""
+    - mas_channel is defined and mas_channel != ""
+    - mas_channel.split('.')[:2] | join('.') is version('9.2', '>=')
+  set_fact:
+    mas_issuer_kind: "ClusterIssuer"
 
 # 10. Determine version of cert-manager in use on the cluster
 # -----------------------------------------------------------------------------
@@ -174,6 +182,7 @@
       - "MAS ICR cpopen content ........ {{ mas_icr_cpopen }}"
       - "Cert Manager namespace ........ {{ cert_manager_cluster_resource_namespace }}"
       - "MAS Cluster Issuer ............ {{ mas_cluster_issuer }}"
+      - "MAS Issuer Kind ............... {{ mas_issuer_kind | default('<not set>', true) }}"
       - "MAS Routing Mode .............. {{ mas_routing_mode | default('<not set>', true) }}"
       - "IPv6 Enabled .................. {{ ocp_enable_ipv6 }}"
 

--- a/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
+++ b/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
@@ -125,9 +125,6 @@ spec:
 {% if mas_routing_mode is defined and mas_routing_mode != '' %}
     routingMode: {{ mas_routing_mode }}
 {% endif %}
-{% if mas_ingress_controller_name is defined and mas_ingress_controller_name != '' %}
-    ingressControllerName: {{ mas_ingress_controller_name }}
-{% endif %}
     manualRouteMgmt: {{ mas_manual_route_mgmt }}
 {% if ocp_enable_ipv6 is defined and ocp_enable_ipv6 == true %}
     services:


### PR DESCRIPTION
## Description
<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->

- this PR introduces automatic default routing mode configuration for MAS 9.2+ installations, setting `mas_routing_mode` to `path` when not explicitly defined by the user. same for mas_issuer_kind if it's not define then set default as `ClusterIssuer`

## Test Results
- tested those changes on 9.1 and 9.2 instance

- 9.1 testresult
   
  <img width="3456" height="2234" alt="image" src="https://github.com/user-attachments/assets/0403cf60-6d02-40d9-a2f8-5d187bafe6e6" />

- 9.2 testresult
   <img width="3456" height="2234" alt="image" src="https://github.com/user-attachments/assets/3164ece8-d431-4ff1-b3c2-55e024b39720" />


<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
