### PR TITLE
[patch] IBM Cloud Pak for Data' option is missing from the dropdown in CPD

### DIFF
--- a/ibm/mas_devops/roles/cp4d/tasks/install-cp4d.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/install-cp4d.yml
@@ -210,8 +210,15 @@
   retries: 60 # Approximately 2 hours before we give up
   delay: 120 # 2 minutes
 
+# 5. Create CPD perspective configuration for Zen UI
+# -----------------------------------------------------------------------------
+- name: "install-cp4d : Apply CPD ZenExtension perspective configuration"
+  kubernetes.core.k8s:
+    state: present
+    apply: yes
+    template: "templates/cpd_platform/zenextension-icp4data-perspective.yml.j2"
 
-# 5. Lookup CPD credentials
+# 6. Lookup CPD credentials
 # -----------------------------------------------------------------------------
 # If 'ibm-iam-bindinfo-platform-auth-idp-credentials' exists, then CPD 4.8 has been installed/upgraded
 # If 'admin-user-details' secret exists, then CPD 4.6 has been installed/upgraded

--- a/ibm/mas_devops/roles/cp4d/templates/cpd_platform/zenextension-icp4data-perspective.yml.j2
+++ b/ibm/mas_devops/roles/cp4d/templates/cpd_platform/zenextension-icp4data-perspective.yml.j2
@@ -1,0 +1,89 @@
+apiVersion: zen.cpd.ibm.com/v1
+kind: ZenExtension
+metadata:
+  name: icp4data-perspective-config
+  namespace: "{{ cpd_instance_namespace }}"
+  labels:
+    icpdsupport/addOnId: zen-lite
+    component: zen-perspectives
+spec:
+  extensions: |
+    [
+      {
+        "extension_point_id": "zen_perspective_configuration",
+        "extension_name": "icp4data-perspective",
+        "display_name": "IBM CloudPak for Data Perspective",
+        "order_hint": 100,
+        "match_permissions": "",
+        "meta": {},
+        "details": {
+          "product_name": "IBM Cloud Pak for Data",
+          "product_edition": "Enterprise",
+          "product_version": "v{{ cpd_product_version }}",
+          "context": "icp4data",
+          "links": {
+            "homepage": "/zen/?context=icp4data#/homepage",
+            "documentation": "https://www.ibm.com/docs/SSQNUZ_{{ cpd_product_version }}.x",
+            "walk_me": "/zen-content/static/lite-guided-tours/5c74b6e5f8b341c7a37268296b6551c6/walkme_5c74b6e5f8b341c7a37268296b6551c6_https.js"
+          },
+          "images": {
+            "homepage": "default_welcome_image.svg",
+            "browser_icon": "default_favicon.ico",
+            "login": "default.svg"
+          },
+          "exclusive_components": [
+            "factsheet",
+            "analyticsengine",
+            "cognos_analytics",
+            "dashboard",
+            "dp",
+            "replication",
+            "datalineage",
+            "datastage_ent",
+            "datastage_ent_plus",
+            "db2oltp",
+            "bigsql",
+            "datagate",
+            "dmc",
+            "db2wh",
+            "dods",
+            "postgresql",
+            "edb_cp4d",
+            "hee",
+            "wkc",
+            "ikc_standard",
+            "ikc_premium",
+            "match360",
+            "informix",
+            "informix_cp4d",
+            "mantaflow",
+            "mongodb",
+            "mongodb_cp4d",
+            "openpages",
+            "planning_analytics",
+            "productmaster",
+            "rstudio",
+            "spss",
+            "streamsets",
+            "voice_gateway",
+            "watson_discovery",
+            "wml",
+            "wml_accelerator",
+            "openscale",
+            "ws_pipelines",
+            "dv",
+            "watson_speech",
+            "ws",
+            "ws_runtimes",
+            "watson_assistant",
+            "watsonx_bi_assistant",
+            "watsonx_data",
+            "watsonx_orchestrate"
+          ],
+          "entitlements": [
+            "cpd-standard",
+            "cpd-enterprise"
+          ]
+        }
+      }
+    ]


### PR DESCRIPTION
## Description
<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->
'IBM Cloud Pak for Data' option is missing from the dropdown in CPD, even though Cognos Analytics was selected during the installation 
## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->
I made changes in MAS CLI in local and then performed the installation , option started appearing .
<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
