### PR TITLE
[minor] db2ucluster migration db2uinstance

### DIFF
--- a/ibm/mas_devops/roles/db2/README.md
+++ b/ibm/mas_devops/roles/db2/README.md
@@ -124,7 +124,7 @@ Specifies which operation to perform on the Db2 database.
 - `override_storageclass`: In Restore, controls whether storage classes are overridden
 - `mas_instance_id`, `mas_config_dir`: Optional for migration; when provided, updates MAS JdbcCfg
 
-**Note**: **WARNING** - When using `upgrade`, ALL Db2 instances in the specified namespace will be upgraded. Plan accordingly and ensure `db2_version` matches the operator channel. When using `db2u-migration`, the Db2uCluster must be v12.x and the original Db2uCluster CR will remain after migration (not automatically deleted).
+**Note**: **WARNING** - When using `upgrade`, ALL Db2 instances in the specified namespace will be upgraded. Plan accordingly and ensure `db2_version` matches the operator channel. When using `db2u-migration`, the Db2uCluster must be v12.x and the original Db2uCluster CR will be deleted after migration.
 
 #### db2_namespace
 OpenShift namespace where Db2 operator and instances will be deployed.

--- a/ibm/mas_devops/roles/db2/README.md
+++ b/ibm/mas_devops/roles/db2/README.md
@@ -1,8 +1,8 @@
 # db2
 
-This role creates or upgrades a Db2 instance using the Db2u Operator. When installing db2, the db2u operator will now be installed into the same namespace as the db2 instance. 
+This role creates, upgrades, migrates, or manages Db2 instances using the Db2u Operator. When installing db2, the db2u operator will now be installed into the same namespace as the db2 instance.
 
-**IMPORTANT:** The Db2uCluster resource is deprecated (replaced by Db2uInstance). This Ansible collection will retain support for Db2uCluster until it's eventual EOL.
+**IMPORTANT:** The Db2uCluster resource is deprecated (replaced by Db2uInstance). This Ansible collection will retain support for Db2uCluster until it's eventual EOL. Use the `db2u-migration` action to migrate existing Db2uCluster deployments to Db2uInstance.
 
 If you already have db2 operator and db2 instances running in separate namespaces, this role will migrate the db2 **operators** (not the instances) from `ibm-common-services` to the namespace defined by `db2_namespace` property (in case of a new role execution for a db2 install or db2 upgrade). A private root CA certificate is created and is used to secure the TLS connections to the database. A Db2 Warehouse cluster will be created along with a public TLS encrypted route to allow external access to the cluster (access is via the ssl-server nodeport port on the *-db2u-engn-svc service). Internal access is via the *-db2u-engn-svc service and port 50001. Both the external route and the internal service use the same server certificate.
 
@@ -96,7 +96,7 @@ Specifies which operation to perform on the Db2 database.
 - Environment Variable: `DB2_ACTION`
 - Default: `install`
 
-**Purpose**: Controls what action the role executes against Db2 instances. This allows the same role to handle installation, upgrades, backups, and restores of Db2 databases.
+**Purpose**: Controls what action the role executes against Db2 instances. This allows the same role to handle installation, upgrades, backups, restores, and migration of Db2 databases.
 
 **When to use**:
 - Use `install` (default) for initial Db2 deployment
@@ -104,8 +104,9 @@ Specifies which operation to perform on the Db2 database.
 - Use `backup` to create a backup of Db2 instance and/or database
 - Use `restore` to restore a backup of db2 instance and database
 - Use `restore-database` to restore only the database to an existing Db2 instance
+- Use `db2u-migration` to migrate Db2uCluster to Db2uInstance (requires v12)
 
-**Valid values**: `install`, `upgrade`, `backup`, `restore`, `restore-database`
+**Valid values**: `install`, `upgrade`, `backup`, `restore`, `restore-database`, `db2u-migration`
 
 **Impact**:
 - `install`: Creates new Db2 operator and instance. When `db2_backup_version` is provided, installs from backup (instance + database)
