### PR TITLE
[patch] Allow adoption metrics to be omitted from Suite spec when not explicitly configured

### DIFF
--- a/ibm/mas_devops/roles/suite_install/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_install/defaults/main.yml
@@ -157,6 +157,6 @@ mas_superuser_password: "{{ lookup('env', 'MAS_SUPERUSER_PASSWORD') }}"
 # -----------------------------------------------------------------------------
 mas_enable_walkme: "{{ lookup('env', 'MAS_ENABLE_WALKME') | default('true', true) | bool }}"
 
-mas_feature_usage: "{{ lookup('env', 'MAS_FEATURE_USAGE') | default('true', true) | bool }}"
-mas_usability_metrics: "{{ lookup('env', 'MAS_USABILITY_METRICS') | default('true', true) | bool }}"
-mas_deployment_progression: "{{ lookup('env', 'MAS_DEPLOYMENT_PROGRESSION') | default('true', true) | bool }}"
+mas_feature_usage: "{{ lookup('env', 'MAS_FEATURE_USAGE') }}"
+mas_usability_metrics: "{{ lookup('env', 'MAS_USABILITY_METRICS') }}"
+mas_deployment_progression: "{{ lookup('env', 'MAS_DEPLOYMENT_PROGRESSION') }}"

--- a/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
+++ b/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
@@ -88,15 +88,15 @@ spec:
       allowSpecialChars: {{ mas_special_characters | bool}}
 {% endif %}
 {% if mas_channel != '8.7.x' and mas_channel != '8.8.x' and mas_channel != '8.9.x' and mas_channel != '8.10.x' and mas_channel != '8.11.x' and mas_channel != '9.0.x' %}
-{% if (mas_deployment_progression is defined and mas_deployment_progression in ['true', 'false']) or (mas_usability_metrics is defined and mas_usability_metrics in ['true', 'false']) or (mas_feature_usage is defined and mas_feature_usage in ['true', 'false']) %}
+{% if (mas_deployment_progression is defined and mas_deployment_progression != '') or (mas_usability_metrics is defined and mas_usability_metrics != '') or (mas_feature_usage is defined and mas_feature_usage != '') %}
     metricCollection:
-{% if mas_deployment_progression is defined and mas_deployment_progression in ['true', 'false'] %}
+{% if mas_deployment_progression is defined and mas_deployment_progression != '' %}
       deploymentProgression: {{ mas_deployment_progression | bool }}
 {% endif %}
-{% if mas_usability_metrics is defined and mas_usability_metrics in ['true', 'false'] %}
+{% if mas_usability_metrics is defined and mas_usability_metrics != '' %}
       usability: {{ mas_usability_metrics | bool }}
 {% endif %}
-{% if mas_feature_usage is defined and mas_feature_usage in ['true', 'false'] %}
+{% if mas_feature_usage is defined and mas_feature_usage != '' %}
       featureUse: {{ mas_feature_usage | bool }}
 {% endif %}
 {% endif %}

--- a/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
+++ b/ibm/mas_devops/roles/suite_install/templates/core_v1_suite.yml.j2
@@ -88,15 +88,15 @@ spec:
       allowSpecialChars: {{ mas_special_characters | bool}}
 {% endif %}
 {% if mas_channel != '8.7.x' and mas_channel != '8.8.x' and mas_channel != '8.9.x' and mas_channel != '8.10.x' and mas_channel != '8.11.x' and mas_channel != '9.0.x' %}
-{% if (mas_deployment_progression is defined and mas_deployment_progression != '') or (mas_usability_metrics is defined and mas_usability_metrics != '') or (mas_feature_usage is defined and mas_feature_usage != '') %}
+{% if (mas_deployment_progression != '') or (mas_usability_metrics != '') or (mas_feature_usage != '') %}
     metricCollection:
-{% if mas_deployment_progression is defined and mas_deployment_progression != '' %}
+{% if mas_deployment_progression != '' %}
       deploymentProgression: {{ mas_deployment_progression | bool }}
 {% endif %}
-{% if mas_usability_metrics is defined and mas_usability_metrics != '' %}
+{% if mas_usability_metrics != '' %}
       usability: {{ mas_usability_metrics | bool }}
 {% endif %}
-{% if mas_feature_usage is defined and mas_feature_usage != '' %}
+{% if mas_feature_usage != '' %}
       featureUse: {{ mas_feature_usage | bool }}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
## Description
Updates adoption metrics configuration to allow metrics to be omitted from the Suite CR spec when not explicitly set, rather than always including them with default values. 
https://jsw.ibm.com/browse/MASCORE-14397

## Test Results
Tested with MAS_FEATURE_USAGE=false and MAS_DEPLOYMENT_PROGRESSION=true
Verified Suite CR spec shows only explicitly set metrics
<img width="1970" height="1654" alt="image" src="https://github.com/user-attachments/assets/3c98988f-c40f-44aa-b06a-76b90a6896b1" />
<img width="3456" height="2004" alt="image" src="https://github.com/user-attachments/assets/99211825-4cc9-4eed-9979-b72ab42c55d0" />


<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
