### PR TITLE
[minor] Backup and restore - option to exclude apps pvc

### DIFF
--- a/ibm/mas_devops/roles/suite_app_backup/README.md
+++ b/ibm/mas_devops/roles/suite_app_backup/README.md
@@ -67,22 +67,13 @@ Optional custom version identifier for the backup. If not specified, defaults to
 - Default: Auto-generated timestamp
 - Example: `20240315-143022` or `v1.0-prod`
 
-### mas_app_backup_manage_include_pvc
-Controls whether persistent volume data should be backed up for Manage application. When set to `false`, only namespace resources (CRs, secrets, subscriptions) are backed up, and PVC data is skipped.
+### mas_app_backup_include_pvc
+Controls whether persistent volume data should be backed up for application. When set to `false`, only namespace resources (CRs, secrets, subscriptions) are backed up, and PVC data is skipped.
 
 - Optional
-- Environment Variable: `MAS_APP_BACKUP_MANAGE_INCLUDE_PVC`
+- Environment Variable: `MAS_APP_BACKUP_INCLUDE_PVC`
 - Default: `true`
 - Valid Values: `true`, `false`
-
-### mas_app_backup_facilities_include_pvc
-Controls whether persistent volume data should be backed up for Facilities application. When set to `false`, only namespace resources (CRs, secrets, subscriptions) are backed up, and PVC data is skipped.
-
-- Optional
-- Environment Variable: `MAS_APP_BACKUP_FACILITIES_INCLUDE_PVC`
-- Default: `true`
-- Valid Values: `true`, `false`
-
 
 What Gets Backed Up
 -------------------------------------------------------------------------------
@@ -268,7 +259,7 @@ Backup only Manage namespace resources, skipping persistent volume data:
     mas_workspace_id: ws1
     mas_app_id: manage
     mas_backup_dir: /backup/mas
-    mas_app_backup_manage_include_pvc: false
+    mas_app_backup_include_pvc: false
   roles:
     - ibm.mas_devops.suite_app_backup
 ```
@@ -284,7 +275,7 @@ Backup only Facilities namespace resources, skipping persistent volume data:
     mas_workspace_id: ws1
     mas_app_id: facilities
     mas_backup_dir: /backup/mas
-    mas_app_backup_facilities_include_pvc: false
+    mas_app_backup_include_pvc: false
   roles:
     - ibm.mas_devops.suite_app_backup
 ```

--- a/ibm/mas_devops/roles/suite_app_backup/README.md
+++ b/ibm/mas_devops/roles/suite_app_backup/README.md
@@ -67,6 +67,22 @@ Optional custom version identifier for the backup. If not specified, defaults to
 - Default: Auto-generated timestamp
 - Example: `20240315-143022` or `v1.0-prod`
 
+### mas_app_backup_manage_include_pvc
+Controls whether persistent volume data should be backed up for Manage application. When set to `false`, only namespace resources (CRs, secrets, subscriptions) are backed up, and PVC data is skipped.
+
+- Optional
+- Environment Variable: `MAS_APP_BACKUP_MANAGE_INCLUDE_PVC`
+- Default: `true`
+- Valid Values: `true`, `false`
+
+### mas_app_backup_facilities_include_pvc
+Controls whether persistent volume data should be backed up for Facilities application. When set to `false`, only namespace resources (CRs, secrets, subscriptions) are backed up, and PVC data is skipped.
+
+- Optional
+- Environment Variable: `MAS_APP_BACKUP_FACILITIES_INCLUDE_PVC`
+- Default: `true`
+- Valid Values: `true`, `false`
+
 
 What Gets Backed Up
 -------------------------------------------------------------------------------
@@ -237,6 +253,38 @@ Backup with a custom version identifier:
     mas_app_id: manage
     mas_backup_dir: /backup/mas
     mas_app_backup_version: "prod-backup-20240315"
