### PR TITLE
Added Rotate variable in the Mongo Role to rotate between mck and community

### DIFF
--- a/ibm/mas_devops/roles/mirror_extras_prepare/vars/mongomck_8.0.20.yml
+++ b/ibm/mas_devops/roles/mirror_extras_prepare/vars/mongomck_8.0.20.yml
@@ -1,0 +1,26 @@
+---
+extra_images:
+  - name: mongodb/mongodb-kubernetes
+    registry: quay.io
+    tag: 1.6.1
+    digest: sha256:22e4ae882cff477adc99cb74bc979cb112d9e0abf37509298a3839fea274ae75
+
+  - name: mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook
+    registry: quay.io
+    tag: 1.0.9
+    digest: sha256:71aa85ff8cc45c245fef869d6027db47d047d29eac3e5e2a5802e36ed5a97196 # 1.0.9-b20250811T000000Z
+
+  - name: mongodb/mongodb-agent
+    registry: quay.io
+    tag: 108.0.20.8953-1
+    digest: sha256:a5bfdb70127de39172931bfcb71627fda7d8960075a589c5cf4e587f985149c5 # 108.0.20.8953-1-olm-20260220154318
+
+  - name: mongodb/mongodb-kubernetes-readinessprobe
+    registry: quay.io
+    tag: 1.0.22
+    digest: sha256:a02a605c3e07b660650458034b059423c6dacf89f57b839fe78005d3ea547c30 # 1.0.22-b20250811T000000Z
+
+  - name: ibmmas/mongo
+    registry: quay.io
+    tag: 8.0.20-ubi8-20260425T063515Z
+    digest: sha256:ed3e3a2b8063dddac215aa191b6380260ba9f79b1cba6119cb67e797b7805f65 # quay.io/mongodb/mongodb-community-server:8.0.20-ubi8-20260425T063515Z

--- a/ibm/mas_devops/roles/mongodb/tasks/main.yml
+++ b/ibm/mas_devops/roles/mongodb/tasks/main.yml
@@ -15,7 +15,23 @@
       - mongodb_action in ["none", "install", "uninstall", "backup", "backup-database", "restore-database", "restore"]
     fail_msg: "mongodb_action property is required and must be one of 'install', 'uninstall', 'backup', 'backup-database','restore-database', 'restore', 'none'"
 
-# 2. Run the install / uninstall for specified provider
+# 2. Rotate mongo provider based on weekday
+# -----------------------------------------------------------------------------
+- name: "Select Mongo provider based on day of the week"
+  when: mongodb_provider == "rotate"
+  set_fact:
+    mongodb_provider: "{{ rotate_mongodb_provider[ansible_date_time['weekday']] }}"
+  vars:
+    rotate_mongodb_provider:
+      Monday: "community"
+      Tuesday: "mck"
+      Wednesday: "community"
+      Thursday: "mck"
+      Friday: "community"
+      Saturday: "mck"
+      Sunday: "community"
+
+# 3. Run the install / uninstall for specified provider
 # -----------------------------------------------------------------------------
 - include_tasks: "tasks/providers/{{ mongodb_provider }}/{{ mongodb_action }}.yml"
   when:


### PR DESCRIPTION

### Rotation Schedule:
- **Even weekday index** (starting from `Monday = 0`): `community`
- **Odd weekday index**: `mck`

| Day | Index | Provider |
|---|:---:|:---:|
| Monday | 0 | `community` |
| Tuesday | 1 | `mck` |
| Wednesday | 2 | `community` |
| Thursday | 3 | `mck` |
| Friday | 4 | `community` |
| Saturday | 5 | `mck` |
| Sunday | 6 | `community` |

---

## Changes
- **`ibm/mas_devops/roles/mongodb/tasks/main.yml`**: Added weekday-based provider evaluation when `mongodb_provider == "rotate"`.
- **`ibm/mas_devops/roles/mirror_extras_prepare/vars/mongomck_8.0.20.yml`**: Added extra image definitions for MCK version 8.0.20.
- **`ibm/mas_devops/roles/mirror_extras_prepare/vars/mongomck_8.0.29.yml`**: Added extra image definitions for MCK version 8.0.29.

---