### PR TITLE
[patch] AI Service - mising aiservice channel variable in aiservice_rhoai role

### DIFF
--- a/ibm/mas_devops/roles/aiservice_rhoai/defaults/main.yml
+++ b/ibm/mas_devops/roles/aiservice_rhoai/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-aiservice_channel: "{{ lookup('env', 'AISERVICE_TENANT_CHANNEL') | default(lookup('env', 'AISERVICE_CHANNEL'), true) }}"
+aiservice_channel: "{{ lookup('env', 'AISERVICE_CHANNEL') }}"
 
 # Action to perform (install or uninstall)
 rhoai_action: "{{ lookup('env', 'RHOAI_ACTION') | default('install', true) }}"

--- a/ibm/mas_devops/roles/aiservice_rhoai/defaults/main.yml
+++ b/ibm/mas_devops/roles/aiservice_rhoai/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+aiservice_channel: "{{ lookup('env', 'AISERVICE_TENANT_CHANNEL') | default(lookup('env', 'AISERVICE_CHANNEL'), true) }}"
+
 # Action to perform (install or uninstall)
 rhoai_action: "{{ lookup('env', 'RHOAI_ACTION') | default('install', true) }}"
 


### PR DESCRIPTION
## Description
There is an issue with aiservice_rhoai role - after last change for DSC we need to add `aiservice_channel`

```
TASK [ibm.mas_devops.aiservice_rhoai : Create Data Science Cluster] ************ [ERROR]: Task failed: AnsibleUndefinedVariable: 'aiservice_channel' is undefined Task failed. Origin: /opt/app-root/lib64/python3.12/site-packages/ansible_collections/ibm/mas_devops/roles/aiservice_rhoai/tasks/install/install-rhoai.yml:67:3 65 # 4. Create Data Science Cluster 66 # ----------------------------------------------------------------------------- 67 - name: 'Create Data Science Cluster' ^ column 3 <<< caused by >>> AnsibleUndefinedVariable: 'aiservice_channel' is undefined fatal: [localhost]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'aiservice_channel' is undefined"}
```

## Test Results
<img width="3132" height="2058" alt="Screenshot 2026-07-17 at 3 30 20 PM" src="https://github.com/user-attachments/assets/46294493-cd6c-443e-9420-f61914bc140c" />
<img width="3132" height="2058" alt="Screenshot 2026-07-17 at 3 30 20 PM" src="https://github.com/user-attachments/assets/46294493-cd6c-443e-9420-f61914bc140c" />


<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
