### PR TITLE
[patch] fix db2u_kind variable in db2 install

### DIFF
--- a/ibm/mas_devops/roles/db2/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/db2/tasks/install/main.yml
@@ -447,7 +447,7 @@
   when:
     - db2_timezone is defined
     - db2_timezone != ""
-    - db2ukind == "db2ucluster"
+    - db2u_kind == "db2ucluster"
 
 # 18. Configure a public route for Db2
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Regression caused by https://github.com/ibm-mas/ansible-devops/pull/2289

Fixing the variable db2ukind which is undefined. The variable to be used is db2u_kind.

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
