### PR TITLE
[patch] Modified default version of OCP of ROKS

### DIFF
--- a/docs/playbooks/ocp.md
+++ b/docs/playbooks/ocp.md
@@ -31,7 +31,7 @@ This also supports upgrading the storage volume used for the cluster's internal 
 
 ```bash
 export CLUSTER_NAME=masinst1
-export OCP_VERSION=4.20_openshift
+export OCP_VERSION=4.21_openshift
 export IBMCLOUD_APIKEY=xxx
 export REBOOT_WORKER_NODES=true
 export CPD_ENTITLEMENT_KEY=xxx

--- a/docs/playbooks/ocp.md
+++ b/docs/playbooks/ocp.md
@@ -54,7 +54,7 @@ ansible-playbook ibm.mas_devops.ocp_fyre_provision
 
 
 Deprovision
--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 Refer to the [ocp_deprovision](../roles/ocp_deprovision.md) role documentation for more information.
 
 ### Deprovision on IBMCloud ROKS

--- a/ibm/mas_devops/playbooks/ocp_convert_to_disconnected.yml
+++ b/ibm/mas_devops/playbooks/ocp_convert_to_disconnected.yml
@@ -5,7 +5,7 @@
   vars:
     ocp_operatorhub_disable_redhat_sources: true
 
-    ocp_release: "{{ lookup('env', 'OCP_RELEASE') | default('4.20', true) }}"
+    ocp_release: "{{ lookup('env', 'OCP_RELEASE') | default('4.21', true) }}"
     setup_redhat_release: true
     setup_redhat_catalogs: true
 

--- a/ibm/mas_devops/playbooks/ocp_roks_provision.yml
+++ b/ibm/mas_devops/playbooks/ocp_roks_provision.yml
@@ -3,7 +3,7 @@
   any_errors_fatal: true
   vars:
     cluster_type: roks
-    ocp_version: "{{ lookup('env', 'OCP_VERSION') | default('4.20_openshift', True) }}"
+    ocp_version: "{{ lookup('env', 'OCP_VERSION') | default('4.21_openshift', True) }}"
     prometheus_storage_class: ibmc-block-gold
     prometheus_alertmgr_storage_class: ibmc-file-gold-gid
 

--- a/ibm/mas_devops/roles/mirror_ocp/README.md
+++ b/ibm/mas_devops/roles/mirror_ocp/README.md
@@ -187,7 +187,7 @@ Path to Red Hat pull secret file.
 
 ## Role Variables - OpenShift Version
 ### ocp_release
-The Red Hat release you are mirroring content for, e.g. `4.20`.
+The Red Hat release you are mirroring content for, e.g. `4.21`.
 
 - **Required**
 - Environment Variable: `OCP_RELEASE`
@@ -198,9 +198,9 @@ The Red Hat release you are mirroring content for, e.g. `4.20`.
 **When to use**:
 - Always required for Red Hat content mirroring
 - Must match the OpenShift version in your target environment
-- Use format: `4.20`, `4.19`, `4.18`, `4.17`
+- Use format: `4.21`, `4.20`, `4.19`, `4.18`, `4.17`
 
-**Valid values**: OpenShift major.minor version (e.g., `4.20`, `4.19`, `4.18`, `4.17`, `4.16`)
+**Valid values**: OpenShift major.minor version (e.g., `4.21`, `4.20`, `4.19`, `4.18`, `4.17`, `4.16`)
 
 **Impact**: Determines which OpenShift version's images and operators are mirrored. Must match your target cluster version.
 
@@ -209,10 +209,10 @@ The Red Hat release you are mirroring content for, e.g. `4.20`.
 - `ocp_max_version`: Maximum patch version to mirror
 - `mirror_redhat_platform`: Whether to mirror platform images for this version
 
-**Note**: Use the major.minor version format (e.g., `4.20`), not full version (e.g., `4.20.8`). Use `ocp_min_version` and `ocp_max_version` to control patch version range.
+**Note**: Use the major.minor version format (e.g., `4.21`), not full version (e.g., `4.21.21`). Use `ocp_min_version` and `ocp_max_version` to control patch version range.
 
 ### ocp_min_version
-The minimum version of the Red Hat release to mirror platform content for, e.g. `4.20.8`.
+The minimum version of the Red Hat release to mirror platform content for, e.g. `4.21.21`.
 
 - **Optional**
 - Environment Variable: `OCP_MIN_VERSION`
@@ -237,7 +237,7 @@ The minimum version of the Red Hat release to mirror platform content for, e.g. 
 **Note**: Only affects platform image mirroring, not operators. Use to limit mirror size when you know the specific OpenShift versions you need.
 
 ### ocp_max_version
-The maximimum version of the Red Hat release to mirror platform content for, e.g. `4.20.12`.
+The maximimum version of the Red Hat release to mirror platform content for, e.g. `4.21.21`.
 
 - **Optional**
 - Environment Variable: `OCP_MAX_VERSION`
@@ -447,7 +447,7 @@ Password for target registry authentication.
     mirror_redhat_platform: false
     mirror_redhat_operators: true
 
-    ocp_release: 4.20
+    ocp_release: 4.21
     redhat_pullsecret: ~/pull-secret.json
 
   roles:

--- a/ibm/mas_devops/roles/ocp_provision/README.md
+++ b/ibm/mas_devops/roles/ocp_provision/README.md
@@ -32,7 +32,7 @@ Infrastructure provider type for cluster provisioning.
 - `ocp_version`: OpenShift version to install
 - Provider-specific variables (ibmcloud_apikey, rosa_token, fyre_apikey, etc.)
 
-**Note**: Fyre clusters automatically configure NFS storage. ROKS requires version format like `4.20_openshift`.
+**Note**: Fyre clusters automatically configure NFS storage. ROKS requires version format like `4.21_openshift`.
 
 ### cluster_name
 Name for the new cluster.
@@ -69,15 +69,15 @@ OpenShift version to install.
 
 **When to use**:
 - Always required for cluster provisioning
-- Use specific version for production (e.g., `4.20.8`)
+- Use specific version for production (e.g., `4.21.21`)
 - Use `default` for latest MAS-supported version
 - Use `rotate` for testing (version changes by day of week)
 
 **Valid values**: 
-- Specific version: `4.20`, `4.20.8`
+- Specific version: `4.21`, `4.21.21`
 - Alias: `default` (newest MAS-supported version)
 - Alias: `rotate` (predetermined version by day, for testing)
-- **ROKS format**: Must append `_openshift` (e.g., `4.20_openshift`, `4.20.8_openshift`)
+- **ROKS format**: Must append `_openshift` (e.g., `4.21_openshift`, `4.21.21_openshift`)
 
 **Impact**: Determines OpenShift version installed. Version must be compatible with MAS and available from the provider.
 

--- a/ibm/mas_devops/roles/ocp_provision/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/defaults/main.yml
@@ -7,7 +7,7 @@ cluster_platform: "{{lookup('env', 'CLUSTER_PLATFORM') | default('x',true)}}"
 
 ocp_version: "{{ lookup('env', 'OCP_VERSION') }}"
 ocp_fips_enabled: "{{ lookup('env', 'OCP_FIPS_ENABLED') | default('false', true) | bool }}"
-default_ocp_version: 4.20
+default_ocp_version: 4.21
 
 supported_cluster_types:
   - fyre


### PR DESCRIPTION
## Description
Modified OCP default version to 4.21 since IBM Cloud has released OCP 4.21.

[JIRA MASR-3896](https://jsw.ibm.com/browse/MASR-3896)
