### PR TITLE
[patch] Revert the change that configures servicesNamespace: ibm-cpd in the CPFS CommonService CR.

### DIFF
--- a/ibm/mas_devops/roles/cp4d/tasks/prereqs/install-cpfs.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/prereqs/install-cpfs.yml
@@ -145,10 +145,7 @@
     apply: yes
     definition:
       spec:
-        license:
-          accept: true
         size: "{{ cpfs_size }}"
-        servicesNamespace: "{{ cpd_instance_namespace }}"
   register: result
   retries: 5 # This can fail transiently if the common service webhook is not yet ready
   delay: 12


### PR DESCRIPTION
## Description

The servicesNamespace change was introduced based on an earlier finding that CPFS services, including IAM, needed to be deployed in the CPD instance namespace (ibm-cpd).
However, during validation with CPFS 4.13 / CPD 5.x, we found that this configuration is no longer valid for the current CPD 5.x architecture.
When servicesNamespace: ibm-cpd is configured, the CPFS admission webhook rejects the propagated CommonService configuration:
admission webhook denied the request:
Services Namespace: ibm-cpd is not allowed to be configured in namespace ibm-cpd
As a result, the CommonService remains in the Updating state and can block the CPD installation/upgrade flow.

**Impact**
For CPD 5.x, forcing servicesNamespace to ibm-cpd can cause CommonService reconciliation to fail and potentially block the installation or upgrade.
Reverting this change prevents our automation from overriding the CPFS-managed namespace configuration.


## Test Results

**Validation**
Validated with CPFS 4.13 / CPD 5.x that:
Configuring servicesNamespace: ibm-cpd triggers the CPFS admission webhook rejection.
The CommonService enters/remains in Updating when the invalid configuration is propagated.
Removing the forced servicesNamespace configuration allows CPFS to manage the namespace according to its expected topology.

**Follow-up**
If servicesNamespace: ibm-cpd is expected to be supported for CPD 5.x, this should be investigated with the CPFS team, particularly the admission webhook policy, rather than forcing the value from CPD automation.

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
