### PR TITLE
[patch] increase db2 instance upgrade timeout to 60 minutes

### DIFF
--- a/ibm/mas_devops/roles/db2/tasks/upgrade/run-db2-instances-upgrade.yml
+++ b/ibm/mas_devops/roles/db2/tasks/upgrade/run-db2-instances-upgrade.yml
@@ -128,7 +128,7 @@
     - db2_instance_lookup.resources[0].status.state is defined
     - db2_instance_lookup.resources[0].status.state == "Ready"
     - db2_instance_lookup.resources[0].status.version == db2_version
-  retries: 30 # Approximately 30 minutes before we give up
+  retries: 60 # Approximately 60 minutes before we give up
   delay: 60 # 1 minute
   loop: "{{ db2Instance_names | zip(db2Instance_versions) | list }}"
 


### PR DESCRIPTION
## Description
In the last `fvtday2` run the timeout wasn't enough for the upgrade of Db2 from v11 to v12. The instances got upgraded, but required more time.

**Failure**
<img width="2368" height="1208" alt="image" src="https://github.com/user-attachments/assets/6efc2778-9a05-4afc-977d-499f05721a34" />

**Instances sucessfully upgraded**
<img width="1222" height="394" alt="image" src="https://github.com/user-attachments/assets/ffbf88fb-12e5-4959-8e43-749954527687" />
<img width="1388" height="1172" alt="image" src="https://github.com/user-attachments/assets/1f20b218-9f38-4ebe-8b35-5f95a3286247" />
<img width="1408" height="1166" alt="image" src="https://github.com/user-attachments/assets/20df87ee-f96f-4349-b283-045678494167" />



## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
