### PR TITLE
[patch] reverting ocp default version to 4.21

### DIFF
--- a/ibm/mas_devops/roles/ocp_provision/defaults/main.yml
+++ b/ibm/mas_devops/roles/ocp_provision/defaults/main.yml
@@ -7,7 +7,7 @@ cluster_platform: "{{lookup('env', 'CLUSTER_PLATFORM') | default('x',true)}}"
 
 ocp_version: "{{ lookup('env', 'OCP_VERSION') }}"
 ocp_fips_enabled: "{{ lookup('env', 'OCP_FIPS_ENABLED') | default('false', true) | bool }}"
-default_ocp_version: 4.22
+default_ocp_version: 4.21
 
 supported_cluster_types:
   - fyre


### PR DESCRIPTION
Reverting OCP default version to 4.21 since OCP 4.22 is not yet released in IBM Cloud