@@ -113,14 +114,17 @@ Specifies which operation to perform on the Db2 database.
 - `backup`: Creates backup of Db2 instance resources and/or database data
 - `restore`: Creates new Db2 operator and instance from the backup of Db2 instance resources and restores database data to the created instance
 - `restore-database`: Restores database to an existing running Db2 instance (does not restore instance resources)
+- `db2u-migration`: Migrates existing Db2uCluster to Db2uInstance using `db2u_migrate` CLI tool (namespace-scoped, requires v12)
 
 **Related variables**:
 - `db2_version`: Required for upgrade action to specify target version
-- `db2_namespace`: All instances in this namespace are affected by upgrade
+- `db2_namespace`: All instances in this namespace are affected by upgrade; migration operates on this namespace
+- `db2_instance_name`: Required for migration to specify which Db2uCluster to migrate
 - `db2_backup_version`: Required for restore/restore-database action; optional for backup, defaults to YYYYMMDD-HHMMSS
 - `override_storageclass`: In Restore, controls whether storage classes are overridden
+- `mas_instance_id`, `mas_config_dir`: Optional for migration; when provided, updates MAS JdbcCfg
 
-**Note**: **WARNING** - When using `upgrade`, ALL Db2 instances in the specified namespace will be upgraded. Plan accordingly and ensure `db2_version` matches the operator channel.
+**Note**: **WARNING** - When using `upgrade`, ALL Db2 instances in the specified namespace will be upgraded. Plan accordingly and ensure `db2_version` matches the operator channel. When using `db2u-migration`, the Db2uCluster must be v12.x and the original Db2uCluster CR will remain after migration (not automatically deleted).
 
 #### db2_namespace
 OpenShift namespace where Db2 operator and instances will be deployed.
@@ -972,6 +976,127 @@ The number of Db2 pods to create in the instance. Note that `db2_num_pods` must 
 - Default: 1
 
 ### db2_addons_audit_config
