### PR TITLE
[patch] Increase restore-namespace retries to 30

### DIFF
--- a/ibm/mas_devops/roles/suite_app_restore/tasks/facilities/restore-namespace.yml
+++ b/ibm/mas_devops/roles/suite_app_restore/tasks/facilities/restore-namespace.yml
@@ -282,7 +282,7 @@
     name: "{{ mas_instance_id }}"
     namespace: "{{ mas_app_namespace }}"
   register: facilities_app_cr
-  retries: 15
+  retries: 30
   delay: 60
   until:
     - facilities_app_cr.resources is defined

--- a/ibm/mas_devops/roles/suite_app_restore/tasks/manage/restore-namespace.yml
+++ b/ibm/mas_devops/roles/suite_app_restore/tasks/manage/restore-namespace.yml
@@ -307,7 +307,7 @@
     name: "{{ mas_instance_id }}"
     namespace: "{{ mas_app_namespace }}"
   register: manage_app_cr
-  retries: 15
+  retries: 30
   delay: 60
   until:
     - manage_app_cr.resources is defined
@@ -384,7 +384,7 @@
         name: "{{ manage_workspace_cr_name }}"
         namespace: "{{ mas_app_namespace }}"
       register: workspace_status
-      retries: 15
+      retries: 30
       delay: 60
       until:
         - workspace_status.resources is defined


### PR DESCRIPTION
## Description
<!-- Provide a summary of the changes. Focus on why the changes are being made and the impact of the changes. -->

A customer complained that their ManageWorkspace CR was taking longer to scale down than what we have defined and as a result could not complete the restore process

```yaml
[ERROR]: Task failed: Action failed: Unknown error.
Origin: /opt/app-root/lib64/python3.12/site-packages/ansible_collections/ibm/mas_devops/roles/suite_app_restore/tasks/manage/restore-namespace.yml:349:7
347    when: current_mode != 'down'
348
349   - name: "Wait for ManageWorkspace to scale down"
     ^ column 7
fatal: [localhost]: FAILED! => {"api_found": true, "attempts": 15, "changed": false, "msg": "Task failed: Action failed: Unknown error.", "resources": [{"apiVersion": "[apps.mas.ibm.com/v1](https://apps.mas.ibm.com/v1)", "kind": "ManageWorkspace", "metadata": {"annotations": {"[kubectl.kubernetes.io/last-applied-configuration](https://kubectl.kubernetes.io/last-applied-configuration)": "{\"apiVersion\":\"apps.mas.ibm.com/v1\",\"kind\":\"ManageWorkspace\",\"metadata\":{\"labels\":................
```

## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. -->
No testing needed as I just increased the retries from 15 to 30 (minutes)
<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
