### PR TITLE
[patch] Fix bug for AI Service tenant upgrade

### DIFF
--- a/ibm/mas_devops/common_vars/compatibility_matrix.yml
+++ b/ibm/mas_devops/common_vars/compatibility_matrix.yml
@@ -129,4 +129,5 @@ upgrade_path:
 # The key is the current installed channel of AI Service
 # and the value is the allowed upgrade versions.
 aiservice_upgrade_path:
+  9.2.x-feature: [9.2.x]
   9.1.x: [9.2.x-feature]

--- a/ibm/mas_devops/common_vars/compatibility_matrix.yml
+++ b/ibm/mas_devops/common_vars/compatibility_matrix.yml
@@ -129,5 +129,4 @@ upgrade_path:
 # The key is the current installed channel of AI Service
 # and the value is the allowed upgrade versions.
 aiservice_upgrade_path:
-  9.2.x-feature: [9.2.x]
-  9.1.x: [9.2.x]
+  9.1.x: [9.2.x-feature]

--- a/ibm/mas_devops/common_vars/compatibility_matrix.yml
+++ b/ibm/mas_devops/common_vars/compatibility_matrix.yml
@@ -130,4 +130,4 @@ upgrade_path:
 # and the value is the allowed upgrade versions.
 aiservice_upgrade_path:
   9.2.x-feature: [9.2.x]
-  9.1.x: [9.2.x-feature]
+  9.1.x: [9.2.x]

--- a/ibm/mas_devops/roles/aiservice_upgrade/tasks/check_aiservice_compatibility.yml
+++ b/ibm/mas_devops/roles/aiservice_upgrade/tasks/check_aiservice_compatibility.yml
@@ -114,7 +114,7 @@
 # reconciled: 9.1.0-pre.stable+8193 cr version
 # opcon_version: 9.1.0-pre.stable-8193 operator condition
 # above versions having `+` and `-` differences in feature channel (stable build)
-- name: "AI Service : Check that the Suite CR has been reconciled to the expected version for feature channels"
+- name: "AI Service : Check that the AIServiceApp CR has been reconciled to the expected version for feature channels"
   when:
     - aiservice_sub_info.resources[0].spec.channel != aiservice_channel
     - "'-feature' in aiservice_sub_info.resources[0].spec.channel"
@@ -123,7 +123,7 @@
       - "(aiservice_info.resources[0].status.versions.reconciled | replace('+', '-') == opcon_version | replace('+', '-'))"
     fail_msg: "Upgrade failed because AI Service version ({{ aiservice_info.resources[0].status.versions.reconciled }}) is not at the expected version {{ opcon_version }}"
 
-- name: "AI Service : Check that the Suite CR is in a healthy state"
+- name: "AI Service : Check that the AIServiceApp CR is in a healthy state"
   when: aiservice_sub_info.resources[0].spec.channel != aiservice_channel
   assert:
     that:

--- a/ibm/mas_devops/roles/aiservice_upgrade/tasks/tenant/upgrade.yml
+++ b/ibm/mas_devops/roles/aiservice_upgrade/tasks/tenant/upgrade.yml
@@ -73,7 +73,7 @@
 - name: "Confirm AIServiceTenant CR is ready"
   kubernetes.core.k8s_info:
     api_version: aiservice.ibm.com/v1
-    name: "{{ tenant_subscription.metadata.name }}"
+    name: "{{ tenant_subscription.metadata.namespace }}"
     namespace: "{{ tenant_subscription.metadata.namespace }}"
     kind: AIServiceTenant
   retries: 20 # about 40 minutes

--- a/ibm/mas_devops/roles/aiservice_upgrade/tasks/upgrade_aiservice.yml
+++ b/ibm/mas_devops/roles/aiservice_upgrade/tasks/upgrade_aiservice.yml
@@ -104,7 +104,7 @@
       - "AIServiceApp reconciled version ............. {{ cr_reconciled_version }}"
       - "OperatorCondition version ............. {{ updated_opcon_version }}"
 
-- name: "upgrade : Get Suite CR for for ibm-aiservice"
+- name: "upgrade : Get AIServiceApp CR for for ibm-aiservice"
   kubernetes.core.k8s_info:
     api_version: aiservice.ibm.com/v1
     name: "{{ aiservice_instance_id }}"
@@ -117,6 +117,6 @@
     - updated_aiservice_info.resources | json_query('[*].status.conditions[?type==`Ready`][].reason') | select ('match','Ready') | list | length == 1
   register: updated_aiservice_info
 
-- name: "upgrade : Debug Suite CR"
+- name: "upgrade : Debug AIServiceApp CR"
   debug:
     var: updated_aiservice_info

--- a/ibm/mas_devops/roles/aiservice_upgrade/tasks/upgrade_aiservice_tenant.yml
+++ b/ibm/mas_devops/roles/aiservice_upgrade/tasks/upgrade_aiservice_tenant.yml
@@ -11,19 +11,21 @@
 # If migration is not needed then proceed with simply upgrading the tenant operator
 - when: not is_migration_needed
   block:
-    - name: Find all subscriptions for ibm-aiservice-tenant
+    - name: Get all subscriptions
       kubernetes.core.k8s_info:
         api_version: operators.coreos.com/v1alpha1
         kind: Subscription
-        name: ibm-aiservice-tenant
-        label_selectors:
-          - "aiservice.ibm.com/instanceId = {{ aiservice_instance_id }}"
-      register: aiservice_tenant_sub_info
+      register: all_subscriptions
       no_log: true
 
-    - name: Set target resources
+    - name: Filter subscriptions named ibm-aiservice-tenant
       ansible.builtin.set_fact:
-        tenant_subscriptions: "{{ aiservice_tenant_sub_info.resources }}"
+        tenant_subscriptions: >-
+          {{
+            all_subscriptions.resources
+            | selectattr('metadata.name', 'equalto', 'ibm-aiservice-tenant')
+            | list
+          }}
 
     - name: Display subscription info
       ansible.builtin.debug:


### PR DESCRIPTION
## Description

- When AIServiceTenant subscriptions is created, it doesn't have label `aiservice.ibm.com/instanceId = {{ aiservice_instance_id }}` because of which while running upgrade, tenant operators were not being selected for upgrade which may cause incompatibility with AI Service 9.2.x operator. 
- To address this issue, the label selector was removed from the subscription lookup, allowing all tenant subscriptions to be selected for upgrade.
- There was a bug which recently surfaced when upgrading tenant operator to 9.2.x, AIServiceTenant CR lookup was wrongly configured to use subscription name. Fixed the bug by using the namespace from subscription context which is essentially same for AIServiceTenant CR.

## Test Results

- Tested successful upgrade from 9.2.x-feature to 9.2.x.
- Tested successful upgrade from 9.1.x to 9.2.x

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
