### PR TITLE
[patch] Fix CIS Suite DNS job failing due to rule name change

### DIFF
--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_suitedns_enhanced.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_suitedns_enhanced.yml
@@ -11,7 +11,8 @@
 
 - name: "cis: use managed_rulesets"
   ansible.builtin.shell: |
-    ibmcloud cis waf-packages {{ (_cis_domains_result.stdout | from_json)[0].id}}
+    ibmcloud cis waf-packages {{ (_cis_domains_result.stdout | from_json)[0].id}} \
+    -i "{{ cis_service_name }}"
   failed_when: false
   register: error_output
 
@@ -34,11 +35,16 @@
     - name: "cis: list of managed ruleset rules to disable"
       ansible.builtin.include_vars: vars/managed_ruleset_rules_to_disable.yml
 
-    - name: "cis: get Cloudflare Managed Ruleset ruleset_id"
+    - name: "cis: get CIS Managed Ruleset ruleset_id"
       ansible.builtin.shell: |
         ibmcloud cis managed-waf rulesets {{ (_cis_domains_result.stdout | from_json)[0].id }} \
-        -i "{{ cis_service_name }}" --output json | jq -r '.[] | select(.name == "Cloudflare Managed Ruleset") | .id'
+        -i "{{ cis_service_name }}" --output json | jq -r '.[] | select(.name == "CIS Managed Ruleset") | .id'
       register: _cis_ruleset_result
+
+    - name: "cis: validate CIS Managed Ruleset ID was found"
+      ansible.builtin.fail:
+        msg: "CIS Managed Ruleset ID not found. Ensure the ruleset exists in the CIS instance."
+      when: _cis_ruleset_result.stdout | trim | length == 0
 
     - name: "cis: get deployed rule id for CIS Managed Ruleset id"
       ansible.builtin.shell: |


### PR DESCRIPTION
Issue: [MASCORE-14956](https://jsw.ibm.com/browse/MASCORE-14956)

## Description
15th June CIS release had some issues which updates Managed Ruleset name as Cloudflare instead of CIS. 
It is then fixed with 22nd June update
<img width="888" height="209" alt="SupportTeamResponse" src="https://github.com/user-attachments/assets/4a5a17a0-f4aa-4374-b215-cc392e4d7818" />


## Test Results
Validated this in fvtsaas
https://console-openshift-console.apps.fvtsaas.6liv.p1.openshiftapps.com/k8s/ns/mas-fvtsaas2-syncres/pods/ibm-suite-dns-1976797022-clq4q/logs

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
