### PR TITLE
[patch] Ensure defaultCertificate exists before use

### DIFF
--- a/ibm/mas_devops/common_tasks/get_signed_ingress_cert.yml
+++ b/ibm/mas_devops/common_tasks/get_signed_ingress_cert.yml
@@ -83,6 +83,8 @@
 
     - when:
         - cluster_ingresscontroller_lookup.resources is defined and cluster_ingresscontroller_lookup.resources | length > 0
+        - cluster_ingresscontroller_lookup.resources[0].spec.defaultCertificate is defined
+        - cluster_ingresscontroller_lookup.resources[0].spec.defaultCertificate.name is defined
         - cluster_ingresscontroller_lookup.resources[0].spec.defaultCertificate.name | length > 0
       block:
         - name: Set default secret name containing cluster's ingress certificate based on IngressController default


### PR DESCRIPTION
Add explicit checks in the IngressController lookup 'when' clause to ensure spec.defaultCertificate and spec.defaultCertificate.name are defined before evaluating the name length. This prevents undefined-attribute errors when an IngressController does not specify a defaultCertificate and guards the subsequent logic that sets the default secret name for the cluster ingress certificate.

## Description
<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
