### PR TITLE
[patch] add topology spread constraints to MongoDB CE 0.12.0 CR

### DIFF
--- a/ibm/mas_devops/roles/mongodb/templates/community/0.12.0/cr.yml.j2
+++ b/ibm/mas_devops/roles/mongodb/templates/community/0.12.0/cr.yml.j2
@@ -54,6 +54,19 @@ spec:
       selector: {}
       template:
         spec:
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  app: mas-mongo-ce-svc
+            - maxSkew: 1
+              topologyKey: topology.kubernetes.io/zone
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  app: mas-mongo-ce-svc
           containers:
             - name: mongod
 {% if controlled_upgrade %}


### PR DESCRIPTION
## Summary
Adds pod `topologySpreadConstraints` to the MongoDB Community Edition (0.12.0) `MongoDBCommunity` CR template so that the replica-set pods are distributed across nodes and zones instead of potentially co-locating on the same node/zone.

## Problem
The community provider deploys the `MongoDBCommunity` CR from `ibm/mas_devops/roles/mongodb/templates/community/0.12.0/cr.yml.j2`, but the pod spec did not declare any topology spread or anti-affinity rules. As a result, the MongoDB replica-set members could be scheduled onto the same node or availability zone, reducing resilience to node/zone failures.

## Fix
Added two `topologySpreadConstraints` under `spec.statefulSet.spec.template.spec`, both selecting the MongoDB CE pods via `app: mas-mongo-ce-svc`:

| topologyKey | maxSkew | whenUnsatisfiable |
| --- | --- | --- |
| `kubernetes.io/hostname` (node) | 1 | `ScheduleAnyway` |
| `topology.kubernetes.io/zone` (zone) | 1 | `ScheduleAnyway` |

`ScheduleAnyway` makes the spreading best-effort, so it improves distribution without ever blocking scheduling on clusters that have fewer nodes/zones than replicas (e.g. single-zone or SNO clusters).

## Scope
- Applies to the `0.12.0` community CR template only.
- Existing pods are not rescheduled automatically; constraints take effect on the next CR apply / reconcile.
