### PR TITLE
[patch] move ClusterRole and ClusterBinding from MVI OLM to Ansible

### DIFF
--- a/ibm/mas_devops/playbooks/mas_add_visualinspection.yml
+++ b/ibm/mas_devops/playbooks/mas_add_visualinspection.yml
@@ -16,6 +16,9 @@
     # Application Configuration
     mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') | default('masdev', true) }}"
 
+    # ClusterRole setup flag for MVI RBAC pre-install step
+    mvi_setup_clusterrole: "{{ lookup('env', 'MVI_SETUP_CLUSTERROLE') | default('true', true) | bool }}"
+
     # Additional Condfiguration - Object Storage
     configure_cos: "{{ lookup('env', 'CONFIGURE_COS') | default('false', true) | bool }}"
     configure_cos_bucket: "{{ lookup('env', 'CONFIGURE_COS_BUCKET') | default('false', true) | bool }}"
@@ -79,6 +82,10 @@
       vars:
         cos_bucket_name: "{{ mas_app_settings_visualinspection_object_storage_workspace }}"
         aws_bucket_name: "{{ mas_app_settings_visualinspection_object_storage_workspace }}"
+
+    # Set up SCC ClusterRole and ClusterRoleBinding for MVI operator (~1 min)
+    - role: ibm.mas_devops.visualinspection_clusterrole
+      when: mvi_setup_clusterrole | bool
 
     # Install Nvidia Operator (~15 Minutes)
     - ibm.mas_devops.nvidia_gpu

--- a/ibm/mas_devops/playbooks/mas_add_visualinspection.yml
+++ b/ibm/mas_devops/playbooks/mas_add_visualinspection.yml
@@ -84,8 +84,9 @@
         aws_bucket_name: "{{ mas_app_settings_visualinspection_object_storage_workspace }}"
 
     # Set up SCC ClusterRole and ClusterRoleBinding for MVI operator (~1 min)
+    # Note: mvi_setup_clusterrole is intentionally not guarded here so that
+    # setting MVI_SETUP_CLUSTERROLE=false triggers the role's teardown tasks.
     - role: ibm.mas_devops.visualinspection_clusterrole
-      when: mvi_setup_clusterrole | bool
 
     # Install Nvidia Operator (~15 Minutes)
     - ibm.mas_devops.nvidia_gpu