+  roles:
+    - ibm.mas_devops.suite_app_backup
+```
+
+### Backup Manage Without PVC Data
+Backup only Manage namespace resources, skipping persistent volume data:
+
+```yaml
+- hosts: localhost
+  any_errors_fatal: true
+  vars:
+    mas_instance_id: inst1
+    mas_workspace_id: ws1
+    mas_app_id: manage
+    mas_backup_dir: /backup/mas
+    mas_app_backup_manage_include_pvc: false
+  roles:
+    - ibm.mas_devops.suite_app_backup
+```
+
+### Backup Facilities Without PVC Data
+Backup only Facilities namespace resources, skipping persistent volume data:
+
+```yaml
+- hosts: localhost
+  any_errors_fatal: true
+  vars:
+    mas_instance_id: inst1
+    mas_workspace_id: ws1
+    mas_app_id: facilities
+    mas_backup_dir: /backup/mas
+    mas_app_backup_facilities_include_pvc: false
   roles:
     - ibm.mas_devops.suite_app_backup
 ```

--- a/ibm/mas_devops/roles/suite_app_backup/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_app_backup/defaults/main.yml
@@ -16,8 +16,5 @@ mas_backup_dir: "{{ lookup('env', 'MAS_BACKUP_DIR') }}"
 # Optional: Specify a custom backup version (defaults to timestamp YYYYMMDD-HHMMSS)
 mas_app_backup_version: "{{ lookup('env', 'MAS_APP_BACKUP_VERSION') }}"
 
-# Optional: Include PVC backup for Manage application (defaults to true)
-mas_app_backup_manage_include_pvc: "{{ lookup('env', 'MAS_APP_BACKUP_MANAGE_INCLUDE_PVC') | default('true', true) | bool }}"
-
-# Optional: Include PVC backup for Facilities application (defaults to true)
-mas_app_backup_facilities_include_pvc: "{{ lookup('env', 'MAS_APP_BACKUP_FACILITIES_INCLUDE_PVC') | default('true', true) | bool }}"
+# Optional: Include PVC backup for application (defaults to true)
+mas_app_backup_include_pvc: "{{ lookup('env', 'MAS_APP_BACKUP_INCLUDE_PVC') | default('true', true) | bool }}"

--- a/ibm/mas_devops/roles/suite_app_backup/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_app_backup/defaults/main.yml
@@ -15,3 +15,9 @@ mas_backup_dir: "{{ lookup('env', 'MAS_BACKUP_DIR') }}"
 
 # Optional: Specify a custom backup version (defaults to timestamp YYYYMMDD-HHMMSS)
 mas_app_backup_version: "{{ lookup('env', 'MAS_APP_BACKUP_VERSION') }}"
+
+# Optional: Include PVC backup for Manage application (defaults to true)
+mas_app_backup_manage_include_pvc: "{{ lookup('env', 'MAS_APP_BACKUP_MANAGE_INCLUDE_PVC') | default('true', true) | bool }}"
+
+# Optional: Include PVC backup for Facilities application (defaults to true)
+mas_app_backup_facilities_include_pvc: "{{ lookup('env', 'MAS_APP_BACKUP_FACILITIES_INCLUDE_PVC') | default('true', true) | bool }}"

--- a/ibm/mas_devops/roles/suite_app_backup/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_backup/tasks/main.yml
@@ -55,6 +55,7 @@
 
         - name: "Backup Manage persistent volumes"
           include_tasks: "{{ role_path }}/tasks/manage/backup-pv.yml"
+          when: mas_app_backup_manage_include_pvc | bool
 
         - name: "Manage backup completed successfully"
           debug:
@@ -65,6 +66,7 @@
               - "Instance ID: {{ mas_instance_id }}"
               - "Workspace ID: {{ mas_workspace_id }}"
               - "Backup Location: {{ manage_backup_path }}"
+              - "PVC Backup: {{ 'Included' if mas_app_backup_manage_include_pvc | bool else 'Skipped' }}"
               - "=========================================="
 
     # Facilities backup
@@ -77,6 +79,7 @@
 
         - name: "Backup Facilities persistent volumes"
           include_tasks: "{{ role_path }}/tasks/facilities/backup-pv.yml"
+          when: mas_app_backup_facilities_include_pvc | bool
 
         - name: "Facilities backup completed successfully"
           debug:
@@ -87,6 +90,7 @@
               - "Instance ID: {{ mas_instance_id }}"
               - "Workspace ID: {{ mas_workspace_id }}"
               - "Backup Location: {{ facilities_backup_path }}"
+              - "PVC Backup: {{ 'Included' if mas_app_backup_facilities_include_pvc | bool else 'Skipped' }}"
               - "=========================================="
 
     # Unsupported app

--- a/ibm/mas_devops/roles/suite_app_backup/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_backup/tasks/main.yml
@@ -55,7 +55,7 @@
 
         - name: "Backup Manage persistent volumes"
           include_tasks: "{{ role_path }}/tasks/manage/backup-pv.yml"
-          when: mas_app_backup_manage_include_pvc | bool
+          when: mas_app_backup_include_pvc | bool
 
         - name: "Manage backup completed successfully"
           debug:
@@ -66,7 +66,7 @@
               - "Instance ID: {{ mas_instance_id }}"
               - "Workspace ID: {{ mas_workspace_id }}"
               - "Backup Location: {{ manage_backup_path }}"
-              - "PVC Backup: {{ 'Included' if mas_app_backup_manage_include_pvc | bool else 'Skipped' }}"
+              - "PVC Backup: {{ 'Included' if mas_app_backup_include_pvc | bool else 'Skipped' }}"
               - "=========================================="
 
     # Facilities backup
@@ -79,7 +79,7 @@
 
         - name: "Backup Facilities persistent volumes"
           include_tasks: "{{ role_path }}/tasks/facilities/backup-pv.yml"
-          when: mas_app_backup_facilities_include_pvc | bool
+          when: mas_app_backup_include_pvc | bool
 
         - name: "Facilities backup completed successfully"
           debug:
@@ -90,7 +90,7 @@
               - "Instance ID: {{ mas_instance_id }}"
               - "Workspace ID: {{ mas_workspace_id }}"
               - "Backup Location: {{ facilities_backup_path }}"
-              - "PVC Backup: {{ 'Included' if mas_app_backup_facilities_include_pvc | bool else 'Skipped' }}"
+              - "PVC Backup: {{ 'Included' if mas_app_backup_include_pvc | bool else 'Skipped' }}"
               - "=========================================="
 
     # Unsupported app

--- a/ibm/mas_devops/roles/suite_app_restore/README.md
+++ b/ibm/mas_devops/roles/suite_app_restore/README.md
@@ -118,22 +118,13 @@ Custom storage class to use for PVCs with ReadWriteOnce (RWO) access mode when `
 - Default: Empty (uses default storage class)
 - Example: `ocs-storagecluster-ceph-rbd`
 
-### mas_app_restore_manage_include_pvc
-Control whether to restore persistent volume data for Manage application. When set to `false`, only namespace resources (CRs, secrets, subscriptions) will be restored, and PVC data restore will be skipped.
+### mas_app_restore_include_pvc
+Control whether to restore persistent volume data for application. When set to `false`, only namespace resources (CRs, secrets, subscriptions) will be restored, and PVC data restore will be skipped.
 
 - Optional
-- Environment Variable: `MAS_APP_RESTORE_MANAGE_INCLUDE_PVC`
+- Environment Variable: `mas_app_restore_include_pvc`
 - Default: `true`
 - Valid Values: `true`, `false`
-
-### mas_app_restore_facilities_include_pvc
-Control whether to restore persistent volume data for Facilities application. When set to `false`, only namespace resources (CRs, secrets, subscriptions) will be restored, and PVC data restore will be skipped.
-
-- Optional
-- Environment Variable: `MAS_APP_RESTORE_FACILITIES_INCLUDE_PVC`
-- Default: `true`
-- Valid Values: `true`, `false`
-
 
 What Gets Restored
 -------------------------------------------------------------------------------
@@ -481,7 +472,7 @@ Restore only namespace resources without restoring persistent volume data:
     mas_backup_dir: /backup/mas
     mas_app_backup_version: "20240315-143022"
     # Skip PVC restore
-    mas_app_restore_manage_include_pvc: false
+    mas_app_restore_include_pvc: false
   roles:
     - ibm.mas_devops.suite_app_restore
 ```
@@ -499,7 +490,7 @@ Restore Facilities namespace resources without restoring persistent volume data:
     mas_backup_dir: /backup/mas
     mas_app_backup_version: "20240315-143022"
     # Skip PVC restore
-    mas_app_restore_facilities_include_pvc: false
+    mas_app_restore_include_pvc: false
   roles:
     - ibm.mas_devops.suite_app_restore
 ```

