### PR TITLE
[patch] OCP 4.22 changes in ansible devops- #2419

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ It is possible to develop the Ansible roles without needing to build the collect
   vars:
     cluster_type: rosa
     cluster_name: fvtrosa
-    ocp_version: "4.21.3"
+    ocp_version: "4.22.8"
 
   roles:
     - ocp_provision

--- a/docs/execution-environment.md
+++ b/docs/execution-environment.md
@@ -225,7 +225,7 @@ If you need to set an environment variable then you can do this in the playbook 
   vars:
     cluster_name: testcluster
     cluster_type: rosa
-    ocp_version: 4.21.3
+    ocp_version: 4.22.8
     rosa_compute_nodes: 3
 
   environment:

--- a/docs/playbooks/ocp.md
+++ b/docs/playbooks/ocp.md
@@ -16,7 +16,7 @@ export AWS_SECRET_ACCESS_KEY=xxx
 export ROSA_TOKEN=xxx
 
 export CLUSTER_NAME=masonrosa
-export OCP_VERSION=4.21
+export OCP_VERSION=4.22
 export ROSA_COMPUTE_NODES=5
 export ROSA_CLUSTER_ADMIN_PASSWORD=xxx
 ansible-playbook ibm.mas_devops.ocp_rosa_provision
@@ -44,7 +44,7 @@ This playbook will provision a QuickBurn OCP cluster in IBM DevIT Fyre service, 
 
 ```bash
 export CLUSTER_NAME=masinst1
-export OCP_VERSION=4.21
+export OCP_VERSION=4.22
 export FYRE_USERNAME=xxx
 export FYRE_APIKEY=xxx
 export FYRE_PRODUCT_ID=xxx

--- a/ibm/mas_devops/playbooks/ocp_convert_to_disconnected.yml
+++ b/ibm/mas_devops/playbooks/ocp_convert_to_disconnected.yml
@@ -5,7 +5,7 @@
   vars:
     ocp_operatorhub_disable_redhat_sources: true
 
-    ocp_release: "{{ lookup('env', 'OCP_RELEASE') | default('4.21', true) }}"
+    ocp_release: "{{ lookup('env', 'OCP_RELEASE') | default('4.22', true) }}"
     setup_redhat_release: true
     setup_redhat_catalogs: true
 

--- a/ibm/mas_devops/playbooks/ocp_fyre_provision.yml
+++ b/ibm/mas_devops/playbooks/ocp_fyre_provision.yml
@@ -2,7 +2,7 @@
 - hosts: localhost
   vars:
     cluster_type: fyre
-    ocp_version: "{{ lookup('env', 'OCP_VERSION') | default('4.21', True) }}"
+    ocp_version: "{{ lookup('env', 'OCP_VERSION') | default('4.22', True) }}"
 
     # Supported providers: nfs, odf, longhorn
     ocp_storage_provider: "{{ lookup('env', 'OCP_STORAGE_PROVIDER') }}"

--- a/ibm/mas_devops/playbooks/ocp_rosa_provision.yml
+++ b/ibm/mas_devops/playbooks/ocp_rosa_provision.yml
@@ -2,7 +2,7 @@
 - hosts: localhost
   vars:
     cluster_type: rosa
-    ocp_version: "{{ lookup('env', 'OCP_VERSION') | default('4.21.3', True) }}"
+    ocp_version: "{{ lookup('env', 'OCP_VERSION') | default('4.22.8', True) }}"
 
     # We use "turbonomic_target_name" as a key to indicate that we want to run the turbonomic role
     turbonomic_target_name: "{{ lookup('env', 'TURBONOMIC_TARGET_NAME') }}"

--- a/ibm/mas_devops/roles/mirror_ocp/README.md
+++ b/ibm/mas_devops/roles/mirror_ocp/README.md
@@ -187,7 +187,7 @@ Path to Red Hat pull secret file.
 
 ## Role Variables - OpenShift Version
 ### ocp_release
-The Red Hat release you are mirroring content for, e.g. `4.21`.
+The Red Hat release you are mirroring content for, e.g. `4.22`.
 
 - **Required**
 - Environment Variable: `OCP_RELEASE`
@@ -198,9 +198,9 @@ The Red Hat release you are mirroring content for, e.g. `4.21`.
 **When to use**:
 - Always required for Red Hat content mirroring
 - Must match the OpenShift version in your target environment
-- Use format: `4.21`, `4.20`, `4.19`, `4.18`, `4.17`
+- Use format: `4.22`, `4.21`, `4.20`, `4.19`, `4.18`, `4.17`
 
-**Valid values**: OpenShift major.minor version (e.g., `4.21`, `4.20`, `4.19`, `4.18`, `4.17`, `4.16`)
+**Valid values**: OpenShift major.minor version (e.g., `4.22`, `4.21`, `4.20`, `4.19`, `4.18`, `4.17`, `4.16`)
 
 **Impact**: Determines which OpenShift version's images and operators are mirrored. Must match your target cluster version.
 
@@ -209,10 +209,10 @@ The Red Hat release you are mirroring content for, e.g. `4.21`.
 - `ocp_max_version`: Maximum patch version to mirror
 - `mirror_redhat_platform`: Whether to mirror platform images for this version
 
-**Note**: Use the major.minor version format (e.g., `4.21`), not full version (e.g., `4.21.21`). Use `ocp_min_version` and `ocp_max_version` to control patch version range.
+**Note**: Use the major.minor version format (e.g., `4.22`), not full version (e.g., `4.22.2`). Use `ocp_min_version` and `ocp_max_version` to control patch version range.
 
 ### ocp_min_version
-The minimum version of the Red Hat release to mirror platform content for, e.g. `4.21.21`.
+The minimum version of the Red Hat release to mirror platform content for, e.g. `4.22.2`.
 
 - **Optional**
 - Environment Variable: `OCP_MIN_VERSION`
@@ -237,7 +237,7 @@ The minimum version of the Red Hat release to mirror platform content for, e.g. 
 **Note**: Only affects platform image mirroring, not operators. Use to limit mirror size when you know the specific OpenShift versions you need.
 
 ### ocp_max_version
-The maximimum version of the Red Hat release to mirror platform content for, e.g. `4.21.21`.
+The maximimum version of the Red Hat release to mirror platform content for, e.g. `4.22.2`.
 
 - **Optional**
 - Environment Variable: `OCP_MAX_VERSION`
@@ -447,7 +447,7 @@ Password for target registry authentication.
     mirror_redhat_platform: false
     mirror_redhat_operators: true
 
-    ocp_release: 4.21
+    ocp_release: 4.22
     redhat_pullsecret: ~/pull-secret.json
 
   roles:

--- a/ibm/mas_devops/roles/mirror_ocp/tasks/actions/direct.yml
+++ b/ibm/mas_devops/roles/mirror_ocp/tasks/actions/direct.yml
@@ -66,9 +66,10 @@
 - name: "Debug Information"
   debug:
     msg:
-      - "Command ...................... DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-tls-verify=false --remove-signatures -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml docker://{{ registry_public_url_with_path_redhat }} --workspace file://{{ mirror_working_dir }}/.ibm-mas --v2"
+      - "Command ...................... DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-tls-verify=false {{ mirror_redhat_operators | default(false) | bool | ternary('--remove-signatures', '') }} -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml docker://{{ registry_public_url_with_path_redhat }} --workspace file://{{ mirror_working_dir }}/.ibm-mas --v2"
       - "Log File ..................... {{ mirror_working_dir }}/logs/mirror-direct-ocp{{ ocp_release }}.log"
 
 - name: "Mirror Red Hat content from source registry to target registry"
   shell: >
-    DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-tls-verify=false --remove-signatures -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml docker://{{ registry_public_url_with_path_redhat }} --workspace file://{{ mirror_working_dir }}/.ibm-mas --v2 &> {{ mirror_working_dir }}/logs/mirror-direct-ocp{{ ocp_release }}.log
+    DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-tls-verify=false {{ mirror_redhat_operators | default(false) | bool | ternary('--remove-signatures', '') }} -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml docker://{{ registry_public_url_with_path_redhat }} --workspace file://{{ mirror_working_dir }}/.ibm-mas --v2 &> {{ mirror_working_dir }}/logs/mirror-direct-ocp{{ ocp_release }}.log
+    

--- a/ibm/mas_devops/roles/mirror_ocp/tasks/actions/direct.yml
+++ b/ibm/mas_devops/roles/mirror_ocp/tasks/actions/direct.yml
@@ -72,4 +72,3 @@
 - name: "Mirror Red Hat content from source registry to target registry"
   shell: >
     DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-tls-verify=false {{ mirror_redhat_operators | default(false) | bool | ternary('--remove-signatures', '') }} -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml docker://{{ registry_public_url_with_path_redhat }} --workspace file://{{ mirror_working_dir }}/.ibm-mas --v2 &> {{ mirror_working_dir }}/logs/mirror-direct-ocp{{ ocp_release }}.log
-    

--- a/ibm/mas_devops/roles/mirror_ocp/tasks/actions/from-filesystem.yml
+++ b/ibm/mas_devops/roles/mirror_ocp/tasks/actions/from-filesystem.yml
@@ -58,9 +58,9 @@
 - name: "Debug Information"
   debug:
     msg:
-      - "Command ...................... DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --remove-signatures -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml --dest-tls-verify=false --parallel-images=1 --from file://{{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }}"
+      - "Command ...................... DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-tls-verify=false {{ mirror_redhat_operators | default(false) | bool | ternary('--remove-signatures', '') }} -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml docker://{{ registry_public_url_with_path_redhat }} --workspace file://{{ mirror_working_dir }}/.ibm-mas --v2"
       - "Log File ..................... {{ mirror_working_dir }}/logs/mirror-from-filesystem-ocp{{ ocp_release }}.log"
 
 - name: "Mirror Red Hat content from filesystem to target registry"
   shell: >
-    DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --remove-signatures -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml --dest-tls-verify=false --parallel-images=1 --from file://{{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }} --v2 &> {{ mirror_working_dir }}/logs/mirror-from-filesystem-ocp{{ ocp_release }}.log
+    DOCKER_CONFIG={{ mirror_working_dir }} oc mirror {{ mirror_redhat_operators | default(false) | bool | ternary('--remove-signatures', '') }} -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml --dest-tls-verify=false --parallel-images=1 --from file://{{ mirror_working_dir }}/mirror_seq1_000000.tar docker://{{ registry_public_url_with_path_redhat }} --v2 &> {{ mirror_working_dir }}/logs/mirror-from-filesystem-ocp{{ ocp_release }}.log

--- a/ibm/mas_devops/roles/mirror_ocp/tasks/actions/to-filesystem.yml
+++ b/ibm/mas_devops/roles/mirror_ocp/tasks/actions/to-filesystem.yml
@@ -19,11 +19,11 @@
 - name: "Debug Information"
   debug:
     msg:
-      - "Command ...................... DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --remove-signatures -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml file:///{{ mirror_working_dir }} --v2"
+      - "Command ...................... DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --dest-tls-verify=false {{ mirror_redhat_operators | default(false) | bool | ternary('--remove-signatures', '') }} -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml docker://{{ registry_public_url_with_path_redhat }} --workspace file://{{ mirror_working_dir }}/.ibm-mas --v2"
       - "Log File ..................... {{ mirror_working_dir }}/logs/mirror-to-filesystem-ocp{{ ocp_release }}.log"
 
 - name: "Mirror Red Hat content from source registry to filesystem"
 # Important: We have added "--remove-signatures" temporarily due to a problem in the Red Hat Certified operator catalog
 # This is the only way we can get image mirroring working.  We will remove this as soon as Red Hat fix the operator catalog
   shell: >
-    DOCKER_CONFIG={{ mirror_working_dir }} oc mirror --remove-signatures -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml file:///{{ mirror_working_dir }} --v2 &> {{ mirror_working_dir }}/logs/mirror-to-filesystem-ocp{{ ocp_release }}.log
+    DOCKER_CONFIG={{ mirror_working_dir }} oc mirror {{ mirror_redhat_operators | default(false) | bool | ternary('--remove-signatures', '') }} -c {{ mirror_working_dir }}/imageset-ocp{{ ocp_release }}.yml file:///{{ mirror_working_dir }} --v2 &> {{ mirror_working_dir }}/logs/mirror-to-filesystem-ocp{{ ocp_release }}.log

--- a/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
+++ b/ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
@@ -143,6 +143,11 @@ mirror:
           channels:
             - name: stable-{{ ocp_release }}
 {% endif %}
+{% if ocp_release >= "4.22" %}
+        - name: ocs-tls-profiles
+          channels:
+            - name: stable-{{ ocp_release }}
+{% endif %}
 
         # Optional Packages - AI Service (RHOAI)
         # ---------------------------------------------------------------------

--- a/ibm/mas_devops/roles/ocp_provision/README.md
+++ b/ibm/mas_devops/roles/ocp_provision/README.md
@@ -71,12 +71,12 @@ OpenShift version to install.
 
 **When to use**:
 - Always required for cluster provisioning
-- Use specific version for production (e.g., `4.21.21`)
+- Use specific version for production (e.g., `4.22.2`)
 - Use `default` for latest MAS-supported version
 - Use `rotate` for testing (version changes by day of week)
 
 **Valid values**: 
-- Specific version: `4.21`, `4.21.21`
+- Specific version: `4.22`, `4.22.2`
 - Alias: `default` (newest MAS-supported version)
 - Alias: `rotate` (predetermined version by day, for testing)
 - **ROKS format**: Must append `_openshift` (e.g., `4.21_openshift`, `4.21.21_openshift`)


### PR DESCRIPTION
Description
Adding OCP 4.22 changes in ansible-devops
[MASCORE-15266](https://jsw.ibm.com/browse/MASCORE-15266)

Files changed
CONTRIBUTING.md
docs/execution-environment.md
docs/playbooks/ocp.md
ibm/mas_devops/playbooks/ocp_convert_to_disconnected.yml
ibm/mas_devops/playbooks/ocp_fyre_provision.yml
ibm/mas_devops/playbooks/ocp_rosa_provision.yml
ibm/mas_devops/roles/mirror_ocp/README.md
ibm/mas_devops/roles/mirror_ocp/tasks/actions/direct.yml
ibm/mas_devops/roles/mirror_ocp/tasks/actions/from-filesystem.yml
ibm/mas_devops/roles/mirror_ocp/tasks/actions/to-filesystem.yml
ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
ibm/mas_devops/roles/ocp_provision/README.md
ibm/mas_devops/roles/ocp_provision/defaults/main.yml

OCP 4.22 changes are made only on fyre and AWS.
OCP 4.22 is not yet released on IBM CLoud (ROKS) hence default version of ROKS will continue with 4.21.

Modified
ibm/mas_devops/roles/mirror_ocp/tasks/actions/direct.yml
ibm/mas_devops/roles/mirror_ocp/tasks/actions/from-filesystem.yml
ibm/mas_devops/roles/mirror_ocp/tasks/actions/to-filesystem.yml
To resolved issue 1 mentioned in [MASCORE-16779](https://jsw.ibm.com/browse/MASCORE-16779)
Failed to pull image "quay.io/openshift-release-dev/ocp-v4.0-art-`dev@sha256:1753eea6d07579de9b83e210dccec20d6e1f203a9a9c2f3bcfd83435c84a6a7f": SignatureValidationFailed: unable to pull image or OCI artifact: pull image err: Source image rejected: A signature was required, but no signature exists; artifact err: image reference: reference is a container image, not an OCI artifact`

Modified
ibm/mas_devops/roles/mirror_ocp/templates/imagesetconfiguration.yml.j2
To resolve issue 3 in [MASCORE-16779](https://jsw.ibm.com/browse/MASCORE-16779)
`constraints not satisfiable: bundle odf-dependencies.v4.22.2-rhodf requires an operator with package: ocs-tls-profiles and with version in range: 4.22.2-rhodf, subscription odf-dependencies exists, subscription odf-dependencies requires redhat-operator-index/openshift-marketplace/stable-4.22/odf-dependencies.v4.22.2-rhodf`