+
+## Migrating from Db2uCluster to Db2uInstance
+The `db2u-migration` action enables migration of existing Db2uCluster deployments to the current Db2uInstance resource type. This migration is necessary as Db2uCluster is deprecated and will reach end-of-life in future releases.
+
+### Migration Requirements
+- **Version**: Db2uCluster must be running v12.x (migration will fail for v11 or earlier)
+- **CLI Tool**: The `db2u_migrate` command-line tool must be available on the machine running the Ansible role
+- **Namespace**: Migration is namespace-scoped; specify the namespace containing the Db2uCluster
+- **No Conflicts**: No Db2uInstance with the same name should exist in the namespace
+
+### Migration Behavior
+- **Non-destructive**: The original Db2uCluster CR remains after migration and is not automatically deleted
+- **Data Preservation**: Database data and configuration are preserved during migration
+- **Service Continuity**: The migration creates a new Db2uInstance that maintains connectivity to the existing database
+- **JdbcCfg Update**: Optionally updates MAS JdbcCfg if `mas_instance_id` and `mas_config_dir` are provided
+
+### Migration Process
+The migration action performs the following steps:
+
+1. **Validation**:
+   - Verifies namespace exists
+   - Confirms Db2uCluster exists and is v12.x
+   - Checks for Db2uInstance naming conflicts
+
+2. **Execution**:
+   - Runs `db2u_migrate --namespace <namespace> --name <name>`
+   - Monitors command output and handles errors
+
+3. **Verification**:
+   - Waits for Db2uInstance to reach Ready state
+   - Waits for Db2uEngine to reach Ready state
+   - Optionally updates MAS JdbcCfg
+
+4. **Post-Migration**:
+   - Displays success status
+   - Reminds user that Db2uCluster still exists
+   - Provides guidance for optional cleanup
+
+### Usage Example
+
+#### Basic Migration
+```bash
+export DB2_ACTION=db2u-migration
+export DB2_NAMESPACE=db2u
+export DB2_INSTANCE_NAME=db2u-db01
+
+ansible-playbook ibm.mas_devops.run_role
+```
+
+#### Migration with MAS JdbcCfg Update
+```bash
+export DB2_ACTION=db2u-migration
+export DB2_NAMESPACE=db2u
+export DB2_INSTANCE_NAME=db2u-manage
+export MAS_INSTANCE_ID=inst1
+export MAS_CONFIG_DIR=/tmp/masconfig
+
+ansible-playbook ibm.mas_devops.run_role
+```
+
+### Post-Migration Steps
+
+#### Verify Migration Success
+```bash
+# Check Db2uInstance status
+oc get db2uinstance -n db2u
+
+# Check Db2uEngine status
+oc get db2uengine -n db2u
+
+# Verify database connectivity
+oc exec -n db2u c-db2u-db01-db2u-0 -- su - db2inst1 -c "db2 connect to BLUDB"
+```
+
+#### Optional: Clean Up Db2uCluster
+After verifying the migration succeeded and the Db2uInstance is functioning correctly, you may optionally delete the original Db2uCluster:
+
+```bash
+# Delete the Db2uCluster CR (optional)
+oc delete db2ucluster db2u-db01 -n db2u
+```
+
+**Note**: Only delete the Db2uCluster after thoroughly verifying the migrated Db2uInstance is working correctly.
+
+### Troubleshooting Migration
+
+#### Migration Fails: Version Check
+```
+Error: Migration requires Db2uCluster to be v12.x
+Current version: 11.5.8.0
+```
+
+**Resolution**: Upgrade your Db2uCluster to v12 before attempting migration:
+```bash
+export DB2_ACTION=upgrade
+export DB2_VERSION=12.0.0.0
+export DB2_CHANNEL=v12.0.0-cn1
+ansible-playbook ibm.mas_devops.run_role
+```
+
+#### Migration Fails: Db2uInstance Already Exists
+```
+Error: Db2uInstance 'db2u-db01' already exists in namespace 'db2u'
+```
+
+**Resolution**: Either delete the existing Db2uInstance or choose a different name:
+```bash
+# Option 1: Delete existing instance
+oc delete db2uinstance db2u-db01 -n db2u
+
+# Option 2: Use different name
+export DB2_INSTANCE_NAME=db2u-db01-migrated
+```
+
+#### Migration Fails: db2u_migrate Command Not Found
+```
+Error: db2u_migrate: command not found
+```
+
+**Resolution**: Install the `db2u_migrate` CLI tool on the machine running the Ansible role. Contact IBM support or refer to Db2 operator documentation for installation instructions.
+
 
 - Optional
 - Environment Variable: `'DB2_ADDONS_AUDIT_CONFIG`

--- a/ibm/mas_devops/roles/db2/defaults/main.yml
+++ b/ibm/mas_devops/roles/db2/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # db2 action
 # ---------------------------------------------------------------------------
-# Supported actions: install, uninstall, backup, backup-database, restore, restore-database and upgrade
+# Supported actions: install, upgrade, backup, backup-database, restore, restore-database, db2u-migration
 db2_action: "{{ lookup('env', 'DB2_ACTION') | default('install', true) }}"
 
 # Configure Db2 instance

