### PR TITLE
[patch] fix manage workspace pod templates not being applied in foundation mode

### DIFF
--- a/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/main.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/main.yml
@@ -3,7 +3,6 @@
 # ------------------------------------------------------------------------
 - name: "Manage pre-config : Pod Templates"
   include_tasks: "tasks/manage/pre-config/setup-pod-templates.yml"
-  when: is_full_manage
 
 
 # 2. Components

--- a/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/setup-pod-templates.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/setup-pod-templates.yml
@@ -21,6 +21,11 @@
 # In foundation mode: active bundles = [] so only always-present pods (monitoragent, manage-maxinst etc.) pass through
 # In non-foundation mode: active bundles = deployed server bundle names for the chosen bundle size
 # ====================================================================
+- name: Set manage workspace components (non-foundation mode)
+  when: is_full_manage
+  set_fact:
+    manageWorkspaceComponents: "{{ mas_appws_components | to_json | from_json }}"
+
 - name: Set manage workspace server bundle data
   set_fact:
     manageServerBundleData: "{{ is_full_manage | ternary(mas_app_settings_server_bundles[mas_app_settings_server_bundles_size]['serverBundles'], []) }}"

--- a/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/setup-pod-templates.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/setup-pod-templates.yml
@@ -1,5 +1,13 @@
 ---
-- name: "Load podTemplates configuration"
+- name: "Load podTemplates configuration (foundation mode)"
+  when: not is_full_manage
+  include_tasks: "{{ role_path }}/../../common_tasks/pod_templates/main.yml"
+  vars:
+    config_files:
+      - "ibm-mas-manage-manageworkspace.yml"
+
+- name: "Load podTemplates configuration (non-foundation mode)"
+  when: is_full_manage
   include_tasks: "{{ role_path }}/../../common_tasks/pod_templates/main.yml"
   vars:
     config_files:
@@ -10,25 +18,29 @@
 
 # This will filter out and get selected serverbundle podTemplates from all available serverbundle podTemplates list
 # Final list of podTemplates added to manageworkspace CR under spec section
+# Only required in non-foundation mode where server bundles are deployed
 # ====================================================================
-- name: Set manage workspace components and server bundle object
-  set_fact:
-    manageWorkspaceComponents: "{{ mas_appws_components | to_json | from_json }}"
-    manageServerBundleData: "{{ mas_app_settings_server_bundles[mas_app_settings_server_bundles_size]['serverBundles'] }}"
+- name: Filter manageworkspace podTemplates to active server bundles
+  when: is_full_manage
+  block:
+    - name: Set manage workspace components and server bundle object
+      set_fact:
+        manageWorkspaceComponents: "{{ mas_appws_components | to_json | from_json }}"
+        manageServerBundleData: "{{ mas_app_settings_server_bundles[mas_app_settings_server_bundles_size]['serverBundles'] }}"
 
-- name: Get available server bundle name
-  set_fact:
-    manageAvailableServerBundle: "{{ manageServerBundleData | json_query(serverBundleQuery) }}"
-  vars:
-    serverBundleQuery: "[*].name"
+    - name: Get available server bundle name
+      set_fact:
+        manageAvailableServerBundle: "{{ manageServerBundleData | json_query(serverBundleQuery) }}"
+      vars:
+        serverBundleQuery: "[*].name"
 
-- name: Merge manage workspace podTemplates containers
-  set_fact:
-    manageWSAvailablePodTemplatesContainers: "{{ manageAvailableServerBundle + manage_workspace_default_podTemplates_containers}}"
+    - name: Merge manage workspace podTemplates containers
+      set_fact:
+        manageWSAvailablePodTemplatesContainers: "{{ manageAvailableServerBundle + manage_workspace_default_podTemplates_containers}}"
 
-- name: Filter podTemplates from manage workspace available podTemplates containers
-  set_fact:
-    ibm_mas_manage_manageworkspace_pod_templates: "{{ ibm_mas_manage_manageworkspace_pod_templates | selectattr('name' , 'in' , manageWSAvailablePodTemplatesContainers) | list }}"
-  when:
-    - ibm_mas_manage_manageworkspace_pod_templates is defined
-    - manageWSAvailablePodTemplatesContainers is defined
+    - name: Filter podTemplates from manage workspace available podTemplates containers
+      set_fact:
+        ibm_mas_manage_manageworkspace_pod_templates: "{{ ibm_mas_manage_manageworkspace_pod_templates | selectattr('name' , 'in' , manageWSAvailablePodTemplatesContainers) | list }}"
+      when:
+        - ibm_mas_manage_manageworkspace_pod_templates is defined
+        - manageWSAvailablePodTemplatesContainers is defined