--- a/ibm/mas_devops/roles/suite_app_restore/README.md
+++ b/ibm/mas_devops/roles/suite_app_restore/README.md
@@ -118,6 +118,22 @@ Custom storage class to use for PVCs with ReadWriteOnce (RWO) access mode when `
 - Default: Empty (uses default storage class)
 - Example: `ocs-storagecluster-ceph-rbd`
 
+### mas_app_restore_manage_include_pvc
+Control whether to restore persistent volume data for Manage application. When set to `false`, only namespace resources (CRs, secrets, subscriptions) will be restored, and PVC data restore will be skipped.
+
+- Optional
+- Environment Variable: `MAS_APP_RESTORE_MANAGE_INCLUDE_PVC`
+- Default: `true`
+- Valid Values: `true`, `false`
+
+### mas_app_restore_facilities_include_pvc
+Control whether to restore persistent volume data for Facilities application. When set to `false`, only namespace resources (CRs, secrets, subscriptions) will be restored, and PVC data restore will be skipped.
+
+- Optional
+- Environment Variable: `MAS_APP_RESTORE_FACILITIES_INCLUDE_PVC`
+- Default: `true`
+- Valid Values: `true`, `false`
+
 
 What Gets Restored
 -------------------------------------------------------------------------------
@@ -448,6 +464,42 @@ Restore with override enabled but using cluster's default storage classes:
     # Enable storage class override without specifying custom classes
     # Will automatically use the cluster's default storage class
     override_storageclass: true
+  roles:
+    - ibm.mas_devops.suite_app_restore
+```
+
+### Restore Without PVC Data
+Restore only namespace resources without restoring persistent volume data:
+
+```yaml
+- hosts: localhost
+  any_errors_fatal: true
+  vars:
+    mas_instance_id: inst1
+    mas_workspace_id: ws1
+    mas_app_id: manage
+    mas_backup_dir: /backup/mas
+    mas_app_backup_version: "20240315-143022"
+    # Skip PVC restore
+    mas_app_restore_manage_include_pvc: false
+  roles:
+    - ibm.mas_devops.suite_app_restore
+```
+
+### Restore Facilities Without PVC Data
+Restore Facilities namespace resources without restoring persistent volume data:
+
+```yaml
+- hosts: localhost
+  any_errors_fatal: true
+  vars:
+    mas_instance_id: inst1
+    mas_workspace_id: ws1
+    mas_app_id: facilities
+    mas_backup_dir: /backup/mas
+    mas_app_backup_version: "20240315-143022"
+    # Skip PVC restore
+    mas_app_restore_facilities_include_pvc: false
   roles:
     - ibm.mas_devops.suite_app_restore
 ```

--- a/ibm/mas_devops/roles/suite_app_restore/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_app_restore/defaults/main.yml
@@ -30,6 +30,14 @@ mas_app_custom_storage_class_rwx: "{{ lookup('env', 'MAS_APP_CUSTOM_STORAGE_CLAS
 # Custom storage class for ReadWriteOnce (RWO) access mode
 mas_app_custom_storage_class_rwo: "{{ lookup('env', 'MAS_APP_CUSTOM_STORAGE_CLASS_RWO') | default('', true) }}"
 
+# PVC Restore Control
+# -----------------------------------------------------------------------------
+# Optional: Include PVC restore for Manage application (defaults to true)
+mas_app_restore_manage_include_pvc: "{{ lookup('env', 'MAS_APP_RESTORE_MANAGE_INCLUDE_PVC') | default('true', true) | bool }}"
+
+# Optional: Include PVC restore for Facilities application (defaults to true)
+mas_app_restore_facilities_include_pvc: "{{ lookup('env', 'MAS_APP_RESTORE_FACILITIES_INCLUDE_PVC') | default('true', true) | bool }}"
+
 _manage_persistent_volumes: "NO_OVERRIDE"
 
 _facilities_log_storage: "NO_OVERRIDE"

--- a/ibm/mas_devops/roles/suite_app_restore/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_app_restore/defaults/main.yml
@@ -32,11 +32,8 @@ mas_app_custom_storage_class_rwo: "{{ lookup('env', 'MAS_APP_CUSTOM_STORAGE_CLAS
 
 # PVC Restore Control
 # -----------------------------------------------------------------------------
-# Optional: Include PVC restore for Manage application (defaults to true)
-mas_app_restore_manage_include_pvc: "{{ lookup('env', 'MAS_APP_RESTORE_MANAGE_INCLUDE_PVC') | default('true', true) | bool }}"
-
-# Optional: Include PVC restore for Facilities application (defaults to true)
-mas_app_restore_facilities_include_pvc: "{{ lookup('env', 'MAS_APP_RESTORE_FACILITIES_INCLUDE_PVC') | default('true', true) | bool }}"
+# Optional: Include PVC restore for application (defaults to true)
+mas_app_restore_include_pvc: "{{ lookup('env', 'MAS_APP_RESTORE_INCLUDE_PVC') | default('true', true) | bool }}"
 
 _manage_persistent_volumes: "NO_OVERRIDE"
 

--- a/ibm/mas_devops/roles/suite_app_restore/tasks/facilities/restore-namespace.yml
+++ b/ibm/mas_devops/roles/suite_app_restore/tasks/facilities/restore-namespace.yml
@@ -40,11 +40,6 @@
 - name: Detect Certificate Manager installation
   include_tasks: "{{ role_path }}/../../common_tasks/detect_cert_manager.yml"
 
-# 2.2. Determine storage class override settings
-# ---------------------------------------------------------------------
-- name: "Determine storage class override settings"
-  include_tasks: "{{ role_path }}/tasks/facilities/determine-storage-class-override.yml"
-
 # 3. Set Facilities namespace and workspace CR name
 # -----------------------------------------------------------------------------
 - name: "Set fact: Facilities namespace"
@@ -68,6 +63,11 @@
 - name: "Set fact: Facilities workspace CR name"
   set_fact:
     facilities_workspace_cr_name: "{{ workspace_backup_cr.metadata.name}}"
+
+# 3.1. Determine storage class override settings
+# ---------------------------------------------------------------------
+- name: "Determine storage class override settings"
+  include_tasks: "{{ role_path }}/tasks/facilities/determine-storage-class-override.yml"
 
 # 4. Restore resources until FacilitiesApp CR (excluding FacilitiesWorkspace)
 # -----------------------------------------------------------------------------