--- a/ibm/mas_devops/roles/visualinspection_clusterrole/README.md
+++ b/ibm/mas_devops/roles/visualinspection_clusterrole/README.md
@@ -1,0 +1,99 @@
+# visualinspection_clusterrole
+This role creates the cluster-scoped RBAC resources required by the Maximo Visual Inspection (MVI) operator before it is installed via OLM. Specifically, it applies a `ClusterRole` that grants the MVI operator ServiceAccount permission to use the custom `ibm-mas-visualinspection-scc` SecurityContextConstraints and to list nodes and pods cluster-wide. It then binds that ClusterRole to the operator ServiceAccount via a `ClusterRoleBinding`.
+
+These resources are managed outside the OLM operator bundle (i.e. not in the CSV `clusterPermissions`) so that the operator subscription does not require elevated cluster-admin privileges at install time.
+
+## Prerequisites
+- OpenShift cluster with `oc` CLI access
+- Cluster administrator access (ClusterRole and ClusterRoleBinding are cluster-scoped resources)
+- The `ibm-mas-visualinspection-scc` SecurityContextConstraints must already exist on the cluster (applied by the MVI CASE bundle or a prior Ansible step)
+- `MAS_INSTANCE_ID` environment variable must be set
+
+## Role Variables
+
+### mas_instance_id
+The MAS instance identifier used to derive the MVI application namespace (`mas-<instance_id>-visualinspection`).
+
+- **Required**
+- Environment Variable: `MAS_INSTANCE_ID`
+- Default: None
+
+**Purpose**: Used to construct `mas_app_namespace`, which is the namespace where the MVI operator ServiceAccount lives and where the ClusterRoleBinding subject is scoped.
+
+**Valid values**: Lowercase alphanumeric string matching the MAS instance ID (e.g. `dev910a`, `prod1`)
+
+**Impact**: Determines which namespace's ServiceAccount is granted the ClusterRole. Each MAS instance gets its own ClusterRoleBinding pointing to its own namespace.
+
+---
+
+### mvi_setup_clusterrole
+Controls whether the ClusterRole and ClusterRoleBinding are created (`true`) or deleted (`false`).
+
+- **Optional**
+- Environment Variable: `MVI_SETUP_CLUSTERROLE`
+- Default: `true`
+
+**Purpose**: Acts as an on/off flag so the role can serve both install-time (create) and teardown (delete) pipelines without needing a separate role.
+
+**When to use**:
+- Leave as `true` (default) during installation — the RBAC resources will be created or updated idempotently.
+- Set to `false` in a post-uninstall pipeline to clean up the cluster-scoped resources that OLM does not manage.
+
+**Valid values**: `true` / `false`
+
+**Impact**:
+- `true` → applies `clusterrole.yml.j2` and `clusterrole_binding.yml.j2` to the cluster
+- `false` → deletes `ibm-mas-visualinspection-clusterrole` and `ibm-mas-visualinspection-clusterrolebinding` from the cluster
+
+**Notes**:
+- Because ClusterRole and ClusterRoleBinding are cluster-scoped, they are not automatically removed when a namespace or OLM subscription is deleted. This flag provides an explicit teardown path.
+- The default value of `true` means this role is safe to include unconditionally in install playbooks.
+
+---
+
+## Resources managed
+
+| Kind | Name |
+|---|---|
+| `ClusterRole` | `ibm-mas-visualinspection-clusterrole` |
+| `ClusterRoleBinding` | `ibm-mas-visualinspection-clusterrolebinding` |
+
+The ClusterRole grants:
+- `use` on `securitycontextconstraints/ibm-mas-visualinspection-scc`
+- `list` on `nodes` and `pods`
+
+The ClusterRoleBinding binds the ClusterRole to `system:serviceaccount:mas-<instance_id>-visualinspection:ibm-mas-visualinspection-operator`.
+
+---
+
+## Example Playbook
+After installing the Ansible Collection you can include this role in your own custom playbooks.
+
+```yaml
+- hosts: localhost
+  vars:
+    mas_instance_id: dev910a
+    mvi_setup_clusterrole: true
+  roles:
+    - ibm.mas_devops.visualinspection_clusterrole
+```
+
+## Run Role Playbook
+After installing the Ansible Collection you can easily run the role standalone using the `run_role` playbook provided.
+
+```bash
+export MAS_INSTANCE_ID=dev910a
+export MVI_SETUP_CLUSTERROLE=true
+ROLE_NAME=visualinspection_clusterrole ansible-playbook ibm.mas_devops.run_role
+```
+
+To tear down the RBAC resources after uninstalling MVI:
+
+```bash
+export MAS_INSTANCE_ID=dev910a
+export MVI_SETUP_CLUSTERROLE=false
+ROLE_NAME=visualinspection_clusterrole ansible-playbook ibm.mas_devops.run_role
+```
+
+## License
+EPL-2.0

--- a/ibm/mas_devops/roles/visualinspection_clusterrole/defaults/main.yml
+++ b/ibm/mas_devops/roles/visualinspection_clusterrole/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+
+# MAS instance and application
+mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
+mas_app_id: visualinspection
+
+# Flag to control whether the SCC ClusterRole and ClusterRoleBinding are created.
+# Set to false to skip RBAC setup (e.g. if a cluster admin pre-creates them).
+mvi_setup_clusterrole: "{{ lookup('env', 'MVI_SETUP_CLUSTERROLE') | default('true', true) | bool }}"

--- a/ibm/mas_devops/roles/visualinspection_clusterrole/meta/main.yml
+++ b/ibm/mas_devops/roles/visualinspection_clusterrole/meta/main.yml
@@ -1,0 +1,23 @@
+galaxy_info:
+  author: Dev Patidar
+  description: Set up SCC ClusterRole and ClusterRoleBinding for Maximo Visual Inspection
+  company: IBM
+
+  license: EPL-2.0
+
+  min_ansible_version: 2.10
+
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+
+  galaxy_tags:
+    - ibm
+    - mas
+    - devops
+    - visualinspection
+    - rbac
+
+dependencies:
+  - role: ibm.mas_devops.ansible_version_check

