### PR TITLE
[patch] Update regex for reading MongoDB certificate file

### DIFF
--- a/ibm/mas_devops/roles/gencfg_mongo/tasks/main.yml
+++ b/ibm/mas_devops/roles/gencfg_mongo/tasks/main.yml
@@ -96,7 +96,7 @@
 - name: Read Mongo Certificate file
   when: mongodb_ca_pem_local_file | length > 0
   set_fact:
-    mongo_tls_crt: "{{ lookup('file', mongodb_ca_pem_local_file) | regex_findall('(-----BEGIN .+?-----(?s).+?-----END .+?-----)', multiline=True, ignorecase=True) }}"
+    mongo_tls_crt: "{{ lookup('file', mongodb_ca_pem_local_file) | regex_findall('(?s)(-----BEGIN .+?-----.*?-----END .+?-----)', multiline=True, ignorecase=True) }}"
   no_log: true
 
 # Load mongo_certs template to dynamically set as many mongo certificates as identified


### PR DESCRIPTION
Refine regex pattern for MongoDB TLS certificate extraction.

## Description
This is a proposed fix for https://github.com/ibm-mas/ansible-devops/issues/2386.

## Test Results
Before:
<img width="1018" height="609" alt="Screenshot 2026-07-27 at 5 17 12 PM" src="https://github.com/user-attachments/assets/45cf2bd5-034b-469c-a48a-60d65e930c81" />

After moving `(?s)`:
<img width="1018" height="369" alt="Screenshot 2026-07-27 at 5 16 28 PM" src="https://github.com/user-attachments/assets/428f5eca-106d-4001-8862-c859e8cb2ef6" />

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
