### PR TITLE
[patch] update timeouts for dro and grafana

### DIFF
--- a/ibm/mas_devops/roles/dro/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/dro/tasks/install/main.yml
@@ -210,7 +210,7 @@
     - rds_sts.resources[0].status is defined
     - rds_sts.resources[0].status.readyReplicas is defined
     - rds_sts.resources[0].status.readyReplicas == 3
-  retries: 40
+  retries: 60
   delay: 20 # seconds
 
 - name: "Wait for the ibm-data-reporter-operator-controller-manager to be ready"

--- a/ibm/mas_devops/roles/grafana/tasks/install/main.yml
+++ b/ibm/mas_devops/roles/grafana/tasks/install/main.yml
@@ -158,7 +158,7 @@
     - grafana_cr_result.resources[0].status.stageStatus is defined
     - grafana_cr_result.resources[0].status.stage == "complete"
     - grafana_cr_result.resources[0].status.stageStatus == "success"
-  retries: 10 # approx 50 minutes before we give up
+  retries: 15 # 15 minutes before we give up
   delay: 60 # 1 minute
   when: grafana_major_version == "5"
 
@@ -172,6 +172,6 @@
   until:
     - grafana_cr_result.resources[0].status.message is defined
     - grafana_cr_result.resources[0].status.message == "success"
-  retries: 10 # approx 50 minutes before we give up
+  retries: 15 # 15 minutes before we give up
   delay: 60 # 1 minute
   when: grafana_major_version == "4"


### PR DESCRIPTION
## Description
Increasing timeouts for grafana and dro in order to prevent fvt pipelines failures.

## Test Results
Simple timeout increase.

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
