### PR TITLE
[patch] Remove debug task for network variable

### DIFF
--- a/ibm/mas_devops/roles/ocp_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_config/tasks/main.yml
@@ -35,10 +35,6 @@
     - ocp_enable_ipv6 == true
   register: _network
 
-- name: "fyre : Debug network"
-  debug:
-    var: _network
-
 # 6. For IPv6 testing, enable dual stack networking
 - name: "Enable dual stack networking"
   kubernetes.core.k8s_json_patch:

--- a/ibm/mas_devops/roles/ocp_login/tasks/login-fyre.yml
+++ b/ibm/mas_devops/roles/ocp_login/tasks/login-fyre.yml
@@ -23,10 +23,6 @@
     validate_certs: false
   register: _cluster_details
 
-- name: debug
-  debug:
-    var: _cluster_details.json
-
 - set_fact:
     api_host: "api.{{ cluster_name }}.cp.fyre.ibm.com"
     _this_cluster: "{{ _cluster_details.json.clusters | selectattr('cluster_name', '==', cluster_name) | last }}"


### PR DESCRIPTION
Removed debug task for network variable.
to remove the unnecessary debug logs from sps gui

as sps pipeline logs have some limitations. our ipv6 enabled pipeline only stucks.

## Description
to remove the unnecessary debug logs from sps gui

## Test Results
not required, as we are just removing debug block from the code.

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
