### PR TITLE
[patch] Fix AWS EFS CSI Driver Credential Mismatch Issue

### DIFF
--- a/ibm/mas_devops/roles/ocp_efs/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_efs/tasks/main.yml
@@ -59,7 +59,47 @@
     template: "templates/efs-csi-driver.yml.j2"
 
 
-# 5. Create a Storage Class for aws efs
+# 5. Wait for ClusterCSIDriver and let cloud-credential-operator create secret
+# -----------------------------------------------------------------------------
+- name: "Wait for ClusterCSIDriver to be created"
+  kubernetes.core.k8s_info:
+    api_version: operator.openshift.io/v1
+    kind: ClusterCSIDriver
+    name: efs.csi.aws.com
+  register: csi_driver
+  until:
+    - csi_driver.resources is defined
+    - csi_driver.resources | length > 0
+  retries: 30
+  delay: 10
+
+- name: "Wait for cloud-credential-operator to create secret (if available)"
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: aws-efs-cloud-credentials
+    namespace: openshift-cluster-csi-drivers
+  register: efs_secret_check
+  until: efs_secret_check.resources | length > 0
+  retries: 12  # Wait up to 2 minutes for cloud-credential-operator
+  delay: 10
+  ignore_errors: true
+
+- name: "Debug: Check if secret was created by cloud-credential-operator"
+  debug:
+    msg: "Secret exists: {{ efs_secret_check.resources | length > 0 }}"
+
+
+# 6. Fallback: Create secret manually if cloud-credential-operator didn't create it
+# -----------------------------------------------------------------------------
+- name: "Fallback: Create secret manually if not created by cloud-credential-operator"
+  kubernetes.core.k8s:
+    apply: yes
+    template: "templates/aws-secret.yml.j2"
+  when: efs_secret_check.resources | length == 0
+
+
+# 7. Create a Storage Class for aws efs
 # -----------------------------------------------------------------------------
 - name: "Create a Storage Class for aws efs"
   kubernetes.core.k8s:

--- a/ibm/mas_devops/roles/ocp_efs/tasks/main.yml
+++ b/ibm/mas_devops/roles/ocp_efs/tasks/main.yml
@@ -45,10 +45,10 @@
 
 # 3. Add AWS credentials to OpenShift secrets
 # -----------------------------------------------------------------------------
-- name: "Create Secret"
-  kubernetes.core.k8s:
-    apply: yes
-    template: "templates/aws-secret.yml.j2"
+# Note: The cloud-credential-operator will automatically create and manage
+# the aws-efs-cloud-credentials secret in openshift-cluster-csi-drivers namespace
+# when the ClusterCSIDriver is installed. Manual secret creation is not needed
+# and can cause credential mismatch issues.
 
 
 # 4. Install AWS EFS CSI DRIVER


### PR DESCRIPTION
## Description
The `ocp_efs` role was causing credential mismatch errors in OpenShift clusters, resulting in a degraded `cloud-credential` operator status. This issue manifested as:

```
NAME               VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
cloud-credential   4.x.x     True        False         True       Xm      1 of 8 credentials requests are failing to sync
```

<img width="1321" height="886" alt="Degraded" src="https://github.com/user-attachments/assets/2d5e84be-8713-48e2-9608-5c65710dde33" />

## Issue

The reported bug- [cli-issues- 1199](https://github.com/ibm-mas/cli/issues/1199)

## Root Cause

The role manually created the `aws-efs-cloud-credentials` secret in the `openshift-cluster-csi-drivers` namespace using credentials from environment variables (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`). However, OpenShift's `cloud-credential-operator` also attempts to manage this same secret automatically when the ClusterCSIDriver is installed.

This created a conflict where:
1. The Ansible role created the secret with credentials from environment variables
2. The cloud-credential-operator expected to manage the secret with credentials from the cluster's AWS credential chain
3. The manually created credentials often didn't match the IAM user's actual access keys
4. This caused the error: **"error processing secret"** with credential mismatch

### Error Details

When checking the CredentialsRequest status, the error showed:

<img width="1286" height="367" alt="credentialrequest-status" src="https://github.com/user-attachments/assets/1e11c504-aae4-4019-9cb3-67ae5be28daa" />

### Impact

- **Degraded cluster operator:** The `cloud-credential` operator showed as degraded
- **Manual intervention required:** Users had to manually delete the secret and IAM access keys to resolve the issue

<img width="1440" height="411" alt="Manual-workaround" src="https://github.com/user-attachments/assets/00ffc26f-d2e4-4ea0-9c1d-d471038497e2" />

Above screenshot shows manual workaround applied in a cluster where issue was observed. 

## Solution

Remove manual secret creation from the `ocp_efs` role and let OpenShift's `cloud-credential-operator` manage the secret automatically.

### Changes Made

**File:** `ibm/mas_devops/roles/ocp_efs/tasks/main.yml`

**Removed (below lines):**
```yaml
# 3. Add AWS credentials to OpenShift secrets
# -----------------------------------------------------------------------------
- name: "Create Secret"
  kubernetes.core.k8s:
    apply: yes
    template: "templates/aws-secret.yml.j2"
```

**Added documentation :**
```yaml
# 3. Add AWS credentials to OpenShift secrets
# -----------------------------------------------------------------------------
# Note: The cloud-credential-operator will automatically create and manage
# the aws-efs-cloud-credentials secret in openshift-cluster-csi-drivers namespace
# when the ClusterCSIDriver is installed. Manual secret creation is not needed
# and can cause credential mismatch issues.
```


## Test Results

### After the Fix

<img width="1686" height="787" alt="After-fix" src="https://github.com/user-attachments/assets/eb3c2927-1a13-4ccd-910c-e47aac6bf410" />

Ran the updated EFS Role, post that verified the status:

<img width="1066" height="828" alt="Verify-afterfix" src="https://github.com/user-attachments/assets/e8bff10d-28f6-45df-a5b4-84b440353be6" />






<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
