### PR TITLE
[patch] Fix delay period

### DIFF
--- a/ibm/mas_devops/roles/suite_manage_pvc_config/README.md
+++ b/ibm/mas_devops/roles/suite_manage_pvc_config/README.md
@@ -273,7 +273,7 @@ export MAS_APP_SETTINGS_CUSTOM_PVC_SIZE=20Gi
 export MAS_APP_SETTINGS_CUSTOM_MOUNT_PATH=/MyOwnDir
 export MAS_APP_SETTINGS_CUSTOM_PV_FILE_PATH=/my-path/manage-pv.yml
 
-ROLE_NAME='suite_manage_pvc_config' ansible-playbook ansible-devops/playbooks/run_role.yml
+ROLE_NAME='suite_manage_pvc_config' ansible-playbook ibm.mas_devops.run_role
 ```
 
 ## License

--- a/ibm/mas_devops/roles/suite_manage_pvc_config/README.md
+++ b/ibm/mas_devops/roles/suite_manage_pvc_config/README.md
@@ -273,7 +273,7 @@ export MAS_APP_SETTINGS_CUSTOM_PVC_SIZE=20Gi
 export MAS_APP_SETTINGS_CUSTOM_MOUNT_PATH=/MyOwnDir
 export MAS_APP_SETTINGS_CUSTOM_PV_FILE_PATH=/my-path/manage-pv.yml
 
-ROLE_NAME='suite_manage_pvc_config' ansible-playbook playbooks/run_role.yml
+ROLE_NAME='suite_manage_pvc_config' ansible-playbook ansible-devops/playbooks/run_role.yml
 ```
 
 ## License

--- a/ibm/mas_devops/roles/suite_manage_pvc_config/tasks/configure-manage-pvcs.yml
+++ b/ibm/mas_devops/roles/suite_manage_pvc_config/tasks/configure-manage-pvcs.yml
@@ -51,7 +51,7 @@
     wait_timeout: 200 # before we give up and fall back into the retry loop
   register: app_cr_result
   retries: 20
-  delay: 0
+  delay: 60
   until:
     - app_cr_result.resources is defined
     - app_cr_result.resources | length > 0


### PR DESCRIPTION
## Description
The delay between retries was `0` hence the workspance instance could not get ready in time. I notices that it take around 15 mins to get ready so set the delay to 60 seconds. 

```yaml

TASK [ibm.mas_devops.suite_manage_pvc_config : Wait for ManageWorkspace to be ready (60s delay)] ***************************************************************************************************************************************************************************************
FAILED - RETRYING: [localhost]: Wait for ManageWorkspace to be ready (60s delay) (20 retries left).
FAILED - RETRYING: [localhost]: Wait for ManageWorkspace to be ready (60s delay) (19 retries left).
FAILED - RETRYING: [localhost]: Wait for ManageWorkspace to be ready (60s delay) (18 retries left).
FAILED - RETRYING: [localhost]: Wait for ManageWorkspace to be ready (60s delay) (17 retries left).
FAILED - RETRYING: [localhost]: Wait for ManageWorkspace to be ready (60s delay) (16 retries left).
FAILED - RETRYING: [localhost]: Wait for ManageWorkspace to be ready (60s delay) (15 retries left).
FAILED - RETRYING: [localhost]: Wait for ManageWorkspace to be ready (60s delay) (14 retries left).
FAILED - RETRYING: [localhost]: Wait for ManageWorkspace to be ready (60s delay) (13 retries left).
FAILED - RETRYING: [localhost]: Wait for ManageWorkspace to be ready (60s delay) (12 retries left).
FAILED - RETRYING: [localhost]: Wait for ManageWorkspace to be ready (60s delay) (11 retries left).
FAILED - RETRYING: [localhost]: Wait for ManageWorkspace to be ready (60s delay) (10 retries left).
FAILED - RETRYING: [localhost]: Wait for ManageWorkspace to be ready (60s delay) (9 retries left).
FAILED - RETRYING: [localhost]: Wait for ManageWorkspace to be ready (60s delay) (8 retries left).
FAILED - RETRYING: [localhost]: Wait for ManageWorkspace to be ready (60s delay) (7 retries left).
FAILED - RETRYING: [localhost]: Wait for ManageWorkspace to be ready (60s delay) (6 retries left).
FAILED - RETRYING: [localhost]: Wait for ManageWorkspace to be ready (60s delay) (5 retries left).
FAILED - RETRYING: [localhost]: Wait for ManageWorkspace to be ready (60s delay) (4 retries left).
FAILED - RETRYING: [localhost]: Wait for ManageWorkspace to be ready (60s delay) (3 retries left).
FAILED - RETRYING: [localhost]: Wait for ManageWorkspace to be ready (60s delay) (2 retries left).
FAILED - RETRYING: [localhost]: Wait for ManageWorkspace to be ready (60s delay) (1 retries left).
[ERROR]: Task failed: Action failed: Unknown error.
Origin: /opt/app-root/lib64/python3.12/site-packages/ansible_collections/ibm/mas_devops/roles/suite_manage_pvc_config/tasks/configure-manage-pvcs.yml:40:3

38       - "ManageWorkspace Changed ............... {{ _changed_pvc.changed }}"
39
40 - name: "Wait for ManageWorkspace to be ready (60s delay)"
     ^ column 3
```

## Test Results
The time was enough for instance to get ready

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
