### PR TITLE
[patch]Fix undefined variable error in CIS edge certificate ordering

### DIFF
--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
@@ -123,4 +123,4 @@
     ibmcloud cis certificate-order {{ _cis_domain_id }} --hostnames {{ item|join(',') }} -i "{{ cis_service_name }}"
   loop: "{{ edge_cert_routes | batch(50) | list }}"
   when:
-    - not hasDedicated or _deleted_certificate["changed"]
+    - not hasDedicated or (_deleted_certificate is defined and _deleted_certificate["changed"])


### PR DESCRIPTION
Jira: https://jsw.ibm.com/browse/MASCORE-15410
Description:
- Fixed line 126 in cis_edge_certificate.yml
- Added check for _deleted_certificate variable existence before accessing it
- Prevents 'undefined variable' error when hasDedicated is false
- Error: '_deleted_certificate' is undefined when ordering certificates