--- a/ibm/mas_devops/roles/db2/tasks/db2u-migration/main.yml
+++ b/ibm/mas_devops/roles/db2/tasks/db2u-migration/main.yml
@@ -1,0 +1,243 @@
+---
+# Db2uCluster to Db2uInstance Migration
+# =============================================================================
+# This task performs migration from deprecated Db2uCluster to Db2uInstance
+# using the db2u_migrate CLI tool. The migration is namespace-scoped and
+# requires the Db2uCluster to be running v12.x.
+#
+# Requirements:
+# - db2u_migrate CLI tool must be available on the local machine
+# - Db2uCluster must be v12.x (migration will fail otherwise)
+# - No Db2uInstance with the same name should exist
+#
+# Note: The Db2uCluster CR remains after migration and is not automatically deleted.
+# =============================================================================
+
+# 1. Validate namespace exists
+# -----------------------------------------------------------------------------
+- name: "Lookup namespace: {{ db2_namespace }}"
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Namespace
+    name: "{{ db2_namespace }}"
+  register: _namespace_lookup
+
+- name: "Fail if namespace does not exist"
+  ansible.builtin.fail:
+    msg: |
+      Namespace '{{ db2_namespace }}' does not exist.
+      Cannot proceed with migration.
+  when:
+    - _namespace_lookup.resources is not defined or _namespace_lookup.resources | length == 0
+
+# 2. Validate Db2uCluster exists
+# -----------------------------------------------------------------------------
+- name: "Lookup Db2uCluster: {{ db2_instance_name }}"
+  kubernetes.core.k8s_info:
+    api_version: db2u.databases.ibm.com/v1
+    kind: Db2uCluster
+    name: "{{ db2_instance_name | lower }}"
+    namespace: "{{ db2_namespace }}"
+  register: _db2ucluster_lookup
+
+- name: "Fail if Db2uCluster does not exist"
+  ansible.builtin.fail:
+    msg: |
+      Db2uCluster '{{ db2_instance_name }}' does not exist in namespace '{{ db2_namespace }}'.
+      Cannot proceed with migration.
+      
+      Available Db2uClusters in namespace:
+      {{ _all_clusters.resources | map(attribute='metadata.name') | list | join(', ') if _all_clusters.resources | length > 0 else 'None' }}
+  when:
+    - _db2ucluster_lookup.resources is not defined or _db2ucluster_lookup.resources | length == 0
+  vars:
+    _all_clusters: "{{ lookup('kubernetes.core.k8s', api_version='db2u.databases.ibm.com/v1', kind='Db2uCluster', namespace=db2_namespace) }}"
+
+# 3. Validate Db2uCluster version is v12
+# -----------------------------------------------------------------------------
+- name: "Extract Db2uCluster version"
+  ansible.builtin.set_fact:
+    _db2_cluster_version: "{{ _db2ucluster_lookup.resources[0].spec.version | default('unknown') }}"
+
+- name: "Display Db2uCluster version"
+  ansible.builtin.debug:
+    msg:
+      - "Db2uCluster name: {{ db2_instance_name }}"
+      - "Db2uCluster version: {{ _db2_cluster_version }}"
+      - "Namespace: {{ db2_namespace }}"
+
+- name: "Validate Db2uCluster is v12"
+  ansible.builtin.fail:
+    msg: |
+      Migration requires Db2uCluster to be v12.x
+      
+      Current version: {{ _db2_cluster_version }}
+      Required: v12.x (e.g., 12.0.0, 12.1.0)
+      
+      Please upgrade your Db2uCluster to v12 before attempting migration.
+  when:
+    - not (_db2_cluster_version is match('^12\..*') or _db2_cluster_version == '12')
+
+# 4. Check for existing Db2uInstance conflict
+# -----------------------------------------------------------------------------
+- name: "Check if Db2uInstance already exists"
+  kubernetes.core.k8s_info:
+    api_version: db2u.databases.ibm.com/v1
+    kind: Db2uInstance
+    name: "{{ db2_instance_name | lower }}"
+    namespace: "{{ db2_namespace }}"
+  register: _db2uinstance_lookup
+
+- name: "Fail if Db2uInstance already exists"
+  ansible.builtin.fail:
+    msg: |
+      Db2uInstance '{{ db2_instance_name }}' already exists in namespace '{{ db2_namespace }}'.
+      Migration cannot proceed as it would conflict with the existing instance.
+      
+      If you want to re-migrate, please delete the existing Db2uInstance first:
+      oc delete db2uinstance {{ db2_instance_name | lower }} -n {{ db2_namespace }}
+  when:
+    - _db2uinstance_lookup.resources is defined
+    - _db2uinstance_lookup.resources | length > 0
+
+# 5. Display pre-migration summary
+# -----------------------------------------------------------------------------
+- name: "Pre-migration summary"
+  ansible.builtin.debug:
+    msg:
+      - "=========================================="
+      - "Db2uCluster to Db2uInstance Migration"
+      - "=========================================="
+      - "Source: Db2uCluster/{{ db2_instance_name }}"
+      - "Target: Db2uInstance/{{ db2_instance_name }}"
+      - "Namespace: {{ db2_namespace }}"
+      - "Version: {{ _db2_cluster_version }}"
+      - ""
+      - "IMPORTANT: The Db2uCluster CR will remain after migration."
+      - "You may manually delete it after verifying the migration succeeded."
+      - "=========================================="
+
+# 6. Execute db2u_migrate command
+# -----------------------------------------------------------------------------
+- name: "Execute db2u_migrate command"
+  ansible.builtin.command:
+    cmd: "db2u_migrate --namespace {{ db2_namespace }} --name {{ db2_instance_name | lower }}"
+  register: _migrate_result
+  changed_when: true
+  failed_when: _migrate_result.rc != 0
+
+- name: "Display migration command output"
+  ansible.builtin.debug:
+    msg:
+      - "Migration command completed"
+      - "Return code: {{ _migrate_result.rc }}"
+      - "Output: {{ _migrate_result.stdout }}"
+  when: _migrate_result.stdout is defined and _migrate_result.stdout != ""
+
+- name: "Display migration command errors (if any)"
+  ansible.builtin.debug:
+    msg:
+      - "Migration command stderr:"
+      - "{{ _migrate_result.stderr }}"
+  when:
+    - _migrate_result.stderr is defined
+    - _migrate_result.stderr != ""
+
+# 7. Verify Db2uInstance was created
+# -----------------------------------------------------------------------------
+- name: "Verify Db2uInstance was created"
+  kubernetes.core.k8s_info:
+    api_version: db2u.databases.ibm.com/v1
+    kind: Db2uInstance
+    name: "{{ db2_instance_name | lower }}"
+    namespace: "{{ db2_namespace }}"
+  register: _verify_instance
+  retries: 5
+  delay: 10
+  until:
+    - _verify_instance.resources is defined
+    - _verify_instance.resources | length > 0
+
+- name: "Fail if Db2uInstance was not created"
+  ansible.builtin.fail:
+    msg: |
+      Migration failed: Db2uInstance '{{ db2_instance_name }}' was not created.
+      
+      The db2u_migrate command completed, but the Db2uInstance resource was not found.
+      Please check the migration command output above for details.
+  when:
+    - _verify_instance.resources is not defined or _verify_instance.resources | length == 0
+
+# 8. Wait for Db2uInstance to be ready
+# -----------------------------------------------------------------------------
+- name: "Wait for Db2uInstance to be ready (5m delay)"
+  kubernetes.core.k8s_info:
+    api_version: db2u.databases.ibm.com/v1
+    name: "{{ db2_instance_name | lower }}"
+    namespace: "{{ db2_namespace }}"
+    kind: Db2uInstance
+  register: _db2_instance_status
+  until:
+    - _db2_instance_status.resources is defined
+    - _db2_instance_status.resources | length == 1
+    - _db2_instance_status.resources[0].status is defined
+    - _db2_instance_status.resources[0].status.state is defined
+    - _db2_instance_status.resources[0].status.state == "Ready"
+  retries: 24 # Approximately 2 hours before we give up
+  delay: 300 # 5 minutes
+
+# 9. Wait for Db2uEngine to be ready
+# -----------------------------------------------------------------------------
+- name: "Wait for Db2uEngine to be ready"
+  kubernetes.core.k8s_info:
+    api_version: db2u.databases.ibm.com/v1alpha1
+    kind: Db2uEngine
+    name: "c-{{ db2_instance_name | lower }}-db2u"
+    namespace: "{{ db2_namespace }}"
+  register: _db2_engine_status
+  until:
+    - _db2_engine_status.resources is defined
+    - _db2_engine_status.resources | length > 0
+    - _db2_engine_status.resources[0].status is defined
+    - _db2_engine_status.resources[0].status.state is defined
+    - _db2_engine_status.resources[0].status.state == 'Ready'
+  retries: 20 # approx 10 minutes before we give up
+  delay: 30 # seconds
+
+# 10. Display post-migration status
+# -----------------------------------------------------------------------------
+- name: "Post-migration status"
+  ansible.builtin.debug:
+    msg:
+      - "=========================================="
+      - "Migration Completed Successfully"
+      - "=========================================="
+      - "Db2uInstance '{{ db2_instance_name }}' is Ready"
+      - "Db2uEngine is Ready"
+      - "Namespace: {{ db2_namespace }}"
+      - ""
+      - "REMINDER: The original Db2uCluster '{{ db2_instance_name }}' still exists."
+      - "After verifying the migration, you may optionally delete it:"
+      - "  oc delete db2ucluster {{ db2_instance_name | lower }} -n {{ db2_namespace }}"
+      - "=========================================="
+
+# 11. Update MAS JdbcCfg (if requested)
+# -----------------------------------------------------------------------------
+- name: "Update MAS JdbcCfg configuration"
+  when:
+    - mas_instance_id is defined
+    - mas_instance_id != ""
+    - mas_config_dir is defined
+    - mas_config_dir != ""
+  block:
+    - name: "Generate JdbcCfg for migrated instance"
+      include_tasks: "tasks/install/suite_jdbccfg.yml"
+
+    - name: "JdbcCfg update completed"
+      ansible.builtin.debug:
+        msg:
+          - "JdbcCfg has been generated for the migrated instance"
+          - "Location: {{ mas_config_dir }}/jdbc-{{ db2_instance_name | lower }}-{{ db2_namespace }}.yml"
+          - "Apply the configuration to update MAS if needed"
+
+# Made with Bob

