### PR TITLE
[patch] delete enforec configmap when deleting db2instance

### DIFF
--- a/ibm/mas_devops/roles/suite_db2_setup_for_facilities/templates/db2_enforce_config.yaml.j2
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_facilities/templates/db2_enforce_config.yaml.j2
@@ -4,9 +4,11 @@ metadata:
   name: "{{db2_instance_name | lower}}-enforce-mref-config"
   ownerReferences:
     - apiVersion: db2u.databases.ibm.com/v1
-      kind: Db2uCluster
-      name: "{{ db2_instance_name | lower }}"
-      uid: "{{ db2_instance_uid }}"  
+      kind: Db2uInstance
+      name: "{{db2_instance_name | lower}}"
+      uid: "{{ _db2_instance_engn_svc.resources[0].metadata.uid }}"
+      controller: false
+      blockOwnerDeletion: false
 data:
   version: "{{ db2_config_version }}"
 

--- a/ibm/mas_devops/roles/suite_db2_setup_for_manage/templates/db2_enforce_config.yaml.j2
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_manage/templates/db2_enforce_config.yaml.j2
@@ -2,6 +2,13 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{db2_instance_name | lower}}-enforce-config"
+  ownerReferences:
+    - apiVersion: db2u.databases.ibm.com/v1
+      kind: Db2uInstance
+      name: "{{db2_instance_name | lower}}"
+      uid: "{{ _db2_instance_engn_svc.resources[0].metadata.uid }}"
+      controller: false
+      blockOwnerDeletion: false
 data:
   version: "{{ db2_config_version }}"
   enforced: "{{ enforce_db2_config | string }}"


### PR DESCRIPTION
## Description
If DB2u deleted, delete "enforce" configmap

## Test Results
```
arunaaravanna@192 manage % oc get db2uinstance -n tenantgroup-xda2jh
NAME     STATE  MAINTENANCESTATE  AGE
db2-xda2jh  Ready           24m



arunaaravanna@192 manage % oc get configmap db2-xda2jh-enforce-config -n tenantgroup-xda2jh  
NAME            DATA  AGE
db2-xda2jh-enforce-config  2   4m18s

arunaaravanna@192 manage % 
arunaaravanna@192 manage % 
arunaaravanna@192 manage % oc delete db2uinstance db2-xda2jh -n tenantgroup-xda2jh
db2uinstance.db2u.databases.ibm.com "db2-xda2jh" deleted from tenantgroup-xda2jh namespace

arunaaravanna@192 manage % oc get db2uinstance -n tenantgroup-xda2jh               
No resources found in tenantgroup-xda2jh namespace.

arunaaravanna@192 manage % oc get configmap db2-xda2jh-enforce-config -n tenantgroup-xda2jh  
Error from server (NotFound): configmaps "db2-xda2jh-enforce-config" not found
<hr/>
```

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
