### PR TITLE
[patch] Fix MinIO listen address to work on non-IPv6 clusters

### DIFF
--- a/ibm/mas_devops/roles/minio/templates/minio/minio-deployment.yml.j2
+++ b/ibm/mas_devops/roles/minio/templates/minio/minio-deployment.yml.j2
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         app: "{{ minio_instance_name }}"
+        tag: "{{ minio_image_tag }}"
     spec:
       volumes:
         - name: storage
@@ -20,17 +21,20 @@ spec:
       containers:
         - name: "{{ minio_instance_name }}"
           image: "{{ minio_image_registry }}/{{ minio_image_name}}@{{ minio_image_digest}}"
-          metadata:
-            labels:
-              tag: "{{ minio_image_tag }}"
           command: ["minio"]
           args:
             - server
             - /data
             - --console-address
+{% if ocp_enable_ipv6 %}
             - "[::]:9090"
             - --address
             - "[::]:9000"
+{% else %}
+            - ":9090"
+            - --address
+            - ":9000"
+{% endif %}
           env:
             - name: MINIO_ROOT_USER
               value: "{{ minio_root_user }}"


### PR DESCRIPTION
## Description

MinIO was unconditionally using `[::]:9090` and `[::]:9000` as listen addresses, causing the route to fail on pure IPv4 clusters even though the pod was `1/1 Running`.

Updated the deployment to use `:9090` and `:9000` by default, which works on both IPv4 and IPv6 clusters. `[::]` is used only when `ocp_enable_ipv6=true`.

Also fixed the invalid `metadata` field in the container spec.

## Changes

* Use `:9090` and `:9000` by default.
* Use `[::]` only when `ocp_enable_ipv6=true`.
* Move the `tag` label to `spec.template.metadata.labels`.

## Test Results

### IPv4 Cluster

* MinIO pod: `1/1 Running`
* Route returned HTTP 200 and console loaded successfully.
* S3 connectivity verified from the aibroker pod. 

<img width="1716" height="670" alt="Screenshot 2026-08-13 at 3 56 45 PM" src="https://github.com/user-attachments/assets/47db3e62-7038-4ecf-afad-23e7ac03a510" />
<img width="1279" height="768" alt="Screenshot 2026-08-13 at 3 57 01 PM" src="https://github.com/user-attachments/assets/ec1bac48-64b3-4b7f-8269-81c130fb8284" />
<img width="1416" height="324" alt="Screenshot 2026-08-13 at 3 57 16 PM" src="https://github.com/user-attachments/assets/4cd55c88-a812-49e6-a206-052f81e43ae4" />
<img width="1267" height="528" alt="Screenshot 2026-08-13 at 3 58 26 PM" src="https://github.com/user-attachments/assets/f1bf8b41-70ed-41ee-b41e-0373184e421f" />


### IPv6 Cluster

* `ocp_enable_ipv6=true` continues to use `[::]:9090` and `[::]:9000`. 
