### PR TITLE
[patch] Add 9.2.x compatibility and upgrade paths

### DIFF
--- a/ibm/mas_devops/common_vars/compatibility_matrix.yml
+++ b/ibm/mas_devops/common_vars/compatibility_matrix.yml
@@ -136,7 +136,6 @@ upgrade_requirement:
 
 # There is probably a better way to do this by manipulating the channel string, but this is fast and cheap!
 upgrade_path:
-  9.2.x: 9.2.x
   9.2.x-feature: 9.2.x
   9.1.x: 9.2.x-feature
   9.1.x-feature: 9.1.x

--- a/ibm/mas_devops/common_vars/compatibility_matrix.yml
+++ b/ibm/mas_devops/common_vars/compatibility_matrix.yml
@@ -2,6 +2,7 @@
 # sequance required old -> new
 compatibility_matrix:
   9.2.x:
+    aiservice: [9.1.x, 9.2.x-feature, 9.2.x]
     manage: [9.1.x, 9.2.x-feature, 9.2.x]
     optimizer: [9.1.x, 9.2.x-feature, 9.2.x]
     visualinspection: [9.1.x, 9.2.x-feature, 9.2.x]
@@ -146,4 +147,6 @@ upgrade_path:
 # The key is the current installed channel of AI Service
 # and the value is the allowed upgrade versions.
 aiservice_upgrade_path:
+  9.2.x: [9.1.x, 9.2.x-feature]
+  9.2.x-feature: [ 9.1.x ]
   9.1.x: [9.2.x-feature]

--- a/ibm/mas_devops/common_vars/compatibility_matrix.yml
+++ b/ibm/mas_devops/common_vars/compatibility_matrix.yml
@@ -2,7 +2,6 @@
 # sequance required old -> new
 compatibility_matrix:
   9.2.x:
-    aiservice_tenant: [9.2.x-feature, 9.2.x]
     aiservice: [9.1.x, 9.2.x-feature, 9.2.x]
     manage: [9.1.x, 9.2.x-feature, 9.2.x]
     optimizer: [9.1.x, 9.2.x-feature, 9.2.x]
@@ -152,7 +151,4 @@ aiservice_upgrade_path:
   9.2.x: [9.1.x, 9.2.x-feature]
   9.2.x-feature: [ 9.1.x ]
   9.1.x: [9.2.x-feature]
-
-aiservice_tenant_upgrade_path:
-  9.2.x: [9.2.x-feature]
 

--- a/ibm/mas_devops/common_vars/compatibility_matrix.yml
+++ b/ibm/mas_devops/common_vars/compatibility_matrix.yml
@@ -2,6 +2,7 @@
 # sequance required old -> new
 compatibility_matrix:
   9.2.x:
+    aiservice_tenant: [9.2.x-feature, 9.2.x]
     aiservice: [9.1.x, 9.2.x-feature, 9.2.x]
     manage: [9.1.x, 9.2.x-feature, 9.2.x]
     optimizer: [9.1.x, 9.2.x-feature, 9.2.x]
@@ -131,6 +132,7 @@ upgrade_requirement:
     8.9.x: [8.8.x]
     8.8.x: [8.7.x]
   facilities:
+    9.2.x: [9.1.x, 9.2.x-feature]
     9.2.x-feature: [ 9.1.x ]
 
 # There is probably a better way to do this by manipulating the channel string, but this is fast and cheap!
@@ -150,3 +152,7 @@ aiservice_upgrade_path:
   9.2.x: [9.1.x, 9.2.x-feature]
   9.2.x-feature: [ 9.1.x ]
   9.1.x: [9.2.x-feature]
+
+aiservice_tenant_upgrade_path:
+  9.2.x: [9.2.x-feature]
+

--- a/ibm/mas_devops/common_vars/compatibility_matrix.yml
+++ b/ibm/mas_devops/common_vars/compatibility_matrix.yml
@@ -1,6 +1,14 @@
 ---
 # sequance required old -> new
 compatibility_matrix:
+  9.2.x:
+    manage: [9.1.x, 9.2.x-feature, 9.2.x]
+    optimizer: [9.1.x, 9.2.x-feature, 9.2.x]
+    visualinspection: [9.1.x, 9.2.x-feature, 9.2.x]
+    monitor: [9.1.x, 9.2.x-feature, 9.2.x]
+    iot: [9.1.x, 9.2.x-feature, 9.2.x]
+    facilities: [9.1.x, 9.2.x-feature, 9.2.x]
+    predict: [9.1.x, 9.2.x-feature, 9.2.x]
   9.2.x-feature:
     manage: [9.1.x, 9.2.x-feature]
     optimizer: [9.1.x, 9.2.x-feature]
@@ -64,6 +72,7 @@ compatibility_matrix:
 # There is probably a better way to do this by manipulating the channel string, but this is fast and cheap!
 upgrade_requirement:
   core:
+    9.2.x: [9.1.x, 9.2.x-feature]
     9.2.x-feature: [ 9.1.x ]
     9.1.x: [9.0.x, 9.1.x-feature]
     9.1.x-feature: [9.0.x]
@@ -76,12 +85,14 @@ upgrade_requirement:
     8.8.x: [8.7.x]
     8.7.x: [8.6.x]
   iot:
+    9.2.x: [9.1.x, 9.2.x-feature]
     9.2.x-feature: [ 9.1.x ]
     9.1.x: [9.0.x]
     9.0.x: [8.8.x]
     8.8.x: [8.7.x]
     8.7.x: [8.6.x]
   manage:
+    9.2.x: [9.1.x, 9.2.x-feature]
     9.2.x-feature: [ 9.1.x ]
     9.1.x: [9.0.x, 9.1.x-feature]
     9.1.x-feature: [9.0.x]
@@ -89,12 +100,14 @@ upgrade_requirement:
     8.7.x: [8.6.x]
     8.6.x: [8.5.x]
   monitor:
+    9.2.x: [9.1.x, 9.2.x-feature]
     9.2.x-feature: [ 9.1.x ]
     9.1.x: [9.0.x]
     9.0.x: [8.11.x]
     8.11.x: [8.10.x]
     8.10.x: [8.9.x]
   optimizer:
+    9.2.x: [9.1.x, 9.2.x-feature]
     9.2.x-feature: [ 9.1.x ]
     9.1.x: [9.0.x, 9.1.x-feature]
     9.1.x-feature: [9.0.x]
@@ -102,12 +115,14 @@ upgrade_requirement:
     8.5.x: [8.4.x]
     8.4.x: [8.3.x]
   predict:
+    9.2.x: [9.1.x, 9.2.x-feature]
     9.2.x-feature: [ 9.1.x ]
     9.1.x: [9.0.x]
     9.0.x: [8.9.x]
     8.9.x: [8.8.x]
     8.8.x: [8.7.x]
   visualinspection:
+    9.2.x: [9.1.x, 9.2.x-feature]
     9.2.x-feature: [ 9.1.x ]
     9.1.x: [9.0.x, 9.1.x-feature]
     9.1.x-feature: [9.0.x]
@@ -119,6 +134,8 @@ upgrade_requirement:
 
 # There is probably a better way to do this by manipulating the channel string, but this is fast and cheap!
 upgrade_path:
+  9.2.x: 9.2.x
+  9.2.x-feature: 9.2.x
   9.1.x: 9.2.x-feature
   9.1.x-feature: 9.1.x
   9.0.x: 9.1.x


### PR DESCRIPTION
Introduce 9.2.x entries to the compatibility matrix and upgrade rules. Added 9.2.x compatibility lists for manage, optimizer, visualinspection, monitor, iot, facilities, and predict, and added corresponding upgrade_requirement entries (pointing to [9.1.x, 9.2.x-feature]) for core, iot, manage, monitor, optimizer, predict, and visualinspection. Also updated upgrade_path to map 9.2.x and 9.2.x-feature to the 9.2.x channel.

## Description
<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
