### PR TITLE
[patch] Increase wait timeout for rosa cluster to become ready

### DIFF
--- a/ibm/mas_devops/roles/ocp_provision/tasks/providers/rosa/provision_rosa.yml
+++ b/ibm/mas_devops/roles/ocp_provision/tasks/providers/rosa/provision_rosa.yml
@@ -72,7 +72,7 @@
     - (rosa_cluster_completion.stdout | from_json).api is defined
     - (rosa_cluster_completion.stdout | from_json).api.url is defined
     - (rosa_cluster_completion.stdout | from_json).api.url != ""
-  retries: 60
+  retries: 120
   delay: 60 # 1 minute
 
 - name: "rosa: Debug final cluster state"


### PR DESCRIPTION
## Description
One hour is not sufficient time for the ROSA cluster to become ready and hence need to increase it to 2 hours

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
