### PR TITLE
[patch] - add facilities archive include variables and filters to dow…

### DIFF
--- a/ibm/mas_devops/roles/download_backup_archive/README.md
+++ b/ibm/mas_devops/roles/download_backup_archive/README.md
@@ -216,6 +216,24 @@ Whether to download Manage DB2 archive (`-db2u-manage.tar.gz`) from S3 or Artifa
 - Environment Variable: `INCLUDE_MANAGE_DB_ARCHIVE`
 - Default Value: `true`
 
+#### include_facilities_app_archive
+Whether to download Facilities app archive (`-app-facilities.tar.gz`) from S3 or Artifactory.
+
+**Important:** When set to `false`, the role will automatically skip downloading facilities app archive (`-app-facilities.tar.gz`) from S3 or Artifactory. This prevents unnecessary downloads when facilities component restore is not needed.
+
+- **Optional**
+- Environment Variable: `INCLUDE_FACILITIES_APP_ARCHIVE`
+- Default Value: `true`
+
+#### include_facilities_db_archive
+Whether to download Facilities DB2 archive (`-db2u-facilities.tar.gz`) from S3 or Artifactory.
+
+**Important:** When set to `false`, the role will automatically skip downloading facilities DB2 archive (`-db2u-facilities.tar.gz`) from S3 or Artifactory. This prevents unnecessary downloads when facilities component restore is not needed.
+
+- **Optional**
+- Environment Variable: `INCLUDE_FACILITIES_DB_ARCHIVE`
+- Default Value: `true`
+
 ## Example Playbook
 
 ### Download Multiple Archives from S3 (Auto-generated names)

--- a/ibm/mas_devops/roles/download_backup_archive/defaults/main.yml
+++ b/ibm/mas_devops/roles/download_backup_archive/defaults/main.yml
@@ -47,3 +47,5 @@ include_sls_archive: "{{ lookup('env', 'INCLUDE_SLS_ARCHIVE') | default(true, tr
 include_mongo_archive: "{{ lookup('env', 'INCLUDE_MONGO_ARCHIVE') | default(true, true) }}"
 include_manage_app_archive: "{{ lookup('env', 'INCLUDE_MANAGE_APP_ARCHIVE') | default(true, true) }}"
 include_manage_db_archive: "{{ lookup('env', 'INCLUDE_MANAGE_DB_ARCHIVE') | default(true, true) }}"
+include_facilities_app_archive: "{{ lookup('env', 'INCLUDE_FACILITIES_APP_ARCHIVE') | default(true, true) }}"
+include_facilities_db_archive: "{{ lookup('env', 'INCLUDE_FACILITIES_DB_ARCHIVE') | default(true, true) }}"

--- a/ibm/mas_devops/roles/download_backup_archive/tasks/main.yml
+++ b/ibm/mas_devops/roles/download_backup_archive/tasks/main.yml
@@ -74,6 +74,16 @@
     backup_archives_to_download: "{{ backup_archives_to_download | reject('search', '-db2u-manage\\.tar\\.gz$') | list }}"
   when: not (include_manage_db_archive | bool)
 
+- name: "Filter out facilities app archive when include_facilities_app_archive is false"
+  ansible.builtin.set_fact:
+    backup_archives_to_download: "{{ backup_archives_to_download | reject('search', '-app-facilities\\.tar\\.gz$') | list }}"
+  when: not (include_facilities_app_archive | bool)
+
+- name: "Filter out facilities db archive when include_facilities_db_archive is false"
+  ansible.builtin.set_fact:
+    backup_archives_to_download: "{{ backup_archives_to_download | reject('search', '-db2u-facilities\\.tar\\.gz$') | list }}"
+  when: not (include_facilities_db_archive | bool)
+
 - name: "Display archives to download"
   ansible.builtin.debug:
     msg:


### PR DESCRIPTION
## Description
Add facilities-specific archive include toggles to [`download_backup_archive`](ibm/mas_devops/roles/download_backup_archive/tasks/main.yml:1) so facilities archives can be excluded from download the same way other component archives already can.

This change adds two new role variables:
- [`include_facilities_app_archive`](ibm/mas_devops/roles/download_backup_archive/defaults/main.yml:50)
- [`include_facilities_db_archive`](ibm/mas_devops/roles/download_backup_archive/defaults/main.yml:51)

When either variable is set to `false`, the role filters the corresponding facilities archive from the auto-generated download list:
- `-app-facilities.tar.gz`
- `-db2u-facilities.tar.gz`

The default behavior is unchanged because both new variables default to `true`. Existing playbooks and callers continue to download facilities archives unless they explicitly opt out.

The role README was also updated to document the two new variables in [`ibm/mas_devops/roles/download_backup_archive/README.md`](ibm/mas_devops/roles/download_backup_archive/README.md).

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->
Before the change, there is no variable to stop facilities applications and db archive from being downloaded. If the archives were included in the backup, the role with fail. 
<img width="1657" height="200" alt="image" src="https://github.com/user-attachments/assets/90d6fd38-9af1-4c0e-9988-270bd5c5e9e7" />

After the change, running with
`INCLUDE_FACILITIES_APP_ARCHIVE=false`
`INCLUDE_FACILITIES_DB_ARCHIVE=false`
`ansible-playbook ibm/mas_devops/dev-download-backup-archive.yml`

<img width="1221" height="310" alt="image" src="https://github.com/user-attachments/assets/9bb52605-4943-47dd-ac0f-861c2bf173d9" />
The two archives are filtered and the right number of archives are downloaded. 

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