--- a/ibm/mas_devops/roles/suite_app_restore/tasks/facilities/restore-namespace.yml
+++ b/ibm/mas_devops/roles/suite_app_restore/tasks/facilities/restore-namespace.yml
@@ -40,6 +40,11 @@
 - name: Detect Certificate Manager installation
   include_tasks: "{{ role_path }}/../../common_tasks/detect_cert_manager.yml"
 
+# 2.2. Determine storage class override settings
+# ---------------------------------------------------------------------
+- name: "Determine storage class override settings"
+  include_tasks: "{{ role_path }}/tasks/facilities/determine-storage-class-override.yml"
+
 # 3. Set Facilities namespace and workspace CR name
 # -----------------------------------------------------------------------------
 - name: "Set fact: Facilities namespace"

--- a/ibm/mas_devops/roles/suite_app_restore/tasks/facilities/restore-pv.yml
+++ b/ibm/mas_devops/roles/suite_app_restore/tasks/facilities/restore-pv.yml
@@ -2,101 +2,11 @@
 # Restore Facilities Persistent Volumes
 # =============================================================================
 # This task restores Facilities persistent volume data by:
-# 1. Checking if FacilitiesWorkspace CR exists
-# 2. If not present, restoring FacilitiesWorkspace CR and waiting for ready
-# 3. If present, scaling down pods using podTemplates
-# 4. Restoring PVC data using dummy pods
-# 5. Scaling up pods by clearing podTemplates
+# 1. If Workspace present, scaling down pods using podTemplates
+# 2. Restoring PVC data using dummy pods
+# 3. Scaling up pods by clearing podTemplates
 
-# 1. Check if FacilitiesWorkspace CR exists
-# -----------------------------------------------------------------------------
-- name: "Display restore phase 3 information"
-  debug:
-    msg:
-      - "=========================================="
-      - "Phase 3: Check FacilitiesWorkspace CR"
-      - "=========================================="
-
-- name: "Check if FacilitiesWorkspace CR exists"
-  kubernetes.core.k8s_info:
-    api_version: apps.mas.ibm.com/v1
-    kind: FacilitiesWorkspace
-    name: "{{ facilities_workspace_cr_name }}"
-    namespace: "{{ mas_app_namespace }}"
-  register: existing_facilities_workspace_cr
-
-- name: "Set fact: FacilitiesWorkspace CR exists"
-  set_fact:
-    facilities_workspace_exists: "{{ existing_facilities_workspace_cr.resources is defined and existing_facilities_workspace_cr.resources | length > 0 }}"
-
-- name: "Display FacilitiesWorkspace CR status"
-  debug:
-    msg: "FacilitiesWorkspace CR {{ 'exists' if facilities_workspace_exists else 'does not exist' }}"
-
-# 2. If workspace CR not present, restore it and wait for ready
-# -----------------------------------------------------------------------------
-- name: "Restore FacilitiesWorkspace CR (if not present)"
-  when: (facilities_workspace_exists | bool) == false
-  block:
-    - name: "Display workspace restore information"
-      debug:
-        msg: "FacilitiesWorkspace CR not found - restoring from backup"
-
-    # Determine storage class override settings
-    # ---------------------------------------------------------------------
-    - name: "Determine storage class override settings"
-      include_tasks: "{{ role_path }}/tasks/facilities/determine-storage-class-override.yml"
-
-    - name: "Restore FacilitiesWorkspace CR"
-      ibm.mas_devops.restore_resource:
-        backup_path: "{{ facilities_backup_path }}"
-        resource_kinds:
-          - FacilitiesWorkspace
-        override_values:
-          FacilitiesWorkspace:
-            - spec.settings.storage.log.class: "{{ _facilities_log_storage }}"
-            - spec.settings.storage.userfiles.class: "{{ _facilities_userfiles_storage }}"
-      register: facilities_restore_workspace_result
-
-    - name: "Display FacilitiesWorkspace CR restore results"
-      debug:
-        msg: >-
-          Facilities Workspace resource: {{ facilities_restore_workspace_result.created_count }} created,
-          {{ facilities_restore_workspace_result.updated_count }} updated,
-          {{ facilities_restore_workspace_result.skipped_count }} skipped,
-          {{ facilities_restore_workspace_result.failed_count }} failed
-
-    - name: "Fail if FacilitiesWorkspace CR restore had errors"
-      fail:
-        msg: "FacilitiesWorkspace CR restore failed. See logs for details."
-      when: facilities_restore_workspace_result.failed_count | int > 0
-
-    - name: "Wait for FacilitiesWorkspace to be ready"
-      kubernetes.core.k8s_info:
-        api_version: apps.mas.ibm.com/v1
-        kind: FacilitiesWorkspace
-        name: "{{ facilities_workspace_cr_name }}"
-        namespace: "{{ mas_app_namespace }}"
-      register: workspace_ready_status
-      retries: "{{ mas_app_restore_wait_retries | int }}"
-      delay: "{{ mas_app_restore_wait_delay | int }}"
-      until:
-        - workspace_ready_status.resources is defined
-        - workspace_ready_status.resources | length > 0
-        - workspace_ready_status.resources[0].status is defined
-        - workspace_ready_status.resources[0].status.conditions is defined
-        - workspace_ready_status.resources[0].status.conditions | selectattr('type', 'equalto', 'Ready') | list | length > 0
-        - (workspace_ready_status.resources[0].status.conditions | selectattr('type', 'equalto', 'Ready') | first).status == 'True'
-
-    - name: "Set fact: FacilitiesWorkspace CR exists"
-      set_fact:
-        facilities_workspace_exists: true
-
-    - name: "FacilitiesWorkspace is ready"
-      debug:
-        msg: "FacilitiesWorkspace {{ facilities_workspace_cr_name }} is ready"
-
-# 3. Check if PV data backup exists (tar.gz files)
+# 1. Check if PV data backup exists (tar.gz files)
 # -----------------------------------------------------------------------------
 - name: "Display restore phase 4 information"
   debug:
@@ -127,7 +37,7 @@
       - "PV data restore {{ 'required' if pv_data_needs_restore else 'not required' }}"
       - "{{ 'Found ' + (pvc_backup_archives.files | default([]) | length | string) + ' tar.gz file(s)' if pv_data_dir_stat.stat.exists and pv_data_dir_stat.stat.isdir else 'Backup data directory not found' }}"
 