--- a/ibm/mas_devops/roles/db2/tasks/db2u-migration/main.yml
+++ b/ibm/mas_devops/roles/db2/tasks/db2u-migration/main.yml
@@ -10,8 +10,23 @@
 # - Db2uCluster must be v12.x (migration will fail otherwise)
 # - No Db2uInstance with the same name should exist
 #
-# Note: The Db2uCluster CR remains after migration and is not automatically deleted.
 # =============================================================================
+
+# 0. Verify db2u_migrate is installed
+# -----------------------------------------------------------------------------
+- name: "Check if db2u_migrate is installed"
+  ansible.builtin.command:
+    cmd: "which db2u_migrate"
+  register: _db2u_migrate_check
+  changed_when: false
+  failed_when: false
+
+- name: "Fail if db2u_migrate is not installed"
+  ansible.builtin.fail:
+    msg: |
+      The 'db2u_migrate' CLI tool was not found on this machine.
+      Please install it before running this migration.
+  when: _db2u_migrate_check.rc != 0
 
 # 1. Validate namespace exists
 # -----------------------------------------------------------------------------
@@ -45,7 +60,7 @@
     msg: |
       Db2uCluster '{{ db2_instance_name }}' does not exist in namespace '{{ db2_namespace }}'.
       Cannot proceed with migration.
