### PR TITLE
[patch] Increase timeout for facilities upgrade task

### DIFF
--- a/ibm/mas_devops/roles/suite_app_upgrade/tasks/upgrade.yml
+++ b/ibm/mas_devops/roles/suite_app_upgrade/tasks/upgrade.yml
@@ -152,7 +152,7 @@
     - app_ws_cr_lookup.resources is defined
     - app_ws_cr_lookup.resources | json_query('[*].status.conditions[?type==`Ready`][].reason') | select ('in', ['Ready', 'WorkspaceReady']) | list | length == app_ws_cr_lookup.resources | length
   when:
-    - mas_app_id != "manage" or mas_app_id == "facilities"
+    - mas_app_id != "manage" or mas_app_id != "facilities"
   register: app_ws_cr_lookup
 
 - name: "{{ mas_app_id }} : Debug Workspaces"

--- a/ibm/mas_devops/roles/suite_app_upgrade/tasks/upgrade.yml
+++ b/ibm/mas_devops/roles/suite_app_upgrade/tasks/upgrade.yml
@@ -112,12 +112,31 @@
   delay: 120 # 2 minutes
   until:
     - manage_ws_cr_lookup.resources is defined
-    - manage_ws_cr_lookup.resources | json_query('[*].status.conditions[?type==`Ready`][].reason') | select ('in', ['Ready']) | list | length == app_ws_cr_lookup.resources | length
-    - manage_ws_cr_lookup.resources | json_query('[*].status.conditions[?type==`Running`][].reason') | select ('in', ['Successful']) | list | length == app_ws_cr_lookup.resources | length
-    - manage_ws_cr_lookup.resources | json_query('[*].status.conditions[?type==`DeploymentCR`][].reason') | select ('in', ['Successful']) | list | length == app_ws_cr_lookup.resources | length
+    - manage_ws_cr_lookup.resources | json_query('[*].status.conditions[?type==`Ready`][].reason') | select ('in', ['Ready']) | list | length == manage_ws_cr_lookup.resources | length
+    - manage_ws_cr_lookup.resources | json_query('[*].status.conditions[?type==`Running`][].reason') | select ('in', ['Successful']) | list | length == manage_ws_cr_lookup.resources | length
+    - manage_ws_cr_lookup.resources | json_query('[*].status.conditions[?type==`DeploymentCR`][].reason') | select ('in', ['Successful']) | list | length == manage_ws_cr_lookup.resources | length
   when:
     - mas_app_id == "manage"
   register: manage_ws_cr_lookup
+
+- name: 'Check that all workspace CRs are healthy (facilities only)'
+  kubernetes.core.k8s_info:
+    api_version: "{{ app_info[mas_app_id].api_version }}"
+    kind: "{{ app_info[mas_app_id].ws_kind }}"
+    namespace: "{{ mas_app_namespace }}"
+    label_selectors:
+      - mas.ibm.com/instanceId={{ mas_instance_id }}
+      - mas.ibm.com/applicationId={{ mas_app_id }}
+  retries: 45 # about 90 minutes
+  delay: 120 # 2 minutes
+  until:
+    - facilities_ws_cr_lookup.resources is defined
+    - facilities_ws_cr_lookup.resources | json_query('[*].status.conditions[?type==`Ready`][].reason') | select ('in', ['Ready']) | list | length == facilities_ws_cr_lookup.resources | length
+    - facilities_ws_cr_lookup.resources | json_query('[*].status.conditions[?type==`Running`][].reason') | select ('in', ['Successful']) | list | length == facilities_ws_cr_lookup.resources | length
+    - facilities_ws_cr_lookup.resources | json_query('[*].status.conditions[?type==`DeploymentCR`][].reason') | select ('in', ['Successful']) | list | length == facilities_ws_cr_lookup.resources | length
+  when:
+    - mas_app_id == "facilities"
+  register: facilities_ws_cr_lookup
 
 - name: 'Check that all workspace CRs are healthy'
   kubernetes.core.k8s_info:
@@ -133,7 +152,7 @@
     - app_ws_cr_lookup.resources is defined
     - app_ws_cr_lookup.resources | json_query('[*].status.conditions[?type==`Ready`][].reason') | select ('in', ['Ready', 'WorkspaceReady']) | list | length == app_ws_cr_lookup.resources | length
   when:
-    - mas_app_id != "manage"
+    - mas_app_id != "manage" or mas_app_id == "facilities"
   register: app_ws_cr_lookup
 
 - name: "{{ mas_app_id }} : Debug Workspaces"


### PR DESCRIPTION
## Description
Increased the timeout for `facilities` upgrade task to 90 minutes and fixed the `Check that all workspace CRs are healthy (manage only)` task

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->
Ran the pfvt with day2 pipeline. Attaching the screenshot of fvt pipeline completion:
<img width="3358" height="2030" alt="image" src="https://github.com/user-attachments/assets/2a21a2ec-03a7-4566-b12c-aa1a3f6d923e" />
<img width="3358" height="2030" alt="image" src="https://github.com/user-attachments/assets/5db366f2-628d-4577-9fe3-40e83eb773ad" />

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
