### PR TITLE
[patch] WSL terminating PVC Issue Fix

### DIFF
--- a/ibm/mas_devops/roles/cp4d/tasks/wait/wait-zenmetastore-edb.yml
+++ b/ibm/mas_devops/roles/cp4d/tasks/wait/wait-zenmetastore-edb.yml
@@ -40,8 +40,6 @@
   until:
     - commonservices_operators_output.resources is defined
     - commonservices_operators_output.resources | length > 0
-    - commonservices_operators_output.resources[0].status.overallStatus is defined
-    - commonservices_operators_output.resources[0].status.overallStatus == "Succeeded"
     - commonservices_operators_output.resources[0].status.phase is defined
     - commonservices_operators_output.resources[0].status.phase == "Succeeded"
   retries: 60 # approx 30 minutes

--- a/ibm/mas_devops/roles/cp4d_service/tasks/helm/cleanup-olm-resources.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/helm/cleanup-olm-resources.yml
@@ -103,8 +103,12 @@
   debug:
     msg: "No existing OLM installation detected, proceeding with Helm installation"
 
-# Delete component CRs so Helm can recreate them with correct version
-# Only deletes CRs explicitly listed in component_cr_mapping
+# Delete component CRs so Helm can adopt them during OLM→Helm migration.
+# Only deletes CRs explicitly listed in component_cr_mapping.
+# NOTE: After deletion, helm upgrade --install is a no-op (changed: false)
+# because Helm's stored release manifest still tracks the CR but does not
+# reapply missing resources on upgrade. The missing CRs are reconciled by
+# a separate reapply task in install-helm.yml after Helm runs.
 - name: "Delete component CRs for {{ component_name }}"
   when: component_name in component_cr_mapping
   block:
@@ -139,6 +143,7 @@
           {%- endfor -%}
           {{ result }}
 
+
     - name: "Remove ownerReferences from PVCs owned by {{ component_name }} CRs"
       kubernetes.core.k8s:
         state: patched
@@ -150,23 +155,6 @@
           metadata:
             ownerReferences: []
       loop: "{{ component_owned_pvcs }}"
-      loop_control:
-        loop_var: pvc_item
-        label: "{{ pvc_item.metadata.name }}"
-      failed_when: false
-
-    # Rescue PVCs already stuck in deletion — remove finalizers via patch
-    - name: "Remove finalizers from PVCs stuck in deletion"
-      kubernetes.core.k8s:
-        state: patched
-        api_version: v1
-        kind: PersistentVolumeClaim
-        name: "{{ pvc_item.metadata.name }}"
-        namespace: "{{ cpd_instance_namespace }}"
-        definition:
-          metadata:
-            finalizers: []
-      loop: "{{ all_pvcs_info.resources | default([]) | selectattr('metadata.deletionTimestamp', 'defined') | list }}"
       loop_control:
         loop_var: pvc_item
         label: "{{ pvc_item.metadata.name }}"
@@ -232,4 +220,102 @@
       loop_control:
         loop_var: cr_subelement
         label: "{{ cr_subelement[1].metadata.name }}"