-      
+
       Available Db2uClusters in namespace:
       {{ _all_clusters.resources | map(attribute='metadata.name') | list | join(', ') if _all_clusters.resources | length > 0 else 'None' }}
   when:
@@ -70,13 +85,13 @@
   ansible.builtin.fail:
     msg: |
       Migration requires Db2uCluster to be v12.x
-      
+
       Current version: {{ _db2_cluster_version }}
-      Required: v12.x (e.g., 12.0.0, 12.1.0)
-      
+      Required: v12.x (e.g., 12.0.0, s12.1.4.0)
+
       Please upgrade your Db2uCluster to v12 before attempting migration.
   when:
-    - not (_db2_cluster_version is match('^12\..*') or _db2_cluster_version == '12')
+    - not (_db2_cluster_version is match('^[^\d]*12[\.\d]*$'))
 
 # 4. Check for existing Db2uInstance conflict
 # -----------------------------------------------------------------------------
@@ -93,7 +108,7 @@
     msg: |
       Db2uInstance '{{ db2_instance_name }}' already exists in namespace '{{ db2_namespace }}'.
       Migration cannot proceed as it would conflict with the existing instance.
-      
+
       If you want to re-migrate, please delete the existing Db2uInstance first:
       oc delete db2uinstance {{ db2_instance_name | lower }} -n {{ db2_namespace }}
   when:
