### PR TITLE
[patch] Syncjob failing for new CIS domains

### DIFF
--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
@@ -1,7 +1,7 @@
 ---
 - name: "cis : Ensure IBMCloud CIS is installed"
   ansible.builtin.shell: |
-    ibmcloud plugin install cis --version 1.19.1 -f
+    ibmcloud plugin install cloud-internet-services@1.19.2 -f
 
 - name: "cis : Lookup for Cluster-info Config Map"
   kubernetes.core.k8s_info:

--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
@@ -1,7 +1,7 @@
 ---
 - name: "cis : Ensure IBMCloud CIS is installed"
   ansible.builtin.shell: |
-    ibmcloud plugin install cis -f
+    ibmcloud plugin install cis 1.19.2 -f
 
 - name: "cis : Lookup for Cluster-info Config Map"
   kubernetes.core.k8s_info:

--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
@@ -1,7 +1,7 @@
 ---
 - name: "cis : Ensure IBMCloud CIS is installed"
   ansible.builtin.shell: |
-    ibmcloud plugin install cis 1.19.2 -f
+    ibmcloud plugin install cis --version 1.19.1 -f
 
 - name: "cis : Lookup for Cluster-info Config Map"
   kubernetes.core.k8s_info:

--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_suitedns_enhanced.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_suitedns_enhanced.yml
@@ -49,7 +49,7 @@
     - name: "cis: get deployed rule id for CIS Managed Ruleset id"
       ansible.builtin.shell: |
         ibmcloud cis managed-waf deployments {{ (_cis_domains_result.stdout | from_json)[0].id }} \
-        -i "{{ cis_service_name }}" --output json | jq -r --arg target_id {{ _cis_ruleset_result.stdout }} '.rules[] | select(.action_parameters.id == $target_id) | .id'
+        -i "{{ cis_service_name }}" --output json | jq -r --arg target_id {{ _cis_ruleset_result.stdout }} '(.rules // [])[] | select(.action_parameters.id == $target_id) | .id'
       register: _cis_rule_id_result
 
     - name: "cis: add CIS Managed Ruleset to WAF when WAF rule does not exist"
@@ -61,7 +61,7 @@
     - name: "cis: get deployed rule id for CIS Managed Ruleset id"
       ansible.builtin.shell: |
         ibmcloud cis managed-waf deployments {{ (_cis_domains_result.stdout | from_json)[0].id }} \
-        -i "{{ cis_service_name }}" --output json | jq -r --arg target_id "{{ _cis_ruleset_result.stdout }}" '.rules[] | select(.action_parameters.id == $target_id) | .id'
+        -i "{{ cis_service_name }}" --output json | jq -r --arg target_id "{{ _cis_ruleset_result.stdout }}" '(.rules // [])[] | select(.action_parameters.id == $target_id) | .id'
       register: _cis_rule_id_result
 
     - name: "cis: enable CIS Default Ruleset"

--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_suitedns_enhanced.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_suitedns_enhanced.yml
@@ -73,7 +73,7 @@
     - name: "cis: enable CIS Managed Ruleset if deployed but disabled"
       ansible.builtin.shell: |
         ibmcloud cis managed-waf deployment-update-ruleset {{ (_cis_domains_result.stdout | from_json)[0].id }} {{ _cis_rule_id_result.stdout }} \
-        --override-rules rule={{ _cis_rule_id_result.stdout }},enabled=true -i "{{ cis_service_name }}"
+        --enabled true --reset-all -i "{{ cis_service_name }}"
       when:
         - _cis_rule_id | trim | length > 0
         - _cis_rule_enabled == 'false'

--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_suitedns_enhanced.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_suitedns_enhanced.yml
@@ -46,17 +46,23 @@
         msg: "CIS Managed Ruleset ID not found. Ensure the ruleset exists in the CIS instance."
       when: _cis_ruleset_result.stdout | trim | length == 0
 
-    - name: "cis: get deployed rule id for CIS Managed Ruleset id"
+    - name: "cis: get deployed rule id and enabled status for CIS Managed Ruleset"
       ansible.builtin.shell: |
         ibmcloud cis managed-waf deployments {{ (_cis_domains_result.stdout | from_json)[0].id }} \
-        -i "{{ cis_service_name }}" --output json | jq -r --arg target_id {{ _cis_ruleset_result.stdout }} '(.rules // [])[] | select(.action_parameters.id == $target_id) | .id'
-      register: _cis_rule_id_result
+        -i "{{ cis_service_name }}" --output json | jq -r --arg target_id {{ _cis_ruleset_result.stdout }} \
+        '(.rules // [])[] | select(.action_parameters.id == $target_id) | "\(.id) \(.enabled)"'
+      register: _cis_rule_status_result
+
+    - name: "cis: set deployed rule facts"
+      ansible.builtin.set_fact:
+        _cis_rule_id: "{{ _cis_rule_status_result.stdout.split(' ')[0] | default('') }}"
+        _cis_rule_enabled: "{{ _cis_rule_status_result.stdout.split(' ')[1] | default('false') }}"
 
     - name: "cis: add CIS Managed Ruleset to WAF when WAF rule does not exist"
       ansible.builtin.shell: |
         ibmcloud cis managed-waf deployment-add-ruleset {{ (_cis_domains_result.stdout | from_json)[0].id }} {{ _cis_ruleset_result.stdout }} \
         -i "{{ cis_service_name }}" --enabled true
-      when: _cis_rule_id_result.stdout | trim | length == 0
+      when: _cis_rule_id | trim | length == 0
 
     - name: "cis: get deployed rule id for CIS Managed Ruleset id"
       ansible.builtin.shell: |
@@ -64,10 +70,13 @@
         -i "{{ cis_service_name }}" --output json | jq -r --arg target_id "{{ _cis_ruleset_result.stdout }}" '(.rules // [])[] | select(.action_parameters.id == $target_id) | .id'
       register: _cis_rule_id_result
 
-    - name: "cis: enable CIS Default Ruleset"
+    - name: "cis: enable CIS Managed Ruleset if deployed but disabled"
       ansible.builtin.shell: |
         ibmcloud cis managed-waf deployment-update-ruleset {{ (_cis_domains_result.stdout | from_json)[0].id }} {{ _cis_rule_id_result.stdout }} \
-        -i "{{ cis_service_name }}" --enabled true
+        --override-rules rule={{ _cis_rule_id_result.stdout }},enabled=true -i "{{ cis_service_name }}"
+      when:
+        - _cis_rule_id | trim | length > 0
+        - _cis_rule_enabled == 'false'
 
     - ansible.builtin.include_tasks: tasks/providers/cis/cis_managed_ruleset.yml
       loop: "{{ managed_ruleset_rules_to_disable }}"


### PR DESCRIPTION
## Description
Syncjob failing for new CIS domains

## Solution
1. Used a fixed version of cis plugin 1.19.2 instead of always installing latest version
2. Fixed some null issues by having an empty list instead if the ruleset is not deployed
3. If the ruleset is deployed but disabled, just enabling it doesn't work. So had to run with reset-all option

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

Not deployed
<img width="1705" height="845" alt="Screenshot 2026-07-08 at 12 00 24 AM" src="https://github.com/user-attachments/assets/36d3a2bf-b62f-4c82-8cd9-0a78b4d57369" />
Deployed after the sync job is run
<img width="1704" height="650" alt="Screenshot 2026-07-08 at 12 10 52 AM" src="https://github.com/user-attachments/assets/998be7b9-ea7f-4de2-9190-8d3f205467de" />

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