+      failed_when: false
+
+    # Re-fetch PVCs after CR deletion — the CR deletion above triggers Kubernetes to set
+    # deletionTimestamp on owned PVCs (cascade delete). We must re-fetch here to see the
+    # current state; the snapshot taken before CR deletion shows no deletionTimestamp.
+    - name: "Re-fetch PVCs after CR deletion to detect cascade-deleted {{ component_name }} PVCs"
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: PersistentVolumeClaim
+        namespace: "{{ cpd_instance_namespace }}"
+      register: all_pvcs_post_delete
+      failed_when: false
+
+    - name: "Identify {{ component_name }} PVCs now stuck in Terminating after CR deletion"
+      set_fact:
+        component_terminating_pvcs: >-
+          {%- set result = [] -%}
+          {%- for pvc in all_pvcs_post_delete.resources | default([]) -%}
+            {%- if pvc.metadata.deletionTimestamp is defined -%}
+              {%- for owned in component_owned_pvcs -%}
+                {%- if owned.metadata.name == pvc.metadata.name -%}
+                  {%- if pvc not in result -%}{%- set _ = result.append(pvc) -%}{%- endif -%}
+                {%- endif -%}
+              {%- endfor -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {{ result }}
+
+    # Scale down zen-core-api 'volumes-*' deployments holding the now-terminating PVCs.
+    # These deployments hold the pvc-protection finalizer, blocking PVC termination.
+    # Must run AFTER CR deletion so deletionTimestamp is set on the PVCs.
+    - name: "Find zen-core-api volumes-* deployments in {{ cpd_instance_namespace }}"
+      kubernetes.core.k8s_info:
+        api_version: apps/v1
+        kind: Deployment
+        namespace: "{{ cpd_instance_namespace }}"
+        label_selectors:
+          - "app.kubernetes.io/managed-by=zen-core-api"
+          - "icpdsupport/app=volumes"
+      register: zen_volumes_deployments
+      failed_when: false
+
+    - name: "Scale down zen-core-api volumes-* deployments holding terminating {{ component_name }} PVCs"
+      vars:
+        # PVC naming: <name>-pvc → zen-core-api deploy app label: volumes-<name>
+        terminating_deploy_labels: "{{ component_terminating_pvcs | map(attribute='metadata.name') | map('regex_replace', '-pvc$', '') | map('regex_replace', '^(.+)$', 'volumes-\\1') | list }}"
+      kubernetes.core.k8s:
+        state: patched
+        api_version: apps/v1
+        kind: Deployment
+        name: "{{ deploy_item.metadata.name }}"
+        namespace: "{{ cpd_instance_namespace }}"
+        definition:
+          spec:
+            replicas: 0
+      loop: "{{ zen_volumes_deployments.resources | default([]) | selectattr('metadata.labels.app', 'defined') | selectattr('metadata.labels.app', 'in', terminating_deploy_labels) | list }}"
+      loop_control:
+        loop_var: deploy_item
+        label: "{{ deploy_item.metadata.name }}"
+      when: component_terminating_pvcs | length > 0
+      failed_when: false
+
+    - name: "Wait for scaled-down volumes-* pods to terminate (up to 2 minutes)"
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Pod
+        namespace: "{{ cpd_instance_namespace }}"
+        label_selectors:
+          - "app.kubernetes.io/managed-by=zen-core-api"
+          - "icpdsupport/app=volumes"
+          - "app in ({{ terminating_deploy_labels | join(',') }})"
+      register: volumes_pods_check
+      vars:
+        terminating_deploy_labels: "{{ component_terminating_pvcs | map(attribute='metadata.name') | map('regex_replace', '-pvc$', '') | map('regex_replace', '^(.+)$', 'volumes-\\1') | list }}"
+      retries: 12
+      delay: 10
+      until: volumes_pods_check.resources | default([]) | length == 0
+      when: component_terminating_pvcs | length > 0
+      failed_when: false
+
+    # Rescue this component's PVCs stuck in Terminating — remove pvc-protection finalizer.
+    # Safe: scoped to component_terminating_pvcs (this component's PVCs only).
+    # Guaranteed to work: zen-core-api pod is already terminated by the scale-down above.
+    - name: "Remove pvc-protection finalizer from {{ component_name }} PVCs stuck in Terminating"
+      kubernetes.core.k8s:
+        state: patched
+        api_version: v1
+        kind: PersistentVolumeClaim
+        name: "{{ pvc_item.metadata.name }}"
+        namespace: "{{ cpd_instance_namespace }}"
+        definition:
+          metadata:
+            finalizers: []
+      loop: "{{ component_terminating_pvcs }}"
+      loop_control:
+        loop_var: pvc_item
+        label: "{{ pvc_item.metadata.name }}"
+      when: component_terminating_pvcs | length > 0
       failed_when: false

--- a/ibm/mas_devops/roles/cp4d_service/tasks/helm/install-component.yml
+++ b/ibm/mas_devops/roles/cp4d_service/tasks/helm/install-component.yml
@@ -153,6 +153,16 @@
   delay: 60
   until: ns_install is not failed
 
+# Airgap: write helm_values to a temp file so special characters in values
+# (storage class names, secret names, etc.) are handled safely by YAML parsing
+# rather than shell string splitting that --set flags are subject to.
+- name: "Write Helm values to temp file (airgap)"
+  when: cpd_helm_airgap
+  copy:
+    content: "{{ helm_values | to_nice_yaml }}"
+    dest: "/tmp/{{ component_name }}-helm-values.yaml"
+    mode: "0600"
+
 - name: "Install/Upgrade {{ component_name }} namespace-scoped chart with Helm (airgap)"
   when: cpd_helm_airgap
   command: >
@@ -169,7 +179,13 @@
   changed_when: "'has been upgraded' in ns_install.stdout or 'has been installed' in ns_install.stdout"
   retries: 10
   delay: 60
-  until: ns_install.rc == 0
+  until: ns_install is not failed
+
+- name: "Remove Helm values temp file (airgap)"
+  when: cpd_helm_airgap
+  file:
+    path: "/tmp/{{ component_name }}-helm-values.yaml"
+    state: absent
 
 - name: "{{ component_name }} Helm charts installed"
   debug:
@@ -178,3 +194,40 @@
       - "✓ Namespace-scoped chart installed via Helm"
       - "✓ CRD established: {{ comp_crd_name }}"
       - "✓ CR will be created automatically by Helm"
+
+# During OLM→Helm migration cleanup deletes the component CR so Helm can adopt it.
+# However helm upgrade --install is a no-op when chart/values are unchanged, so
+# it does not reapply the now-missing CR from its stored manifest.
+# Check for each CR entry in component_cr_mapping and force Helm to reapply if missing.
+- name: "Check {{ cr_entry.kind }} CR after Helm install (OLM→Helm migration)"
+  when: component_name in (component_cr_mapping | default({}))
+  kubernetes.core.k8s_info:
+    api_version: "{{ cr_entry.api_version }}"
+    kind: "{{ cr_entry.kind }}"
+    namespace: "{{ cpd_instance_namespace }}"
+    name: "{{ cr_entry.name if cr_entry.name != 'all' else omit }}"
+  register: dep_cr_existence_check
+  loop: "{{ component_cr_mapping[component_name] | default([]) }}"
+  loop_control:
+    loop_var: cr_entry
+    label: "{{ cr_entry.kind }}/{{ cr_entry.name }}"
+  failed_when: false
+
+- name: "Force Helm to reapply when {{ component_name }} CRs are missing (OLM→Helm migration)"
+  when:
+    - component_name in (component_cr_mapping | default({}))
+    - dep_cr_existence_check.results | default([]) | map(attribute='resources') | flatten | length == 0
+  command: >
+    helm upgrade {{ component_name | replace('_', '-') }}
+    {{ cpd_helm_repo_name if not cpd_helm_airgap else cpd_airgap_helm_repo_url }}/{{ comp_chart_name }}
+    --version {{ chart_version }}
+    --namespace {{ cpd_instance_namespace }}
+    --reuse-values
+    --force
+    --wait
+    --timeout {{ cpd_helm_timeout }}
+  register: helm_dep_force_reapply
+  retries: 3
+  delay: 30
+  until: helm_dep_force_reapply.rc == 0
+  failed_when: false


### PR DESCRIPTION
## Description
<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->

During WSL upgrade (5.2→5.3.1), ws-runtimes-libs-pvc gets stuck Terminating because a zen-core-api-managed deployment independently mounts it and holds the pvc-protection finalizer; the fix explicitly scales that deployment to 0 and waits for its pod to exit before patching the finalizer, making the PVC deletion deterministic instead of a race condition.

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->

<img width="1728" height="1117" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/0944d0b4-611b-4acb-b953-81fac609f1e2" />

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