-# 4. If workspace CR exists and PV data needs restore, scale down pods using podTemplates
+# 2. If workspace CR exists and PV data needs restore, scale down pods using podTemplates
 # -----------------------------------------------------------------------------
 - name: "Scale down FacilitiesWorkspace pods (if exists and PV data needs restore)"
   when:
@@ -270,7 +180,7 @@
       set_fact:
         pods_scaled_down: true
 
-# 5. Restore PV data using dummy pods
+# 3. Restore PV data using dummy pods
 # -----------------------------------------------------------------------------
 - name: "Display restore phase 6 information"
   debug:
@@ -280,7 +190,7 @@
       - "=========================================="
   when: (pv_data_needs_restore | bool) == true
 
-# 6. Restore PV data using dummy pods
+# Restore PV data using dummy pods
 # -----------------------------------------------------------------------------
 - name: "Restore Facilities persistent volume data"
   when:
@@ -384,14 +294,14 @@
         msg:
           - "Facilities PV restore completed"
 
-# 7. Skip message if no PV data to restore
+# Skip message if no PV data to restore
 # -----------------------------------------------------------------------------
 - name: "Skip PV restore message"
   debug:
     msg: "Skipping Facilities PV restore - no persistent volume data found in backup"
   when: (pv_data_needs_restore | bool) == false
 
-# 8. Scale up pods by clearing podTemplates (only if workspace existed before and PV data was restored)
+# Scale up pods by clearing podTemplates (only if workspace existed before and PV data was restored)
 # -----------------------------------------------------------------------------
 - name: "Scale up FacilitiesWorkspace pods"
   when:
@@ -463,14 +373,3 @@
     - name: "All pods scaled back up"
       debug:
         msg: "All Facilities pods have been scaled back up and are ready"
-
-# 9. Final status
-# -----------------------------------------------------------------------------
-- name: "Facilities restore completed"
-  debug:
-    msg:
-      - "=========================================="
-      - "Facilities Restore Completed Successfully"
-      - "=========================================="
-      - "Workspace: {{ facilities_workspace_cr_name }}"
-      - "Namespace: {{ mas_app_namespace }}"

--- a/ibm/mas_devops/roles/suite_app_restore/tasks/facilities/restore-workspace.yml
+++ b/ibm/mas_devops/roles/suite_app_restore/tasks/facilities/restore-workspace.yml
@@ -1,0 +1,89 @@
+---
+# Restore Facilities Workspace
+# =============================================================================
+# This task restores Facilities persistent volume data by:
+# 1. Checking if FacilitiesWorkspace CR exists
+# 2. If not present, restoring FacilitiesWorkspace CR and waiting for ready
+
+# 1. Check if FacilitiesWorkspace CR exists
+# -----------------------------------------------------------------------------
+- name: "Display restore phase 3 information"
+  debug:
+    msg:
+      - "=========================================="
+      - "Phase 3: Check FacilitiesWorkspace CR"
+      - "=========================================="
+
+- name: "Check if FacilitiesWorkspace CR exists"
+  kubernetes.core.k8s_info:
+    api_version: apps.mas.ibm.com/v1
+    kind: FacilitiesWorkspace
+    name: "{{ facilities_workspace_cr_name }}"
+    namespace: "{{ mas_app_namespace }}"
+  register: existing_facilities_workspace_cr
+
+- name: "Set fact: FacilitiesWorkspace CR exists"
+  set_fact:
+    facilities_workspace_exists: "{{ existing_facilities_workspace_cr.resources is defined and existing_facilities_workspace_cr.resources | length > 0 }}"
+
+- name: "Display FacilitiesWorkspace CR status"
+  debug:
+    msg: "FacilitiesWorkspace CR {{ 'exists' if facilities_workspace_exists else 'does not exist' }}"
+
+# 2. If workspace CR not present, restore it and wait for ready
+# -----------------------------------------------------------------------------
+- name: "Restore FacilitiesWorkspace CR (if not present)"
+  when: (facilities_workspace_exists | bool) == false
+  block:
+    - name: "Display workspace restore information"
+      debug:
+        msg: "FacilitiesWorkspace CR not found - restoring from backup"
+
+    - name: "Restore FacilitiesWorkspace CR"
+      ibm.mas_devops.restore_resource:
+        backup_path: "{{ facilities_backup_path }}"
+        resource_kinds:
+          - FacilitiesWorkspace
+        override_values:
+          FacilitiesWorkspace:
+            - spec.settings.storage.log.class: "{{ _facilities_log_storage }}"
+            - spec.settings.storage.userfiles.class: "{{ _facilities_userfiles_storage }}"
+      register: facilities_restore_workspace_result
+
+    - name: "Display FacilitiesWorkspace CR restore results"
+      debug:
+        msg: >-
+          Facilities Workspace resource: {{ facilities_restore_workspace_result.created_count }} created,
+          {{ facilities_restore_workspace_result.updated_count }} updated,
+          {{ facilities_restore_workspace_result.skipped_count }} skipped,
+          {{ facilities_restore_workspace_result.failed_count }} failed
+
+    - name: "Fail if FacilitiesWorkspace CR restore had errors"
+      fail:
+        msg: "FacilitiesWorkspace CR restore failed. See logs for details."
+      when: facilities_restore_workspace_result.failed_count | int > 0
+
+    - name: "Wait for FacilitiesWorkspace to be ready"
+      kubernetes.core.k8s_info:
+        api_version: apps.mas.ibm.com/v1
+        kind: FacilitiesWorkspace
+        name: "{{ facilities_workspace_cr_name }}"
+        namespace: "{{ mas_app_namespace }}"
+      register: workspace_ready_status
+      retries: "{{ mas_app_restore_wait_retries | int }}"
+      delay: "{{ mas_app_restore_wait_delay | int }}"
+      until:
+        - workspace_ready_status.resources is defined
+        - workspace_ready_status.resources | length > 0
+        - workspace_ready_status.resources[0].status is defined
+        - workspace_ready_status.resources[0].status.conditions is defined
+        - workspace_ready_status.resources[0].status.conditions | selectattr('type', 'equalto', 'Ready') | list | length > 0
+        - (workspace_ready_status.resources[0].status.conditions | selectattr('type', 'equalto', 'Ready') | first).status == 'True'
+
+    - name: "Set fact: FacilitiesWorkspace CR exists"
+      set_fact:
+        facilities_workspace_exists: true
+
+    - name: "FacilitiesWorkspace is ready"
+      debug:
+        msg: "FacilitiesWorkspace {{ facilities_workspace_cr_name }} is ready"

