### PR TITLE
[patch] Fix debug logging with Manage Foundation

### DIFF
--- a/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/main.yml
@@ -25,7 +25,7 @@
 
 - name: "Manage pre-config : Debug manageWorkspaceComponents"
   debug:
-    msg: "{{ manageWorkspaceComponents }}"
+    msg: "{{ manageWorkspaceComponents | default('<undefined>' }}"
 
 - name: "Manage pre-config : Set Components"
   set_fact:

--- a/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/main.yml
@@ -25,7 +25,7 @@
 
 - name: "Manage pre-config : Debug manageWorkspaceComponents"
   debug:
-    msg: "{{ manageWorkspaceComponents | default('<undefined>' }}"
+    msg: "{{ manageWorkspaceComponents | default('<undefined>') }}"
 
 - name: "Manage pre-config : Set Components"
   set_fact:


### PR DESCRIPTION
## Description

```---
# 1. Configure pod templates
# ------------------------------------------------------------------------
- name: "Manage pre-config : Pod Templates"
  include_tasks: "tasks/manage/pre-config/setup-pod-templates.yml"
  when: is_full_manage
```

we don't run the setup-pod-templates part of the manage pre-config for manage foundation ... is there a reason manage foundation doesn't support pod templating?

Within that task is a key part for all manage install types where this `manageWorkspaceComponents` was set:

```# This will filter out and get selected serverbundle podTemplates from all available serverbundle podTemplates list
# Final list of podTemplates added to manageworkspace CR under spec section
# ====================================================================
- name: Set manage workspace components and server bundle object
  set_fact:
    manageWorkspaceComponents: "{{ mas_appws_components | to_json | from_json }}"
    manageServerBundleData: "{{ mas_app_settings_server_bundles[mas_app_settings_server_bundles_size]['serverBundles'] }}"
```

That debug was new to help with issues in civil enablement ... I'll just add a | default clause to it so that it handles the foundation scenario where this is undefined ... because I assume the rest of the code already handles foundation mode

## Test Results
Tested in fvtcore

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
