### PR TITLE
[patch] suite_app_restore: prefix PVC names with instance and workspace ID during Manage restore

### DIFF
--- a/ibm/mas_devops/roles/suite_app_restore/README.md
+++ b/ibm/mas_devops/roles/suite_app_restore/README.md
@@ -122,7 +122,7 @@ Custom storage class to use for PVCs with ReadWriteOnce (RWO) access mode when `
 Control whether to restore persistent volume data for application. When set to `false`, only namespace resources (CRs, secrets, subscriptions) will be restored, and PVC data restore will be skipped.
 
 - Optional
-- Environment Variable: `mas_app_restore_include_pvc`
+- Environment Variable: `MAS_APP_RESTORE_INCLUDE_PVC`
 - Default: `true`
 - Valid Values: `true`, `false`
 

--- a/ibm/mas_devops/roles/suite_app_restore/tasks/manage/restore-pv.yml
+++ b/ibm/mas_devops/roles/suite_app_restore/tasks/manage/restore-pv.yml
@@ -72,7 +72,7 @@
           apiVersion: v1
           kind: PersistentVolumeClaim
           metadata:
-            name: "{{ pv_item.pvcName }}"
+            name: "{{ mas_instance_id }}-{{ mas_workspace_id }}-{{ pv_item.pvcName }}"
             namespace: "{{ mas_app_namespace }}"
           spec:
             accessModes: "{{ pv_item.accessModes }}"
@@ -99,7 +99,7 @@
       kubernetes.core.k8s_info:
         api_version: v1
         kind: PersistentVolumeClaim
-        name: "{{ pv_item.pvcName }}"
+        name: "{{ mas_instance_id }}-{{ mas_workspace_id }}-{{ pv_item.pvcName }}"
         namespace: "{{ mas_app_namespace }}"
       register: pvc_status
       retries: 60
@@ -138,13 +138,13 @@
         volume_mounts: |
           {% set mounts = [] %}
           {% for pv in manage_persistent_volumes %}
-          {% set _ = mounts.append({'name': pv.pvcName, 'mountPath': pv.mountPath}) %}
+          {% set _ = mounts.append({'name': mas_instance_id + '-' + mas_workspace_id + '-' + pv.pvcName, 'mountPath': pv.mountPath}) %}
           {% endfor %}
           {{ mounts }}
         volumes: |
           {% set vols = [] %}
           {% for pv in manage_persistent_volumes %}
-          {% set _ = vols.append({'name': pv.pvcName, 'persistentVolumeClaim': {'claimName': pv.pvcName}}) %}
+          {% set _ = vols.append({'name': mas_instance_id + '-' + mas_workspace_id + '-' + pv.pvcName, 'persistentVolumeClaim': {'claimName': mas_instance_id + '-' + mas_workspace_id + '-' + pv.pvcName}}) %}
           {% endfor %}
           {{ vols }}
       register: dummy_pod_created

--- a/ibm/mas_devops/roles/suite_app_restore/tasks/manage/restore-single-pv.yml
+++ b/ibm/mas_devops/roles/suite_app_restore/tasks/manage/restore-single-pv.yml
@@ -7,7 +7,7 @@
 - name: "Set fact: PV restore details"
   set_fact:
     pv_mount_path: "{{ pv_item.mountPath }}"
-    pv_pvc_name: "{{ pv_item.pvcName }}"
+    pv_pvc_name: "{{ mas_instance_id }}-{{ mas_workspace_id }}-{{ pv_item.pvcName }}"
     pv_archive_name: "{{ pv_item.pvcName }}.tar.gz"
     pv_archive_path: "{{ manage_backup_path }}/data/{{ pv_item.pvcName }}.tar.gz"
 


### PR DESCRIPTION
## Description

During a Manage application restore, PVC names are now prefixed with
`{{ mas_instance_id }}-{{ mas_workspace_id }}-` to correctly reference
the scoped PVCs created by Manage operator (e.g. `inst1-ws1-manage-attachments`)
rather than using the bare `pvcName` from the backup manifest.

## Changes

- `restore-pv.yml`: Prefix PVC name with `mas_instance_id` and
  `mas_workspace_id` when creating the PVC, waiting for it, and when
  constructing the volume/volume_mount entries for the dummy pod.
- `restore-single-pv.yml`: Apply the same prefix when setting the
  `pv_pvc_name` fact used throughout the single-PV restore flow.

## Testing

- [x] Restore tested against a Manage instance with at least one PV
- [x] Dummy pod mounts correctly with prefixed volume/claim names
- [x] No regression on single-PV restore path

## Test Results
Restore flow created PVCs to restore - 

<img width="538" height="322" alt="Screenshot 2026-07-08 at 14 25 56" src="https://github.com/user-attachments/assets/592f937f-dbcd-4629-841d-b8aa5ed471c0" />
-------------------------------------------------------------------

PVs defined in ManageWorkspace

<img width="637" height="434" alt="Screenshot 2026-07-08 at 14 27 18" src="https://github.com/user-attachments/assets/00cbc827-394a-462d-95ec-1cbc151e3c29" />
-------------------------------------------------------------------


<img width="1003" height="692" alt="Screenshot 2026-07-08 at 14 29 26" src="https://github.com/user-attachments/assets/c5572c53-3ff3-4011-8acf-76c221d50353" />

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