--- a/ibm/mas_devops/roles/suite_app_restore/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_restore/tasks/main.yml
@@ -60,7 +60,7 @@
         - name: "Restore Manage persistent volumes"
           include_tasks: "{{ role_path }}/tasks/manage/restore-pv.yml"
           when: mas_app_restore_include_pvc | bool
-        
+
         - name: "Restore Manage Workspace"
           include_tasks: "{{ role_path }}/tasks/manage/restore-workspace.yml"
 
@@ -83,7 +83,7 @@
       block:
         - name: "Restore Facilities namespace resources"
           include_tasks: "{{ role_path }}/tasks/facilities/restore-namespace.yml"
-        
+
         - name: "Restore Facilities Workspace"
           include_tasks: "{{ role_path }}/tasks/facilities/restore-workspace.yml"
 

--- a/ibm/mas_devops/roles/suite_app_restore/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_restore/tasks/main.yml
@@ -59,7 +59,7 @@
 
         - name: "Restore Manage persistent volumes"
           include_tasks: "{{ role_path }}/tasks/manage/restore-pv.yml"
-          when: mas_app_restore_manage_include_pvc | bool
+          when: mas_app_restore_include_pvc | bool
         
         - name: "Restore Manage Workspace"
           include_tasks: "{{ role_path }}/tasks/manage/restore-workspace.yml"
@@ -73,7 +73,7 @@
               - "Instance ID: {{ mas_instance_id }}"
               - "Backup Version: {{ mas_app_backup_version }}"
               - "Restored from: {{ manage_backup_path }}"
-              - "PVC Restore: {{ 'Included' if mas_app_restore_manage_include_pvc | bool else 'Skipped' }}"
+              - "PVC Restore: {{ 'Included' if mas_app_restore_include_pvc | bool else 'Skipped' }}"
               - "=========================================="
 
     # Facilities restore
@@ -89,7 +89,7 @@
 
         - name: "Restore Facilities persistent volumes"
           include_tasks: "{{ role_path }}/tasks/facilities/restore-pv.yml"
-          when: mas_app_restore_facilities_include_pvc | bool
+          when: mas_app_restore_include_pvc | bool
 
         - name: "Facilities restore completed successfully"
           debug:
@@ -100,7 +100,7 @@
               - "Instance ID: {{ mas_instance_id }}"
               - "Backup Version: {{ mas_app_backup_version }}"
               - "Restored from: {{ facilities_backup_path }}"
-              - "PVC Restore: {{ 'Included' if mas_app_restore_facilities_include_pvc | bool else 'Skipped' }}"
+              - "PVC Restore: {{ 'Included' if mas_app_restore_include_pvc | bool else 'Skipped' }}"
               - "=========================================="
 
     # Unsupported app

--- a/ibm/mas_devops/roles/suite_app_restore/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_app_restore/tasks/main.yml
@@ -59,6 +59,10 @@
 
         - name: "Restore Manage persistent volumes"
           include_tasks: "{{ role_path }}/tasks/manage/restore-pv.yml"
+          when: mas_app_restore_manage_include_pvc | bool
+        
+        - name: "Restore Manage Workspace"
+          include_tasks: "{{ role_path }}/tasks/manage/restore-workspace.yml"
 
         - name: "Manage restore completed successfully"
           debug:
@@ -69,6 +73,7 @@
               - "Instance ID: {{ mas_instance_id }}"
               - "Backup Version: {{ mas_app_backup_version }}"
               - "Restored from: {{ manage_backup_path }}"
+              - "PVC Restore: {{ 'Included' if mas_app_restore_manage_include_pvc | bool else 'Skipped' }}"
               - "=========================================="
 
     # Facilities restore
@@ -78,9 +83,13 @@
       block:
         - name: "Restore Facilities namespace resources"
           include_tasks: "{{ role_path }}/tasks/facilities/restore-namespace.yml"
+        
+        - name: "Restore Facilities Workspace"
+          include_tasks: "{{ role_path }}/tasks/facilities/restore-workspace.yml"
 
         - name: "Restore Facilities persistent volumes"
           include_tasks: "{{ role_path }}/tasks/facilities/restore-pv.yml"
+          when: mas_app_restore_facilities_include_pvc | bool
 
         - name: "Facilities restore completed successfully"
           debug:
@@ -91,6 +100,7 @@
               - "Instance ID: {{ mas_instance_id }}"
               - "Backup Version: {{ mas_app_backup_version }}"
               - "Restored from: {{ facilities_backup_path }}"
+              - "PVC Restore: {{ 'Included' if mas_app_restore_facilities_include_pvc | bool else 'Skipped' }}"
               - "=========================================="
 
     # Unsupported app

--- a/ibm/mas_devops/roles/suite_app_restore/tasks/manage/restore-namespace.yml
+++ b/ibm/mas_devops/roles/suite_app_restore/tasks/manage/restore-namespace.yml
@@ -353,7 +353,7 @@
 - name: "Set ManageWorkspace mode to down (if exists)"
   when: 
     - manage_workspace_exists
-    - mas_app_restore_manage_include_pvc | bool
+    - mas_app_restore_include_pvc | bool
   block:
     - name: "Get current ManageWorkspace spec.mode"
       set_fact:

--- a/ibm/mas_devops/roles/suite_app_restore/tasks/manage/restore-namespace.yml
+++ b/ibm/mas_devops/roles/suite_app_restore/tasks/manage/restore-namespace.yml
@@ -351,7 +351,7 @@
 # 7. If ManageWorkspace exists, set mode to down
 # -----------------------------------------------------------------------------
 - name: "Set ManageWorkspace mode to down (if exists)"
-  when: 
+  when:
     - manage_workspace_exists
     - mas_app_restore_include_pvc | bool
   block:

--- a/ibm/mas_devops/roles/suite_app_restore/tasks/manage/restore-namespace.yml
+++ b/ibm/mas_devops/roles/suite_app_restore/tasks/manage/restore-namespace.yml
@@ -40,6 +40,35 @@
 - name: Detect Certificate Manager installation
   include_tasks: "{{ role_path }}/../../common_tasks/detect_cert_manager.yml"
 
