### PR TITLE
[patch] CAService's instance ca-addon-cr not updating after running upgrade of Cp4d.

### DIFF
--- a/ibm/mas_devops/roles/cp4d_service/tasks/install.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/install.yml
@@ -194,6 +194,9 @@
   kubernetes.core.k8s:
     apply: yes
     template: "templates/services/{{ cpd_service_name }}.yml.j2"
+    server_side_apply:
+      field_manager: ansible
+      force_conflicts: true
 
 # This is just a validation step to prevent the "wait tasks" to run before it gives enough time for the new cpd service operator version
 # to start reconciling in case of an upgrade, otherwise it might not have given enough time for it to process the new version to be upgrade


### PR DESCRIPTION
## Description
<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->
Version mismatch error comes when upgrading the cp4d where CA is also Installed.
## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->
tested in my cluster, it updated the version of ca-addon-cr successfully.
<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
