### PR TITLE
[patch] add network operator reconciliation wait for dual-stack

### DIFF
--- a/ibm/mas_devops/roles/ocp_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_config/tasks/main.yml
@@ -76,6 +76,7 @@
     msg: "Network operator - Progressing: {{ _network_status.resources[0].status.conditions | selectattr('type', 'equalto', 'Progressing') | map(attribute='status') | first }}, Available: {{ _network_status.resources[0].status.conditions | selectattr('type', 'equalto', 'Available') | map(attribute='status') | first }}"
   when:
     - ocp_enable_ipv6 == true
+    - _network_status is defined
     - _network_status is failed
 
 # 8. Wait for all nodes to report network ready
@@ -84,7 +85,10 @@
     api_version: v1
     kind: Node
   register: _nodes
-  until: _nodes.resources | selectattr('status.conditions', 'defined') | map(attribute='status.conditions') | flatten | selectattr('type', 'equalto', 'NetworkUnavailable') | map(attribute='status') | select('equalto', 'True') | list | length == 0
+  until:
+    - _nodes is succeeded
+    - _nodes.resources is defined
+    - _nodes.resources | selectattr('status.conditions', 'defined') | map(attribute='status.conditions') | flatten | selectattr('type', 'equalto', 'NetworkUnavailable') | map(attribute='status') | select('equalto', 'True') | list | length == 0
   retries: 60
   delay: 10
   when:

--- a/ibm/mas_devops/roles/ocp_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_config/tasks/main.yml
@@ -70,14 +70,12 @@
   delay: 10
   when:
     - ocp_enable_ipv6 == true
-    - _dualstackNetworkAddr is changed
 
 - name: "Debug network operator status"
   debug:
     msg: "Network operator - Progressing: {{ _network_status.resources[0].status.conditions | selectattr('type', 'equalto', 'Progressing') | map(attribute='status') | first }}, Available: {{ _network_status.resources[0].status.conditions | selectattr('type', 'equalto', 'Available') | map(attribute='status') | first }}"
   when:
     - ocp_enable_ipv6 == true
-    - _dualstackNetworkAddr is changed
     - _network_status is failed
 
 # 8. Wait for all nodes to report network ready
@@ -91,4 +89,3 @@
   delay: 10
   when:
     - ocp_enable_ipv6 == true
-    - _dualstackNetworkAddr is changed

--- a/ibm/mas_devops/roles/ocp_config/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_config/tasks/main.yml
@@ -35,10 +35,6 @@
     - ocp_enable_ipv6 == true
   register: _network
 
-- name: "fyre : Debug network"
-  debug:
-    var: _network
-
 # 6. For IPv6 testing, enable dual stack networking
 - name: "Enable dual stack networking"
   kubernetes.core.k8s_json_patch:
@@ -58,3 +54,41 @@
   when:
     - ocp_enable_ipv6 == true
     - "'fd01::/48' not in (_network.result.spec.clusterNetwork | map(attribute='cidr') | list)"
+
+# 7. Wait for network operator to reconcile after dual-stack changes
+- name: "Wait for network operator to complete dual-stack reconciliation"
+  kubernetes.core.k8s_info:
+    api_version: operator.openshift.io/v1
+    kind: Network
+    name: cluster
+  register: _network_status
+  until:
+    - _network_status.resources[0].status.conditions is defined
+    - _network_status.resources[0].status.conditions | selectattr('type', 'equalto', 'Progressing') | map(attribute='status') | first == 'False'
+    - _network_status.resources[0].status.conditions | selectattr('type', 'equalto', 'Available') | map(attribute='status') | first == 'True'
+  retries: 60
+  delay: 10
+  when:
+    - ocp_enable_ipv6 == true
+    - _dualstackNetworkAddr is changed
+
+- name: "Debug network operator status"
+  debug:
+    msg: "Network operator - Progressing: {{ _network_status.resources[0].status.conditions | selectattr('type', 'equalto', 'Progressing') | map(attribute='status') | first }}, Available: {{ _network_status.resources[0].status.conditions | selectattr('type', 'equalto', 'Available') | map(attribute='status') | first }}"
+  when:
+    - ocp_enable_ipv6 == true
+    - _dualstackNetworkAddr is changed
+    - _network_status is failed
+
+# 8. Wait for all nodes to report network ready
+- name: "Wait for all nodes to report network ready"
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Node
+  register: _nodes
+  until: _nodes.resources | selectattr('status.conditions', 'defined') | map(attribute='status.conditions') | flatten | selectattr('type', 'equalto', 'NetworkUnavailable') | map(attribute='status') | select('equalto', 'True') | list | length == 0
+  retries: 60
+  delay: 10
+  when:
+    - ocp_enable_ipv6 == true
+    - _dualstackNetworkAddr is changed


### PR DESCRIPTION
## Description
<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->

## Test Results
https://cloud.ibm.com/devops/pipelines/tekton/3612e317-4d13-42a4-b798-d7db422549f8/runs/09db3c4f-998b-43ac-87f0-8ac19e78a5c9/fvt-init?env_id=ibm:yp:us-south&view=logs

<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
