### PR TITLE
[patch] Support --insecure-skip-tls-verify

### DIFF
--- a/ibm/mas_devops/roles/ocp_login/README.md
+++ b/ibm/mas_devops/roles/ocp_login/README.md
@@ -118,7 +118,15 @@ Authentication token for direct login.
 - `ocp_server`: Required with this variable
 - `cluster_name`/`cluster_type`: Alternative automatic lookup method
 
-**Note**: **SECURITY** - Both `ocp_server` and `ocp_token` must be provided together. Token should be kept secure and not committed to version control. This method works with any Kubernetes cluster.
+
+### ocp_skip_tls_verify
+
+Disable certificate check when logging in using `ocp_server` and `ocp_token` properties.
+
+- **Optional** (when `ocp_server` and `ocp_token` are set)
+- Environment Variable: `OCP_SKIP_TLS_VERIFY`
+- Default: `true`
+
 
 ## Role Variables - IBMCloud ROKS
 

--- a/ibm/mas_devops/roles/ocp_login/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_login/defaults/main.yml
@@ -5,6 +5,7 @@ cluster_type: "{{ lookup('env', 'CLUSTER_TYPE')}}"
 # For already provisioned clusters set token and server to log directly into rather than cluster type (ROKS/Fyre) specific login
 ocp_token: "{{ lookup('env', 'OCP_TOKEN') }}"
 ocp_server: "{{ lookup('env', 'OCP_SERVER') }}"
+ocp_skip_tls_verify: "{{ lookup('env', 'OCP_SKIP_TLS_VERIFY') | default('true', true)  }}"
 
 # IBM Cloud ROKS API Key - used when cluster_type == "roks"
 ibmcloud_endpoint: "{{ lookup('env', 'IBMCLOUD_ENDPOINT') | default('https://cloud.ibm.com', true) }}"

--- a/ibm/mas_devops/roles/ocp_login/tasks/login.yml
+++ b/ibm/mas_devops/roles/ocp_login/tasks/login.yml
@@ -1,18 +1,19 @@
 ---
 # 1. Check that we have the ocp vars defined
 # -----------------------------------------------------------------------------
-- name: "login : Fail if ocp_server or ocp_token are not provided"
+- name: "login : Fail if ocp_server, ocp_token, or ocp_skip_tls_verify are not provided"
   assert:
     that:
       - ocp_token is defined and ocp_token != ""
       - ocp_server is defined and ocp_server != ""
-    fail_msg: "ocp_server and ocp_token must be provided together"
+      - ocp_skip_tls_verify is defined and ocp_skip_tls_verify != ""
+    fail_msg: "ocp_server, ocp_token, & ocp_skip_tls_verify must be provided together"
 
 
 # 2. Login to OCP
 # -----------------------------------------------------------------------------
 - name: "login : Login to OCP"
-  shell: oc login --token={{ ocp_token }} --server={{ ocp_server }}
+  shell: oc login --token={{ ocp_token }} --server={{ ocp_server }} --insecure-skip-tls-verify={{ ocp_skip_tls_verify }}
   register: login_result
   retries: 5
   delay: 10 # seconds


### PR DESCRIPTION
## Description
Add `ocp_skip_tls_verify` to the `ocp_login` role to complement `ocp_server` and `ocp_token`, enabling usage with providers that don't use "real" certificates (like Fyre).

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