--- a/ibm/mas_devops/roles/visualinspection_clusterrole/tasks/main.yml
+++ b/ibm/mas_devops/roles/visualinspection_clusterrole/tasks/main.yml
@@ -1,0 +1,57 @@
+---
+
+# 1. Derive the MVI application namespace
+# -----------------------------------------------------------------------------
+- name: "Configure namespace"
+  set_fact:
+    mas_app_namespace: "mas-{{ mas_instance_id }}-{{ mas_app_id }}"
+
+- name: "Debug information"
+  debug:
+    msg:
+      - "Instance ID ................ {{ mas_instance_id }}"
+      - "Application ID ............. {{ mas_app_id }}"
+      - "MAS app namespace .......... {{ mas_app_namespace }}"
+      - "Setup ClusterRole .......... {{ mvi_setup_clusterrole }}"
+
+
+# 2. Apply SCC ClusterRole and ClusterRoleBinding
+# -----------------------------------------------------------------------------
+# These are cluster-scoped resources that grant the MVI operator ServiceAccount
+# permission to use the ibm-mas-visualinspection-scc before the operator starts
+# its first reconcile.  They are managed here (outside OLM) so the operator
+# bundle does not need clusterPermissions.
+
+- name: "Apply SCC ClusterRole for visualinspection"
+  when: mvi_setup_clusterrole | bool
+  kubernetes.core.k8s:
+    apply: yes
+    template: "templates/clusterrole.yml.j2"
+
+- name: "Apply SCC ClusterRoleBinding for visualinspection"
+  when: mvi_setup_clusterrole | bool
+  kubernetes.core.k8s:
+    apply: yes
+    template: "templates/clusterrole_binding.yml.j2"
+
+
+# 3. Clean up ClusterRole and ClusterRoleBinding on teardown
+# -----------------------------------------------------------------------------
+# These tasks only run when mvi_setup_clusterrole is false, which signals
+# the caller wants to remove the RBAC (e.g. post-uninstall pipeline).
+
+- name: "Delete SCC ClusterRoleBinding for visualinspection"
+  when: not (mvi_setup_clusterrole | bool)
+  kubernetes.core.k8s:
+    state: absent
+    api_version: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    name: ibm-mas-visualinspection-clusterrolebinding
+
+- name: "Delete SCC ClusterRole for visualinspection"
+  when: not (mvi_setup_clusterrole | bool)
+  kubernetes.core.k8s:
+    state: absent
+    api_version: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    name: ibm-mas-visualinspection-clusterrole

--- a/ibm/mas_devops/roles/visualinspection_clusterrole/tasks/main.yml
+++ b/ibm/mas_devops/roles/visualinspection_clusterrole/tasks/main.yml
@@ -6,6 +6,10 @@
   set_fact:
     mas_app_namespace: "mas-{{ mas_instance_id }}-{{ mas_app_id }}"
 
+- name: "Configure binding name"
+  set_fact:
+    mvi_clusterrolebinding_name: "ibm-mas-visualinspection-{{ mas_instance_id }}-clusterrolebinding"
+
 - name: "Debug information"
   debug:
     msg:
@@ -13,6 +17,7 @@
       - "Application ID ............. {{ mas_app_id }}"
       - "MAS app namespace .......... {{ mas_app_namespace }}"
       - "Setup ClusterRole .......... {{ mvi_setup_clusterrole }}"
+      - "ClusterRoleBinding name .... {{ mvi_clusterrolebinding_name }}"
 
 
 # 2. Apply SCC ClusterRole and ClusterRoleBinding
@@ -46,7 +51,7 @@
     state: absent
     api_version: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
-    name: ibm-mas-visualinspection-clusterrolebinding
+    name: "{{ mvi_clusterrolebinding_name }}"
 
 - name: "Delete SCC ClusterRole for visualinspection"
   when: not (mvi_setup_clusterrole | bool)

--- a/ibm/mas_devops/roles/visualinspection_clusterrole/tasks/main.yml
+++ b/ibm/mas_devops/roles/visualinspection_clusterrole/tasks/main.yml
@@ -6,10 +6,6 @@
   set_fact:
     mas_app_namespace: "mas-{{ mas_instance_id }}-{{ mas_app_id }}"
 
-- name: "Configure binding name"
-  set_fact:
-    mvi_clusterrolebinding_name: "ibm-mas-visualinspection-{{ mas_instance_id }}-clusterrolebinding"
-
 - name: "Debug information"
   debug:
     msg:
@@ -17,7 +13,6 @@
       - "Application ID ............. {{ mas_app_id }}"
       - "MAS app namespace .......... {{ mas_app_namespace }}"
       - "Setup ClusterRole .......... {{ mvi_setup_clusterrole }}"
-      - "ClusterRoleBinding name .... {{ mvi_clusterrolebinding_name }}"
 
 
 # 2. Apply SCC ClusterRole and ClusterRoleBinding
@@ -51,7 +46,7 @@
     state: absent
     api_version: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
-    name: "{{ mvi_clusterrolebinding_name }}"
+    name: ibm-mas-visualinspection-clusterrolebinding
 
 - name: "Delete SCC ClusterRole for visualinspection"
   when: not (mvi_setup_clusterrole | bool)

