### PR TITLE
[patch] Revert manage pod-templates changes

### DIFF
--- a/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/main.yml
@@ -3,6 +3,7 @@
 # ------------------------------------------------------------------------
 - name: "Manage pre-config : Pod Templates"
   include_tasks: "tasks/manage/pre-config/setup-pod-templates.yml"
+  when: is_full_manage
 
 
 # 2. Components

--- a/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/setup-pod-templates.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/setup-pod-templates.yml
@@ -1,13 +1,5 @@
 ---
-- name: "Load podTemplates configuration (foundation mode)"
-  when: not is_full_manage
-  include_tasks: "{{ role_path }}/../../common_tasks/pod_templates/main.yml"
-  vars:
-    config_files:
-      - "ibm-mas-manage-manageworkspace.yml"
-
-- name: "Load podTemplates configuration (non-foundation mode)"
-  when: is_full_manage
+- name: "Load podTemplates configuration"
   include_tasks: "{{ role_path }}/../../common_tasks/pod_templates/main.yml"
   vars:
     config_files:
@@ -18,14 +10,13 @@
 
 # This will filter out and get selected serverbundle podTemplates from all available serverbundle podTemplates list
 # Final list of podTemplates added to manageworkspace CR under spec section
-# In foundation mode: active bundles = [] so only always-present pods (monitoragent, manage-maxinst etc.) pass through
-# In non-foundation mode: active bundles = deployed server bundle names for the chosen bundle size
 # ====================================================================
-- name: Set manage workspace server bundle data
+- name: Set manage workspace components and server bundle object
   set_fact:
-    manageServerBundleData: "{{ is_full_manage | ternary(mas_app_settings_server_bundles[mas_app_settings_server_bundles_size]['serverBundles'], []) }}"
+    manageWorkspaceComponents: "{{ mas_appws_components | to_json | from_json }}"
+    manageServerBundleData: "{{ mas_app_settings_server_bundles[mas_app_settings_server_bundles_size]['serverBundles'] }}"
 
-- name: Get available server bundle names
+- name: Get available server bundle name
   set_fact:
     manageAvailableServerBundle: "{{ manageServerBundleData | json_query(serverBundleQuery) }}"
   vars:
@@ -33,11 +24,11 @@
 
 - name: Merge manage workspace podTemplates containers
   set_fact:
-    manageWSAvailablePodTemplatesContainers: "{{ manageAvailableServerBundle + manage_workspace_default_podTemplates_containers }}"
+    manageWSAvailablePodTemplatesContainers: "{{ manageAvailableServerBundle + manage_workspace_default_podTemplates_containers}}"
 
 - name: Filter podTemplates from manage workspace available podTemplates containers
   set_fact:
-    ibm_mas_manage_manageworkspace_pod_templates: "{{ ibm_mas_manage_manageworkspace_pod_templates | selectattr('name', 'in', manageWSAvailablePodTemplatesContainers) | list }}"
+    ibm_mas_manage_manageworkspace_pod_templates: "{{ ibm_mas_manage_manageworkspace_pod_templates | selectattr('name' , 'in' , manageWSAvailablePodTemplatesContainers) | list }}"
   when:
     - ibm_mas_manage_manageworkspace_pod_templates is defined
     - manageWSAvailablePodTemplatesContainers is defined

--- a/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
@@ -245,4 +245,4 @@ mas_app_settings_customization_credentials:
 
 # Pod Templates
 # -----------------------------------------------------------------------------
-manage_workspace_default_podTemplates_containers: ['monitoragent', 'manage-maxinst', 'mcp']
+manage_workspace_default_podTemplates_containers: ['monitoragent', 'manage-maxinst']


### PR DESCRIPTION
## Description
`manageWorkspaceComponents` was removed causing manage to be always installed in foundation mode. Hence, reverting the changes for now.

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
