### PR TITLE
[patch] Fixed the workspace health check condition and increased the timeout

### DIFF
--- a/ibm/mas_devops/roles/suite_app_upgrade/tasks/upgrade.yml
+++ b/ibm/mas_devops/roles/suite_app_upgrade/tasks/upgrade.yml
@@ -127,11 +127,11 @@
     label_selectors:
       - mas.ibm.com/instanceId={{ mas_instance_id }}
       - mas.ibm.com/applicationId={{ mas_app_id }}
-  retries: 45 # about 90 minutes
+  retries: 60 # about 90 minutes
   delay: 120 # 2 minutes
   until:
-    - facilities_ws_cr_lookup.resources is defined
-    - facilities_ws_cr_lookup.status.versions.reconciled == updated_opcon_version
+    - facilities_ws_cr_lookup.resources | length > 0
+    - facilities_ws_cr_lookup.resources[0].status.versions.reconciled == updated_opcon_version
     - facilities_ws_cr_lookup.resources | json_query('[*].status.conditions[?type==`Ready`][].reason') | select ('in', ['Ready']) | list | length == facilities_ws_cr_lookup.resources | length
     - facilities_ws_cr_lookup.resources | json_query('[*].status.conditions[?type==`Running`][].reason') | select ('in', ['Successful']) | list | length == facilities_ws_cr_lookup.resources | length
   when:

--- a/ibm/mas_devops/roles/suite_app_upgrade/tasks/upgrade.yml
+++ b/ibm/mas_devops/roles/suite_app_upgrade/tasks/upgrade.yml
@@ -130,6 +130,7 @@
   retries: 60 # about 90 minutes
   delay: 120 # 2 minutes
   until:
+    - facilities_ws_cr_lookup.resources is defined
     - facilities_ws_cr_lookup.resources | length > 0
     - facilities_ws_cr_lookup.resources[0].status.versions.reconciled == updated_opcon_version
     - facilities_ws_cr_lookup.resources | json_query('[*].status.conditions[?type==`Ready`][].reason') | select ('in', ['Ready']) | list | length == facilities_ws_cr_lookup.resources | length


### PR DESCRIPTION
## Description
<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->
Fixed the workspace health check condition and increased the timeout for the Facilities upgrade task, as the upgrade process may consume more time depending on OM package changes (9.2 has more OM packages compare to 9.1)

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
