### PR TITLE
[patch]Fix undefined variable error in CIS edge certificate ordering

### DIFF
--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
@@ -123,4 +123,4 @@
     ibmcloud cis certificate-order {{ _cis_domain_id }} --hostnames {{ item|join(',') }} -i "{{ cis_service_name }}"
   loop: "{{ edge_cert_routes | batch(50) | list }}"
   when:
-    - not hasDedicated or _deleted_certificate["changed"]
+    - not hasDedicated or (_deleted_certificate is defined and _deleted_certificate["changed"])


### PR DESCRIPTION
Description
This PR fixes a bug in the suite_dns role where the DNS sync job fails with an undefined variable error when ordering CIS edge certificates.
