### PR TITLE
[patch] Add backward compatibility for AIServiceTenant CR's rsl field

### DIFF
--- a/ibm/mas_devops/roles/aiservice_tenant/templates/aiservice/aiservicetenant.yml.j2
+++ b/ibm/mas_devops/roles/aiservice_tenant/templates/aiservice/aiservicetenant.yml.j2
@@ -31,9 +31,11 @@ spec:
             url: "{{ slscfg.url }}"
             secretName: "{{ aiservice_sls_secret }}"
             ca: "{{ slscfg.ca | b64encode  }}"
-{% if rsl_ca_crt is defined and rsl_ca_crt | length > 0 %}
         rsl:
+{% if rsl_ca_crt is defined and rsl_ca_crt | length > 0 %}
             ca: "{{ rsl_ca_crt | b64encode }}"
+{% else %}
+            ca: ""
 {% endif %}
         watsonxai:
             url: "{{ aiservice_watsonxai_url }}"


### PR DESCRIPTION
## Description
<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->
When we will release the new catalog then ibm-aiservice operator (CRD) have the rsl field as optional one. but right now if someone tries to install 9.1.x channel of AI Service and if they dont pass the rsl_ca_crt then rsl field not passed in the AI SerivceTenant CR and according CRD, operator will Not allows to create CR as the current 9.1.x has the rsl field as Required. So for time being we have to add the rsl.ca filed as empty string when not provided.

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

Tested by mas aiservice-install command where I didn't give the rsl_ca_crt value and able to install AI Service
<img width="1459" height="389" alt="image" src="https://github.com/user-attachments/assets/605f53c9-b5ca-478c-b70e-9bd5828da51c" />

 
<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
