### PR TITLE
[patch] Removed pinned grafana version to default

### DIFF
--- a/ibm/mas_devops/roles/grafana/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/grafana/tasks/install/main.yml
@@ -69,8 +69,6 @@
     namespace: "{{ grafana_namespace }}"
     package_name: grafana-operator
     package_channel: "v{{grafana_major_version}}"
-    install_plan_approval: Manual
-    starting_csv: grafana-operator.v5.21.2
     config:
       env:
         - name: "WATCH_NAMESPACE"


### PR DESCRIPTION
## Description

[JIRA MASCORE-15075](https://jsw.ibm.com/browse/MASCORE-15075)
The Grafana version used by MAS is currently pinned to v5.21.2. The Customer has reported vulnerabilities in this version that require an upgrade to a newer Grafana release.

This PR removed the v5.21.2 and to use the latest version as the grafana teams fixed the issue in https://github.com/grafana/grafana-operator/pull/2583

## Test Results
Created OCP 4.18 cluster to install latest grafana version and grafana 5.24.0 was installed successfully.