--- a/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/setup-pod-templates.yml
+++ b/ibm/mas_devops/roles/suite_app_config/tasks/manage/pre-config/setup-pod-templates.yml
@@ -18,29 +18,26 @@
 
 # This will filter out and get selected serverbundle podTemplates from all available serverbundle podTemplates list
 # Final list of podTemplates added to manageworkspace CR under spec section
-# Only required in non-foundation mode where server bundles are deployed
+# In foundation mode: active bundles = [] so only always-present pods (monitoragent, manage-maxinst etc.) pass through
+# In non-foundation mode: active bundles = deployed server bundle names for the chosen bundle size
 # ====================================================================
-- name: Filter manageworkspace podTemplates to active server bundles
-  when: is_full_manage
-  block:
-    - name: Set manage workspace components and server bundle object
-      set_fact:
-        manageWorkspaceComponents: "{{ mas_appws_components | to_json | from_json }}"
-        manageServerBundleData: "{{ mas_app_settings_server_bundles[mas_app_settings_server_bundles_size]['serverBundles'] }}"
+- name: Set manage workspace server bundle data
+  set_fact:
+    manageServerBundleData: "{{ is_full_manage | ternary(mas_app_settings_server_bundles[mas_app_settings_server_bundles_size]['serverBundles'], []) }}"
 
-    - name: Get available server bundle name
-      set_fact:
-        manageAvailableServerBundle: "{{ manageServerBundleData | json_query(serverBundleQuery) }}"
-      vars:
-        serverBundleQuery: "[*].name"
+- name: Get available server bundle names
+  set_fact:
+    manageAvailableServerBundle: "{{ manageServerBundleData | json_query(serverBundleQuery) }}"
+  vars:
+    serverBundleQuery: "[*].name"
 
-    - name: Merge manage workspace podTemplates containers
-      set_fact:
-        manageWSAvailablePodTemplatesContainers: "{{ manageAvailableServerBundle + manage_workspace_default_podTemplates_containers}}"
+- name: Merge manage workspace podTemplates containers
+  set_fact:
+    manageWSAvailablePodTemplatesContainers: "{{ manageAvailableServerBundle + manage_workspace_default_podTemplates_containers }}"
 
-    - name: Filter podTemplates from manage workspace available podTemplates containers
-      set_fact:
-        ibm_mas_manage_manageworkspace_pod_templates: "{{ ibm_mas_manage_manageworkspace_pod_templates | selectattr('name' , 'in' , manageWSAvailablePodTemplatesContainers) | list }}"
-      when:
-        - ibm_mas_manage_manageworkspace_pod_templates is defined
-        - manageWSAvailablePodTemplatesContainers is defined
+- name: Filter podTemplates from manage workspace available podTemplates containers
+  set_fact:
+    ibm_mas_manage_manageworkspace_pod_templates: "{{ ibm_mas_manage_manageworkspace_pod_templates | selectattr('name', 'in', manageWSAvailablePodTemplatesContainers) | list }}"
+  when:
+    - ibm_mas_manage_manageworkspace_pod_templates is defined
+    - manageWSAvailablePodTemplatesContainers is defined

--- a/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
+++ b/ibm/mas_devops/roles/suite_app_config/vars/manage.yml
@@ -245,4 +245,4 @@ mas_app_settings_customization_credentials:
 
 # Pod Templates
 # -----------------------------------------------------------------------------
-manage_workspace_default_podTemplates_containers: ['monitoragent', 'manage-maxinst']
+manage_workspace_default_podTemplates_containers: ['monitoragent', 'manage-maxinst', 'mcp']


### PR DESCRIPTION
## Description
Currently, manageworkspace podTemplates are not being applied in foundation mode. Hence, modified the ansible tasks to apply the non bundle podTemplates for foundation mode.
Added mcp to the list of pods for manage where podTemplates is supported.

