### PR TITLE
[patch] resolve SQL0290N tablespace access error on facilities db2 setup

### DIFF
--- a/ibm/mas_devops/roles/suite_db2_setup_for_facilities/templates/db2/scripts/db2configdb.sh.j2
+++ b/ibm/mas_devops/roles/suite_db2_setup_for_facilities/templates/db2/scripts/db2configdb.sh.j2
@@ -39,8 +39,12 @@ echo "Return code for starting instance $DB2_INSTANCE_USERNAME is $rc"
 
 ok=0
 
-# connect to the newly created database - required 
+# Fix SQL0290N  Table space access is not allowed.  SQLSTATE=55039
+if ! $(ls /mnt/tempts/systemp/db2inst1/NODE0000/{{ db2_dbname }}/T0000001); then
+    db2 "restart database {{ db2_dbname }} drop pending tablespaces (TEMPSPACE1)"
+fi
 
+# connect to the newly created database - required 
 echo "$DB2_HOME/bin/db2 connect to $DB2_DBNAME"
 $DB2_HOME/bin/db2 connect to $DB2_DBNAME
 rc=$?


### PR DESCRIPTION
## Description
The recent `fvtday2` runs the installation of `suite_db2_setup_for_facilities` is throwing the same issue as `suite_db2_setup_for_manage`. Therefore, it was applied the same solution in the script.

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