--- a/ibm/mas_devops/roles/visualinspection_clusterrole/templates/clusterrole.yml.j2
+++ b/ibm/mas_devops/roles/visualinspection_clusterrole/templates/clusterrole.yml.j2
@@ -1,0 +1,32 @@
+---
+# (C) Copyright IBM Corp. 2024  All Rights Reserved.
+#
+# Grants the MVI operator ServiceAccount the 'use' verb on the
+# ibm-mas-visualinspection-scc SecurityContextConstraints resource,
+# and cluster-wide list access on nodes and pods.
+# Applied as a pre-install step before the operator subscription so
+# that workload pods can run under the custom SCC from the first reconcile.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ibm-mas-visualinspection-clusterrole
+  labels:
+    app.kubernetes.io/instance: ibm-mas-visualinspection
+    app.kubernetes.io/managed-by: ibm.mas_devops.visualinspection_clusterrole
+    app.kubernetes.io/name: ibm-mas-visualinspection
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  resourceNames:
+  - ibm-mas-visualinspection-scc
+  verbs:
+  - use
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - pods
+  verbs:
+  - list

--- a/ibm/mas_devops/roles/visualinspection_clusterrole/templates/clusterrole_binding.yml.j2
+++ b/ibm/mas_devops/roles/visualinspection_clusterrole/templates/clusterrole_binding.yml.j2
@@ -1,0 +1,21 @@
+---
+# (C) Copyright IBM Corp. 2024  All Rights Reserved.
+#
+# Binds ibm-mas-visualinspection-clusterrole to the MVI operator
+# ServiceAccount in the target namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ibm-mas-visualinspection-clusterrolebinding
+  labels:
+    app.kubernetes.io/instance: ibm-mas-visualinspection
+    app.kubernetes.io/managed-by: ibm.mas_devops.visualinspection_clusterrole
+    app.kubernetes.io/name: ibm-mas-visualinspection
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ibm-mas-visualinspection-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: ibm-mas-visualinspection-operator
+  namespace: {{ mas_app_namespace }}

--- a/ibm/mas_devops/roles/visualinspection_clusterrole/templates/clusterrole_binding.yml.j2
+++ b/ibm/mas_devops/roles/visualinspection_clusterrole/templates/clusterrole_binding.yml.j2
@@ -6,7 +6,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ibm-mas-visualinspection-clusterrolebinding
+  name: "ibm-mas-visualinspection-{{ mas_instance_id }}-clusterrolebinding"
   labels:
     app.kubernetes.io/instance: ibm-mas-visualinspection
     app.kubernetes.io/managed-by: ibm.mas_devops.visualinspection_clusterrole

--- a/ibm/mas_devops/roles/visualinspection_clusterrole/templates/clusterrole_binding.yml.j2
+++ b/ibm/mas_devops/roles/visualinspection_clusterrole/templates/clusterrole_binding.yml.j2
@@ -18,4 +18,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: ibm-mas-visualinspection-operator
-  namespace: {{ mas_app_namespace }}
+  namespace: "{{ mas_app_namespace }}"

--- a/ibm/mas_devops/roles/visualinspection_clusterrole/templates/clusterrole_binding.yml.j2
+++ b/ibm/mas_devops/roles/visualinspection_clusterrole/templates/clusterrole_binding.yml.j2
@@ -6,7 +6,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: "ibm-mas-visualinspection-{{ mas_instance_id }}-clusterrolebinding"
+  name: ibm-mas-visualinspection-clusterrolebinding
   labels:
     app.kubernetes.io/instance: ibm-mas-visualinspection
     app.kubernetes.io/managed-by: ibm.mas_devops.visualinspection_clusterrole


### PR DESCRIPTION
add Clusterrole for MVI

## Description
Move clusterrole and cluster_binding from mvi to ansible. 

https://jsw.ibm.com/browse/MASMVI-3430
## Test Results
Ran`playbooks/mas_add_visualinspection.yml` for `visualinspection_clusterrole`

<img width="1283" height="597" alt="Screenshot 2026-08-13 at 2 43 15 PM" src="https://github.com/user-attachments/assets/3b75f7be-d7c9-4ae0-94ba-77c7d0544129" />


Clusterrole and Clusterbinding are successfully created on fips cluster after successfully ran playbook.
<img width="1430" height="645" alt="Screenshot 2026-08-13 at 2 56 25 PM" src="https://github.com/user-attachments/assets/b09ccf29-3e9a-47ba-bf0f-3870ec49b2e4" />
<img width="1429" height="642" alt="Screenshot 2026-08-13 at 2 56 32 PM" src="https://github.com/user-attachments/assets/d2436408-2388-4f52-896e-4d124c7d7742" />



On `dev910a` instance

<img width="1500" height="597" alt="Screenshot 2026-08-19 at 7 19 34 PM" src="https://github.com/user-attachments/assets/5ccdc76d-5354-4858-bf4c-fba545695836" />

<img width="1492" height="704" alt="Screenshot 2026-08-19 at 7 20 44 PM" src="https://github.com/user-attachments/assets/9c49af27-5d2d-47ef-8597-d0dcdc26ebc3" />


removed `clusterPermissions` from csv to avoid OLM owns the ClusterRole and ClusterRoleBinding 


<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