+# 2.2. Get default storage classes if override is enabled but custom classes not provided
+# ---------------------------------------------------------------------
+- name: "Lookup default storage classes"
+  when:
+    - override_storageclass
+  block:
+    - name: "Include default storage classes lookup"
+      include_tasks: "{{ role_path }}/../../common_tasks/default_storage_classes.yml"
+
+    - name: "Set default RWX storage class if not provided"
+      set_fact:
+        mas_app_custom_storage_class_rwx: "{{ defaultStorageClasses.rwx }}"
+      when: mas_app_custom_storage_class_rwx == ''
+
+    - name: "Set default RWO storage class if not provided"
+      set_fact:
+        mas_app_custom_storage_class_rwo: "{{ defaultStorageClasses.rwo }}"
+      when: mas_app_custom_storage_class_rwo == ''
+
+    - name: "Fail storage class override if default storage classes not found"
+      fail:
+        msg: "Storage class override enabled but no custom storage classes provided and default storage classes not found"
+      when: mas_app_custom_storage_class_rwx == '' or mas_app_custom_storage_class_rwo == ''
+
+    - name: Replace ManageWorkspace Persistent Volumes when override_storageclass is true
+      set_fact:
+        _manage_persistent_volumes: "{{ manage_persistent_volumes | ibm.mas_devops.override_manage_persistent_volumes(mas_app_custom_storage_class_rwo, mas_app_custom_storage_class_rwx) }}"
+      when: manage_persistent_volumes is defined and manage_persistent_volumes | length > 0
+
 # 3. Set Manage namespace and workspace CR name
 # -----------------------------------------------------------------------------
 - name: "Set fact: Manage namespace"
@@ -322,7 +351,9 @@
 # 7. If ManageWorkspace exists, set mode to down
 # -----------------------------------------------------------------------------
 - name: "Set ManageWorkspace mode to down (if exists)"
-  when: manage_workspace_exists
+  when: 
+    - manage_workspace_exists
+    - mas_app_restore_manage_include_pvc | bool
   block:
     - name: "Get current ManageWorkspace spec.mode"
       set_fact:

--- a/ibm/mas_devops/roles/suite_app_restore/tasks/manage/restore-pv.yml
+++ b/ibm/mas_devops/roles/suite_app_restore/tasks/manage/restore-pv.yml
@@ -6,8 +6,6 @@
 # 2. If ManageWorkspace CR is not deployed, create PVCs and a dummy pod
 # 3. Restore PVC data using the pod
 # 4. Shutdown the dummy pod
-# 5. Continue with ManageWorkspace CR restore
-# 6. Wait for Manage deployment to be activated
 
 # 1. Read ManageWorkspace CR from backup to get PVC configuration
 # -----------------------------------------------------------------------------
@@ -64,35 +62,6 @@
           - "Storage class override enabled: {{ override_storageclass }}"
           - "Custom RWX storage class: {{ mas_app_custom_storage_class_rwx | default('not set') }}"
           - "Custom RWO storage class: {{ mas_app_custom_storage_class_rwo | default('not set') }}"
-
-    # Get default storage classes if override is enabled but custom classes not provided
-    # ---------------------------------------------------------------------
-    - name: "Lookup default storage classes"
-      when:
-        - override_storageclass
-      block:
-        - name: "Include default storage classes lookup"
-          include_tasks: "{{ role_path }}/../../common_tasks/default_storage_classes.yml"
-
-        - name: "Set default RWX storage class if not provided"
-          set_fact:
-            mas_app_custom_storage_class_rwx: "{{ defaultStorageClasses.rwx }}"
-          when: mas_app_custom_storage_class_rwx == ''
-
-        - name: "Set default RWO storage class if not provided"
-          set_fact:
-            mas_app_custom_storage_class_rwo: "{{ defaultStorageClasses.rwo }}"
-          when: mas_app_custom_storage_class_rwo == ''
-
-        - name: "Fail storage class override if default storage classes not found"
-          fail:
-            msg: "Storage class override enabled but no custom storage classes provided and default storage classes not found"
-          when: mas_app_custom_storage_class_rwx == '' or mas_app_custom_storage_class_rwo == ''
-
-        - name: Replace ManageWorkspace Persistent Volumes when override_storageclass is true
-          set_fact:
-            _manage_persistent_volumes: "{{ manage_persistent_volumes | ibm.mas_devops.override_manage_persistent_volumes(mas_app_custom_storage_class_rwo, mas_app_custom_storage_class_rwx) }}"
-          when: manage_persistent_volumes is defined and manage_persistent_volumes | length > 0
 
     # Create PVCs
     # ---------------------------------------------------------------------
@@ -247,69 +216,3 @@
   debug:
     msg: "Skipping Manage PV restore - no persistent volume data found in backup"
   when: not pv_data_needs_restore