@@ -113,8 +128,6 @@
       - "Namespace: {{ db2_namespace }}"
       - "Version: {{ _db2_cluster_version }}"
       - ""
-      - "IMPORTANT: The Db2uCluster CR will remain after migration."
-      - "You may manually delete it after verifying the migration succeeded."
       - "=========================================="
 
 # 6. Execute db2u_migrate command
@@ -162,7 +175,7 @@
   ansible.builtin.fail:
     msg: |
       Migration failed: Db2uInstance '{{ db2_instance_name }}' was not created.
-      
+
       The db2u_migrate command completed, but the Db2uInstance resource was not found.
       Please check the migration command output above for details.
   when:
@@ -216,9 +229,6 @@
       - "Db2uEngine is Ready"
       - "Namespace: {{ db2_namespace }}"
       - ""
-      - "REMINDER: The original Db2uCluster '{{ db2_instance_name }}' still exists."
-      - "After verifying the migration, you may optionally delete it:"
-      - "  oc delete db2ucluster {{ db2_instance_name | lower }} -n {{ db2_namespace }}"
       - "=========================================="
 
 # 11. Update MAS JdbcCfg (if requested)
@@ -239,5 +249,3 @@
           - "JdbcCfg has been generated for the migrated instance"
           - "Location: {{ mas_config_dir }}/jdbc-{{ db2_instance_name | lower }}-{{ db2_namespace }}.yml"
           - "Apply the configuration to update MAS if needed"
-
-# Made with Bob

--- a/ibm/mas_devops/roles/db2/tasks/main.yml
+++ b/ibm/mas_devops/roles/db2/tasks/main.yml
@@ -3,10 +3,10 @@
   include_tasks: "tasks/{{ db2_action }}/main.yml"
   when:
     - db2_action != "none"
-    - db2_action in ["install", "upgrade", "backup", "restore-database", "backup-database", "restore"]
+    - db2_action in ["install", "upgrade", "backup", "restore-database", "backup-database", "restore", "db2u-migration"]
 
 - name: "Fail if db2_action is invalid"
   fail:
-    msg: "db2_action must be one of ['install', 'upgrade', 'backup', 'restore-database', 'backup-database', 'restore', 'none']"
+    msg: "db2_action must be one of ['install', 'upgrade', 'backup', 'restore-database', 'backup-database', 'restore', 'db2u-migration', 'none']"
   when:
-    - db2_action not in ["none", "install", "upgrade", "backup", "restore-database", "backup-database", "restore"]
+    - db2_action not in ["none", "install", "upgrade", "backup", "restore-database", "backup-database", "restore", "db2u-migration"]


### PR DESCRIPTION
## Description
Introduction of new action for Db2. The new action is called `db2u-migration` and migrates Db2uCluster to Db2uInstance. This tool relies on `db2u_migrate` CLI provided by Db2 team. Pre-requisites:
- Db2uCluster on v12

Related PRs:


## Test Results
Create Db2uCluster on v12, migrate to Db2uInstance.

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