## Test Results
Tested in a cluster by running the `suite_app_config` role.
foundation mode generated template using FVT podTemplates:
```
spec:
  bindings:
    jdbc: workspace-application
  components: {}
  podTemplates:
    - affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
              - matchExpressions:
                  - key: kubernetes.io/arch
                    operator: In
                    values:
                      - amd64
                      - s390x
                      - ppc64le
      containers:
        - name: monitoragent
          resources:
            limits:
              cpu: 251m
              memory: 351Mi
            requests:
              cpu: 101m
              memory: 255Mi
      name: monitoragent
    - affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
              - matchExpressions:
                  - key: kubernetes.io/arch
                    operator: In
                    values:
                      - amd64
                      - s390x
                      - ppc64le
      containers:
        - name: manage-maxinst-maxinst
          resources:
            limits:
              cpu: 2.1
              memory: 4Gi
            requests:
              cpu: 0.6
              memory: 550Mi
      name: manage-maxinst
      replicas: 1
  settings:
    aio:
      install: true
    customizationList: []
    db:
      dbSchema: maximo
      maxinst:
        bypassUpgradeVersionCheck: false
        db2Vargraphic: true
        demodata: false
        indexSpace: MAXINDEX
        tableSpace: MAXDATA
      upgrade:
        upgradeType: regularUpgrade
    deployment:
      buildTag: latest
      defaultJMS: false
      ephemeralVolumes: []
      mode: up
      persistentVolumes: []
      serverBundles: []
      serverTimezone: GMT
    languages:
      baseLang: EN
      secondaryLangs: []
    skipImageBuild: false
```


non-foundation mode generated spec using FVT podTemplates:
```
spec:
  bindings:
    jdbc: workspace-application
  components:
    base:
      version: latest
    strategize:
      version: latest
  podTemplates:
    - affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
              - matchExpressions:
                  - key: kubernetes.io/arch
                    operator: In
                    values:
                      - amd64
                      - s390x
                      - ppc64le
      containers:
        - name: monitoragent
          resources:
            limits:
              cpu: 251m
              memory: 351Mi
            requests:
              cpu: 101m
              memory: 255Mi
      name: monitoragent
    - affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
              - matchExpressions:
                  - key: kubernetes.io/arch
                    operator: In
                    values:
                      - amd64
                      - s390x
                      - ppc64le
      containers:
        - name: manage-maxinst-maxinst
          resources:
            limits:
              cpu: 2.1
              memory: 4Gi
            requests:
              cpu: 0.6
              memory: 550Mi
      name: manage-maxinst
      replicas: 1
    - affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
              - matchExpressions:
                  - key: kubernetes.io/arch
                    operator: In
                    values:
                      - amd64
                      - s390x
                      - ppc64le
      containers:
        - name: all
          resources:
            limits:
              cpu: 6
              memory: 10Gi
            requests:
              cpu: 0.5
              memory: 2Gi
        - name: monitoragent
          resources:
            limits:
              cpu: 1
              memory: 512Mi
            requests:
              cpu: 0.1
              memory: 256Mi
      name: all
  settings:
    aio:
      install: true
    customizationList: []
    db:
      dbSchema: maximo
      maxinst:
        bypassUpgradeVersionCheck: false
        db2Vargraphic: true
        demodata: false
        indexSpace: MAXINDEX
        tableSpace: MAXDATA
      upgrade:
        upgradeType: regularUpgrade
    deployment:
      buildTag: latest
      defaultJMS: false
      ephemeralVolumes: []
      mode: up
      persistentVolumes: []
      serverBundles:
        - bundleType: all
          isDefault: true
          isMobileTarget: true
          isUserSyncTarget: true
          name: all
          replica: 1
          routeSubDomain: all
      serverTimezone: GMT
    languages:
      baseLang: EN
      secondaryLangs: []
    skipImageBuild: false
```

FVT run in non-foundation mode:
https://dashboard.ibmmas.com/tests/hrtest
<img width="409" height="352" alt="Screenshot 2026-08-31 at 16 55 51" src="https://github.com/user-attachments/assets/c8515b22-419d-4241-9d5e-620884ad911f" />

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
