### PR TITLE
[patch] CIS Suite DNS job failing in FVT

### DIFF
--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_managed_ruleset.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_managed_ruleset.yml
@@ -1,7 +1,8 @@
 ---
 - name: "cis: validate rule {{ item.rule_id }} exists"
   ansible.builtin.shell: |
-    ibmcloud cis managed-waf ruleset {{ (_cis_domains_result.stdout | from_json)[0].id }} {{ _cis_ruleset_result.stdout }} --output json | jq -r --arg rule_id {{ item.rule_id }} '.rules[] | select(.id == $rule_id) | .id'
+    ibmcloud cis managed-waf ruleset {{ (_cis_domains_result.stdout | from_json)[0].id }} {{ _cis_ruleset_result.stdout }} \
+    -i "{{ cis_service_name }}" --output json | jq -r --arg rule_id {{ item.rule_id }} '.rules[] | select(.id == $rule_id) | .id'
   failed_when: false
   register: _cis_rule_check
 

--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_suitedns_enhanced.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_suitedns_enhanced.yml
@@ -34,32 +34,34 @@
     - name: "cis: list of managed ruleset rules to disable"
       ansible.builtin.include_vars: vars/managed_ruleset_rules_to_disable.yml
 
-    - name: "cis: get CIS Managed Ruleset ruleset_id"
+    - name: "cis: get Cloudflare Managed Ruleset ruleset_id"
       ansible.builtin.shell: |
         ibmcloud cis managed-waf rulesets {{ (_cis_domains_result.stdout | from_json)[0].id }} \
-        --output json | jq '.[] | select(.name == "CIS Managed Ruleset") | .id'
+        -i "{{ cis_service_name }}" --output json | jq -r '.[] | select(.name == "Cloudflare Managed Ruleset") | .id'
       register: _cis_ruleset_result
 
     - name: "cis: get deployed rule id for CIS Managed Ruleset id"
       ansible.builtin.shell: |
         ibmcloud cis managed-waf deployments {{ (_cis_domains_result.stdout | from_json)[0].id }} \
-        --output json | jq -r --arg target_id {{ _cis_ruleset_result.stdout }} '.rules[] | select(.action_parameters.id == $target_id) | .id'
+        -i "{{ cis_service_name }}" --output json | jq -r --arg target_id {{ _cis_ruleset_result.stdout }} '.rules[] | select(.action_parameters.id == $target_id) | .id'
       register: _cis_rule_id_result
 
     - name: "cis: add CIS Managed Ruleset to WAF when WAF rule does not exist"
       ansible.builtin.shell: |
-        ibmcloud cis managed-waf deployment-add-ruleset {{ (_cis_domains_result.stdout | from_json)[0].id }} {{ _cis_ruleset_result.stdout }} --enabled true
+        ibmcloud cis managed-waf deployment-add-ruleset {{ (_cis_domains_result.stdout | from_json)[0].id }} {{ _cis_ruleset_result.stdout }} \
+        -i "{{ cis_service_name }}" --enabled true
       when: _cis_rule_id_result.stdout | trim | length == 0
 
     - name: "cis: get deployed rule id for CIS Managed Ruleset id"
       ansible.builtin.shell: |
         ibmcloud cis managed-waf deployments {{ (_cis_domains_result.stdout | from_json)[0].id }} \
-        --output json | jq -r --arg target_id "{{ _cis_ruleset_result.stdout }}" '.rules[] | select(.action_parameters.id == $target_id) | .id'
+        -i "{{ cis_service_name }}" --output json | jq -r --arg target_id "{{ _cis_ruleset_result.stdout }}" '.rules[] | select(.action_parameters.id == $target_id) | .id'
       register: _cis_rule_id_result
 
     - name: "cis: enable CIS Default Ruleset"
       ansible.builtin.shell: |
-        ibmcloud cis managed-waf deployment-update-ruleset {{ (_cis_domains_result.stdout | from_json)[0].id }} {{ _cis_rule_id_result.stdout }} --enabled true
+        ibmcloud cis managed-waf deployment-update-ruleset {{ (_cis_domains_result.stdout | from_json)[0].id }} {{ _cis_rule_id_result.stdout }} \
+        -i "{{ cis_service_name }}" --enabled true
 
     - ansible.builtin.include_tasks: tasks/providers/cis/cis_managed_ruleset.yml
       loop: "{{ managed_ruleset_rules_to_disable }}"


### PR DESCRIPTION
Issue: [MASCORE-14831](https://jsw.ibm.com/browse/MASCORE-14831)

## Description
- CIS Managed Ruleset is not available - only Cloudflare Managed Ruleset
- Set instance context to cis service name

## Test Results
Tested in fvtsaas https://openshift-gitops-server-openshift-gitops.apps.fvtsaas.ub9f.p1.openshiftapps.com/applications/openshift-gitops/syncjobs.fvtsaas.fvtsaas?view=tree&resource=&node=batch%2FJob%2Fmas-fvtsaas-syncres%2Fibm-suite-dns-2586685340&tab=logs

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
