### PR TITLE
[patch] Fix IPv6 boolean evaluation in MinIO deployment template

### DIFF
--- a/ibm/mas_devops/roles/minio/templates/minio/minio-deployment.yml.j2
+++ b/ibm/mas_devops/roles/minio/templates/minio/minio-deployment.yml.j2
@@ -26,7 +26,7 @@ spec:
             - server
             - /data
             - --console-address
-{% if ocp_enable_ipv6 %}
+{% if ocp_enable_ipv6 is defined and ocp_enable_ipv6 | bool %}
             - "[::]:9090"
             - --address
             - "[::]:9000"


### PR DESCRIPTION
## Description

Fixes the boolean evaluation for `ocp_enable_ipv6` in the MinIO deployment Jinja template (`minio-deployment.yml.j2`).

### Problem
Previously, the template used `{% if ocp_enable_ipv6 %}`. In Jinja2 / Python, if `ocp_enable_ipv6` is passed as a string (such as `"false"` or `"False"` from unparsed CLI args or environment variables), non-empty strings evaluate to truthy (`bool("false") == True`). This caused MinIO to bind to IPv6 addresses (`[::]:9090` and `[::]:9000`) instead of fallback default dual-stack / IPv4 wildcard addresses (`:9090` and `:9000`) on non-IPv6 clusters.

### Test result
- ipv4 cluster:
<img width="967" height="685" alt="Screenshot 2026-09-02 at 4 10 42 PM" src="https://github.com/user-attachments/assets/d0efe84b-e2ba-4000-9d3e-08729eebbcf3" />
<img width="1422" height="293" alt="Screenshot 2026-09-02 at 4 10 57 PM" src="https://github.com/user-attachments/assets/4b04ef63-4749-44fd-b8b4-c0dbfa6620a1" />
