### PR TITLE
[patch] added verification for generating SLSCfg with external SLS

### DIFF
--- a/ibm/mas_devops/roles/sls/tasks/gencfg/main.yml
+++ b/ibm/mas_devops/roles/sls/tasks/gencfg/main.yml
@@ -43,13 +43,15 @@
 # has no Route (no domain field in CR), then there is a delay until the operator reconciles
 # and updates the url field in the configmap. Hence, we should not take the value from
 # the configmap as it may still hold the old value (service url instead of domain).
+# If the user has explicitly provided sls_url (e.g. an external SLS instance) then we must
+# honour it and skip both the domain-based derivation and the configmap lookup/assertion.
 - name: Set sls_url when sls_domain is defined
-  when: sls_domain is defined and sls_domain != ""
+  when: sls_domain is defined and sls_domain != "" and (sls_url is not defined or sls_url == "")
   ansible.builtin.set_fact:
     sls_url: "https://{{sls_instance_name}}.{{sls_namespace}}.{{sls_domain}}"
 
 - name: "Assert that SLS url has been provided"
-  when: sls_domain is not defined or sls_domain == ""
+  when: (sls_domain is not defined or sls_domain == "") and (sls_url is not defined or sls_url == "")
   ansible.builtin.assert:
     that:
       - _sls_suite_registration.resources[0].data['url'] is defined
@@ -57,7 +59,7 @@
     fail_msg: "url is not defined in sls-suite-registration configmap"
 
 - name: Set sls_url from sls-suite-registration ConfigMap
-  when: sls_domain is not defined or sls_domain == ""
+  when: (sls_domain is not defined or sls_domain == "") and (sls_url is not defined or sls_url == "")
   ansible.builtin.set_fact:
     sls_url: "{{ _sls_suite_registration.resources[0].data['url'] }}"
 


### PR DESCRIPTION
## Summary
Fixes a failure in the `sls` role's `gencfg` task when generating an SLSCfg against an existing/external SLS instance by passing `sls_url` (along with cert and registration key).

## Problem
In `ibm/mas_devops/roles/sls/tasks/gencfg/main.yml` the URL-handling tasks only branched on `sls_domain`. Because `sls_domain` is always defined (defaults to an empty string via `lookup('env', ...)`), the role ignored a user-supplied `sls_url` and tried to read `url` from the `sls-suite-registration` ConfigMap, which does not contain it for an instance with no Route. This caused:

```
[ERROR]: Task failed: Action failed: url is not defined in sls-suite-registration configmap
```

## Fix
The three URL tasks now also check `(sls_url is not defined or sls_url == "")` so that an explicitly provided `sls_url` is honoured and the ConfigMap lookup/assertion is skipped. This matches the behaviour already described in the existing code comment above those tasks.

## Testing
Ran `ROLE_NAME=sls ansible-playbook ibm.mas_devops.run_role` with `SLS_ACTION=gencfg`, `SLS_URL`, `SLS_REGISTRATION_KEY` and `SLS_TLS_CERT_LOCAL_FILE_PATH` set against an existing external SLS instance; the SLSCfg now generates successfully.