-
-# 5. Restore ManageWorkspace CR
-# -----------------------------------------------------------------------------
-- name: "Display restore phase 4 information"
-  debug:
-    msg:
-      - "=========================================="
-      - "Phase 4: Restore ManageWorkspace CR"
-      - "=========================================="
-
-- name: "Restore ManageWorkspace CR"
-  ibm.mas_devops.restore_resource:
-    backup_path: "{{ manage_backup_path }}"
-    resource_kinds:
-      - ManageWorkspace
-    override_values:
-      ManageWorkspace:
-        - spec.settings.deployment.persistentVolumes: "{{ _manage_persistent_volumes }}"
-  register: manage_restore_phase4_result
-
-- name: "Display ManageWorkspace CR restore results"
-  debug:
-    msg: >-
-      Manage Worspace resource: {{ manage_restore_phase4_result.created_count }} created,
-      {{ manage_restore_phase4_result.updated_count }} updated,
-      {{ manage_restore_phase4_result.skipped_count }} skipped,
-      {{ manage_restore_phase4_result.failed_count }} failed
-
-- name: "Fail if ManageWorkspace CR restore had errors"
-  fail:
-    msg: "ManageWorkspace CR restore failed. See logs for details."
-  when: manage_restore_phase4_result.failed_count | int > 0
-
-# 6. Wait for Manage deployment to be activated
-# -----------------------------------------------------------------------------
-- name: "Display restore phase 5 information"
-  debug:
-    msg:
-      - "=========================================="
-      - "Phase 5: Wait for Manage Deployment"
-      - "=========================================="
-
-- name: "Wait for ManageWorkspace to be ready"
-  kubernetes.core.k8s_info:
-    api_version: apps.mas.ibm.com/v1
-    kind: ManageWorkspace
-    name: "{{ manage_workspace_cr_name }}"
-    namespace: "{{ mas_app_namespace }}"
-  register: workspace_ready_status
-  retries: "{{ mas_app_restore_wait_retries | int }}"
-  delay: "{{ mas_app_restore_wait_delay | int }}"
-  until:
-    - workspace_ready_status.resources is defined
-    - workspace_ready_status.resources | length > 0
-    - workspace_ready_status.resources[0].status is defined
-    - workspace_ready_status.resources[0].status.conditions is defined
-    - workspace_ready_status.resources[0].status.conditions | selectattr('type', 'equalto', 'Ready') | list | length > 0
-    - (workspace_ready_status.resources[0].status.conditions | selectattr('type', 'equalto', 'Ready') | first).status == 'True'
-
-- name: "ManageWorkspace is ready"
-  debug:
-    msg:
-      - "=========================================="
-      - "ManageWorkspace {{ manage_workspace_cr_name }} is ready"
-      - "Manage deployment has been activated"
-      - "=========================================="

--- a/ibm/mas_devops/roles/suite_app_restore/tasks/manage/restore-workspace.yml
+++ b/ibm/mas_devops/roles/suite_app_restore/tasks/manage/restore-workspace.yml
@@ -1,0 +1,72 @@
+---
+# Restore Manage Workspace CR
+# =============================================================================
+# This task restores Manage WorkspaceCR:
+# 1. Continue with ManageWorkspace CR restore
+# 2. Wait for Manage deployment to be activated
+
+# 1. Restore ManageWorkspace CR
+# -----------------------------------------------------------------------------
+- name: "Display restore phase 4 information"
+  debug:
+    msg:
+      - "=========================================="
+      - "Phase 4: Restore ManageWorkspace CR"
+      - "=========================================="
+
+- name: "Restore ManageWorkspace CR"
+  ibm.mas_devops.restore_resource:
+    backup_path: "{{ manage_backup_path }}"
+    resource_kinds:
+      - ManageWorkspace
+    override_values:
+      ManageWorkspace:
+        - spec.settings.deployment.persistentVolumes: "{{ _manage_persistent_volumes }}"
+  register: manage_restore_phase4_result
+
+- name: "Display ManageWorkspace CR restore results"
+  debug:
+    msg: >-
+      Manage Worspace resource: {{ manage_restore_phase4_result.created_count }} created,
+      {{ manage_restore_phase4_result.updated_count }} updated,
+      {{ manage_restore_phase4_result.skipped_count }} skipped,
+      {{ manage_restore_phase4_result.failed_count }} failed
+
+- name: "Fail if ManageWorkspace CR restore had errors"
+  fail:
+    msg: "ManageWorkspace CR restore failed. See logs for details."
+  when: manage_restore_phase4_result.failed_count | int > 0
+
+# 2. Wait for Manage deployment to be activated
+# -----------------------------------------------------------------------------
+- name: "Display restore phase 5 information"
+  debug:
+    msg:
+      - "=========================================="
+      - "Phase 5: Wait for Manage Deployment"
+      - "=========================================="
+
+- name: "Wait for ManageWorkspace to be ready"
+  kubernetes.core.k8s_info:
+    api_version: apps.mas.ibm.com/v1
+    kind: ManageWorkspace
+    name: "{{ manage_workspace_cr_name }}"
+    namespace: "{{ mas_app_namespace }}"
+  register: workspace_ready_status
+  retries: "{{ mas_app_restore_wait_retries | int }}"
+  delay: "{{ mas_app_restore_wait_delay | int }}"
+  until:
+    - workspace_ready_status.resources is defined
+    - workspace_ready_status.resources | length > 0
+    - workspace_ready_status.resources[0].status is defined
+    - workspace_ready_status.resources[0].status.conditions is defined
+    - workspace_ready_status.resources[0].status.conditions | selectattr('type', 'equalto', 'Ready') | list | length > 0
+    - (workspace_ready_status.resources[0].status.conditions | selectattr('type', 'equalto', 'Ready') | first).status == 'True'
+
+- name: "ManageWorkspace is ready"
+  debug:
+    msg:
+      - "=========================================="
+      - "ManageWorkspace {{ manage_workspace_cr_name }} is ready"
+      - "Manage deployment has been activated"
+      - "=========================================="

--- a/ibm/mas_devops/roles/suite_backup/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_backup/tasks/main.yml
@@ -48,7 +48,9 @@
 - name: "Set fact: base config resources list"
   set_fact:
     config_resources:
-      - kind: AppCfg
+      - kind: AiCfg # 9.2 and later
+        api_version: config.mas.ibm.com/v1
+      - kind: AppCfg # 9.1 and later
         api_version: config.mas.ibm.com/v1
       - kind: IDPCfg
         api_version: config.mas.ibm.com/v1
@@ -113,7 +115,7 @@
         api_version: cert-manager.io/v1
         labels:
           - "mas.ibm.com/instanceId={{ mas_instance_id }}"
-      # addons.mas.ibm.com
+      # addons.mas.ibm.com (9.1 and later)
       - kind: MVIEdge
         api_version: addons.mas.ibm.com/v1
       - kind: ReplicaDB

--- a/ibm/mas_devops/roles/suite_restore/tasks/main.yml
+++ b/ibm/mas_devops/roles/suite_restore/tasks/main.yml
@@ -183,6 +183,7 @@
 - name: "Set fact: base config resource kinds"
   set_fact:
     config_resource_kinds:
+      - AiCfg # MAS 9.2 and later
       - AppCfg
       - IDPCfg
       - JdbcCfg


### PR DESCRIPTION
## Description

- Option to include/exclude Apps' PVC backup and restore in pipelines
- Added AiCfg resource suite_backup and suite_restore  to support 9.2 resources.

Depends on https://github.com/ibm-mas/python-devops/pull/395

## Test Results

Shown in CLI PR - https://github.com/ibm-mas/cli/pull/2396

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
