### PR TITLE
[patch] Remove channel-specific rawDeploymentServiceConfig condition

### DIFF
--- a/ibm/mas_devops/roles/aiservice_rhoai/templates/rhoai/data-science-cluster.yml.j2
+++ b/ibm/mas_devops/roles/aiservice_rhoai/templates/rhoai/data-science-cluster.yml.j2
@@ -25,8 +25,4 @@ spec:
 {% else %}
         managementState: Managed
 {% endif %}
-{% if aiservice_channel.startswith("9.1.") %}
-      rawDeploymentServiceConfig: Headless
-{% else %}
       rawDeploymentServiceConfig: Headed
-{% endif %}


### PR DESCRIPTION
## Description
Always use Headed rawDeploymentServiceConfig in DataScienceCluster template for all AIService versions.

## Test result

9.1 env:
<img width="1053" height="936" alt="Screenshot 2026-08-20 at 2 02 24 PM" src="https://github.com/user-attachments/assets/9659f252-c3ab-43f3-b2ea-b7e8e4d4679b" />

9.2 env:
<img width="1464" height="942" alt="Screenshot 2026-08-20 at 1 03 29 PM" src="https://github.com/user-attachments/assets/85ad1bcd-206c-4d34-9cd8-54c4dd11daf6" />