### PR TITLE
[patch] ansible-devops: update mongodb/atlas role to align with Terraform module

### DIFF
--- a/ibm/mas_devops/roles/mongodb/README.md
+++ b/ibm/mas_devops/roles/mongodb/README.md
@@ -2354,7 +2354,7 @@ Enable alerts for cluster health issues.
 - Environment Variable: `ATLAS_ENABLE_CLUSTER_HEALTH_ALERTS`
 - Default Value: `false`
 
-**Purpose**: Enables alerts for cluster health events including replication lag, primary election, and node failures.
+**Purpose**: Enables alerts for cluster health events including replication lag, low op log window, primary election, and node failures.
 
 **Valid values**: `true`, `false`
 

--- a/ibm/mas_devops/roles/mongodb/defaults/main.yml
+++ b/ibm/mas_devops/roles/mongodb/defaults/main.yml
@@ -212,7 +212,8 @@ atlas_enable_performance_alerts: "{{ (lookup('env', 'ATLAS_ENABLE_PERFORMANCE_AL
 atlas_alert_cpu_thresholds: "{{ lookup('env', 'ATLAS_ALERT_CPU_THRESHOLDS') | default('[70, 80]', True) | from_json }}"
 atlas_alert_memory_thresholds: "{{ lookup('env', 'ATLAS_ALERT_MEMORY_THRESHOLDS') | default('[70, 80]', True) | from_json }}"
 atlas_alert_connection_thresholds: "{{ lookup('env', 'ATLAS_ALERT_CONNECTION_THRESHOLDS') | default('[70, 80]', True) | from_json }}"
-atlas_alert_replication_lag_threshold: "{{ lookup('env', 'ATLAS_ALERT_REPLICATION_LAG_THRESHOLD') | default(300, True) | int }}"
+atlas_alert_replication_lag_threshold: "{{ lookup('env', 'ATLAS_ALERT_REPLICATION_LAG_THRESHOLD') | default(30, True) | int }}"
+atlas_alert_oplog_window_threshold_minutes: "{{ lookup('env', 'ATLAS_ALERT_OPLOG_WINDOW_THRESHOLD_MINUTES') | default(60, True) | int }}"
 
 # Alert interval configuration (in minutes) - applies to all metric threshold alerts
 atlas_alert_interval_min: "{{ lookup('env', 'ATLAS_ALERT_INTERVAL_MIN') | default(60, True) | int }}"

--- a/ibm/mas_devops/roles/mongodb/tasks/providers/atlas/configure_alerts_cluster.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/providers/atlas/configure_alerts_cluster.yml
@@ -21,7 +21,7 @@
     - name: "Configure cluster health alerts"
       when: atlas_enable_cluster_health_alerts | bool
       block:
-        - name: "Create replication lag alert"
+        - name: "Create oplog window low alert"
           uri:
             url: "{{ atlas_api_base_url }}/groups/{{ atlas_project_id }}/alertConfigs"
             method: POST
@@ -33,13 +33,42 @@
               enabled: true
               threshold:
                 operator: "LESS_THAN"
-                threshold: 1
-                units: "HOURS"
+                threshold: "{{ atlas_alert_oplog_window_threshold_minutes }}"
+                units: "MINUTES"
               matchers:
                 - fieldName: "CLUSTER_NAME"
                   operator: "EQUALS"
                   value: "{{ atlas_cluster_name }}"
               notifications: "{{ atlas_email_notifications }}"
+            body_format: json
+            status_code: [200, 201]
+            timeout: "{{ atlas_api_timeout }}"
+          register: alert_oplog_window
+
+        - name: "Create replication lag notifications with required delay"
+          set_fact:
+            atlas_replication_lag_notifications: >-
+              {{
+                atlas_email_notifications | map('combine', {'delayMin': 1}) | list
+              }}
+
+        - name: "Create replication lag alert"
+          uri:
+            url: "{{ atlas_api_base_url }}/groups/{{ atlas_project_id }}/alertConfigs"
+            method: POST
+            user: "{{ atlas_public_key }}"
+            password: "{{ atlas_private_key }}"
+            force_basic_auth: false
+            body:
+              eventTypeName: "OUTSIDE_METRIC_THRESHOLD"
+              enabled: true
+              metricThreshold:
+                metricName: "OPLOG_SLAVE_LAG_MASTER_TIME"
+                operator: "GREATER_THAN"
+                threshold: "{{ atlas_alert_replication_lag_threshold }}"
+                units: "SECONDS"
+                mode: "AVERAGE"
+              notifications: "{{ atlas_replication_lag_notifications }}"
             body_format: json
             status_code: [200, 201]
             timeout: "{{ atlas_api_timeout }}"


### PR DESCRIPTION
Issue: [MASCORE-14766](https://jsw.ibm.com/browse/MASCORE-14766)

## Description
Updates to alerts done in https://github.ibm.com/maximoappsuite/mas-iac-aws-mongo-db-atlas/pull/24 has to be made in ansible module as well

## Test Results
Able to configure alerts by executing playbook in local
<img width="622" height="79" alt="Screenshot 2026-06-18 at 7 33 58 PM" src="https://github.com/user-attachments/assets/ca3ef601-786a-4956-ae1d-63eb41f187ca" />
<img width="622" height="101" alt="Screenshot 2026-06-18 at 7 35 21 PM" src="https://github.com/user-attachments/assets/06d6c243-11fb-407d-b2ae-cec369fe5509" />


<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
