### PR TITLE
[patch] increase wait for elasticsearch-master to be created

### DIFF
--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-opensearch.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-opensearch.yml
@@ -8,7 +8,7 @@
     name: elasticsearch-master
     namespace: "{{ cpd_instance_namespace }}"
   register: opensearch_cr_lookup
-  retries: 30 # Up to 30 minutes
+  retries: 60 # Up to 30 minutes
   delay: 60 # Every 1 minute
   until:
     - opensearch_cr_lookup.resources is defined

--- a/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-opensearch.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/wait/wait-opensearch.yml
@@ -8,7 +8,7 @@
     name: elasticsearch-master
     namespace: "{{ cpd_instance_namespace }}"
   register: opensearch_cr_lookup
-  retries: 60 # Up to 30 minutes
+  retries: 60 # Up to 60 minutes
   delay: 60 # Every 1 minute
   until:
     - opensearch_cr_lookup.resources is defined


### PR DESCRIPTION
## Description
Based on a recent run the job including the call to wait-opensearch started at 6:12 and completed at 7:02 while the elasticsearch-master wasn't created until 7:15 manual rerun shows the task was able to find the elasticsearch-master and continue.

## Test Results
reran task manually to confirm it was a timing issue only

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
