### PR TITLE
[patch] Remove ocp_version 4.17 from rotation

### DIFF
--- a/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
@@ -34,7 +34,7 @@
       Wednesday: "4.19"
       Thursday: "4.16"
       Friday: "4.20"
-      Saturday: "4.17"
+      Saturday: "4.18"
       Sunday: "4.19"
 
 - name: "Set default OCP version"

--- a/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/main.yml
@@ -29,12 +29,14 @@
     ocp_version: "{{ rotate_ocp_version[ansible_date_time['weekday']] ~ ('_openshift' if cluster_type == 'roks' else '') }}"
   vars:
     rotate_ocp_version:
+      # Test supported LTS releases twice (4.20, 4.18, 4.16)
       Monday: "4.20"
       Tuesday: "4.18"
-      Wednesday: "4.19"
-      Thursday: "4.16"
-      Friday: "4.20"
-      Saturday: "4.18"
+      Wednesday: "4.16"
+      Thursday: "4.20"
+      Friday: "4.18"
+      Saturday: "4.16"
+      # Test supported Non-TLS releases once (4.19)
       Sunday: "4.19"
 
 - name: "Set default OCP version"


### PR DESCRIPTION
## Description

- Remove ocp version 4.17 from rotation as the maintenance support has ended.

## Test Results

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
