### PR TITLE
[patch] add retry logic while fetching db2 manifest data

### DIFF
--- a/ibm/mas_devops/roles/db2/tasks/upgrade/prepare-db2-upgrade.yml
+++ b/ibm/mas_devops/roles/db2/tasks/upgrade/prepare-db2-upgrade.yml
@@ -10,7 +10,7 @@
         namespace: "{{ ibm_common_services_namespace }}"
       register: db2u_manifest_info
       until:
-        - db2u_manifest_info.resources is defined  
+        - db2u_manifest_info.resources is defined
         - db2u_manifest_info.resources | length > 0
       retries: 10 # Approximately 5 minutes before we give up
       delay: 30

--- a/ibm/mas_devops/roles/db2/tasks/upgrade/prepare-db2-upgrade.yml
+++ b/ibm/mas_devops/roles/db2/tasks/upgrade/prepare-db2-upgrade.yml
@@ -9,6 +9,11 @@
         name: db2u-operator
         namespace: "{{ ibm_common_services_namespace }}"
       register: db2u_manifest_info
+      until:
+        - db2u_manifest_info.resources is defined  
+        - db2u_manifest_info.resources | length > 0
+      retries: 10 # Approximately 5 minutes before we give up
+      delay: 30
 
     - name: Set db2u-operator update channel to latest default channel if not provided
       set_fact:


### PR DESCRIPTION
## Description
When `db2_channel` is not defined, we fallback to getting the latest channel option from PackageManifest. Sometimes, the package manifest is not ready when the automation tries to get the channels and throws an error due to empty resources. Therefore, it has been added a retry logic to avoid that scenario.

Alongside with this PR, there is another one that fixes the `db2_channel` parameter in the CLI that makes sure that the data is coming from the catalog metadata.

Reference: https://github.com/ibm-mas/cli/pull/2376

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
