### PR TITLE
[patch] fix suite_app_restore pvc for manage

### DIFF
--- a/ibm/mas_devops/roles/suite_app_restore/README.md
+++ b/ibm/mas_devops/roles/suite_app_restore/README.md
@@ -49,13 +49,6 @@ Defines the MAS instance ID for the restore action. Must match the instance ID f
 - Environment Variable: `MAS_INSTANCE_ID`
 - Default: None
 
-### mas_workspace_id
-Defines the MAS workspace ID for the restore action. Must match the workspace ID from the backup.
-
-- **Required**
-- Environment Variable: `MAS_WORKSPACE_ID`
-- Default: None
-
 ### mas_backup_dir
 Defines the directory where backups are stored. The role will look for the backup version subdirectory within this location.
 
@@ -71,6 +64,13 @@ Specifies which backup version to restore. This should match the version identif
 - Environment Variable: `MAS_APP_BACKUP_VERSION`
 - Default: None
 - Example: `20240315-143022` or `v1.0-prod`
+
+### mas_workspace_id
+Defines the MAS workspace ID for the restore action. If not provided, it is automatically derived from the `mas.ibm.com/workspaceId` label on the workspace backup CR.
+
+- Optional
+- Environment Variable: `MAS_WORKSPACE_ID`
+- Default: Auto-discovered from workspace backup CR label `mas.ibm.com/workspaceId`
 
 ### mas_app_restore_wait_retries
 Maximum time in seconds to wait for ManageWorkspace to become ready after restore.
@@ -310,14 +310,13 @@ Example Playbooks
 -------------------------------------------------------------------------------
 
 ### Basic Restore
-Restore Manage namespace resources and persistent volumes from a backup:
+Restore Manage namespace resources and persistent volumes from a backup. The workspace ID is automatically derived from the backup CR:
 
 ```yaml
 - hosts: localhost
   any_errors_fatal: true
   vars:
     mas_instance_id: inst1
-    mas_workspace_id: ws1
     mas_app_id: manage
     mas_backup_dir: /backup/mas
     mas_app_backup_version: "20240315-143022"
@@ -333,7 +332,6 @@ Restore with a custom wait timeout for large deployments:
   any_errors_fatal: true
   vars:
     mas_instance_id: inst1
-    mas_workspace_id: ws1
     mas_app_id: manage
     mas_backup_dir: /backup/mas
     mas_app_backup_version: "prod-backup-20240315"
@@ -351,7 +349,6 @@ Restore Facilities namespace resources and persistent volumes from a backup:
   any_errors_fatal: true
   vars:
     mas_instance_id: inst1
-    mas_workspace_id: ws1
     mas_app_id: facilities
     mas_backup_dir: /backup/mas
     mas_app_backup_version: "20240315-143022"
@@ -367,7 +364,6 @@ Complete workflow including database restore:
   any_errors_fatal: true
   vars:
     mas_instance_id: inst1
-    mas_workspace_id: ws1
     mas_backup_dir: /backup/mas
     backup_version: "20240315-143022"
   
@@ -397,7 +393,6 @@ Complete workflow including database restore:
   any_errors_fatal: true
   vars:
     mas_instance_id: inst1
-    mas_workspace_id: ws1
     mas_backup_dir: /backup/mas
     backup_version: "20240315-143022"
   
@@ -427,7 +422,6 @@ Restore to a different cluster with different storage classes:
   any_errors_fatal: true
   vars:
     mas_instance_id: inst1
-    mas_workspace_id: ws1
     mas_app_id: manage
     mas_backup_dir: /backup/mas
     mas_app_backup_version: "20240315-143022"
@@ -448,7 +442,6 @@ Restore with override enabled but using cluster's default storage classes:
   any_errors_fatal: true
   vars:
     mas_instance_id: inst1
-    mas_workspace_id: ws1
     mas_app_id: manage
     mas_backup_dir: /backup/mas
     mas_app_backup_version: "20240315-143022"
@@ -467,7 +460,6 @@ Restore only namespace resources without restoring persistent volume data:
   any_errors_fatal: true
   vars:
     mas_instance_id: inst1
-    mas_workspace_id: ws1
     mas_app_id: manage
     mas_backup_dir: /backup/mas
     mas_app_backup_version: "20240315-143022"
@@ -485,7 +477,6 @@ Restore Facilities namespace resources without restoring persistent volume data:
   any_errors_fatal: true
   vars:
     mas_instance_id: inst1
-    mas_workspace_id: ws1
     mas_app_id: facilities
     mas_backup_dir: /backup/mas
     mas_app_backup_version: "20240315-143022"
@@ -531,6 +522,7 @@ Troubleshooting
 
 Notes
 -------------------------------------------------------------------------------
+- **Workspace ID Auto-Discovery**: `mas_workspace_id` is automatically derived from the `mas.ibm.com/workspaceId` label on the workspace backup CR. You only need to set `MAS_WORKSPACE_ID` explicitly if you want to override the value from the backup
 - **Database Restore**: This role does NOT restore application databases. Use the [db2](db2.md) role to restore Db2 databases separately, and do this BEFORE running the application restore
 - **Suite Resources**: This role restores application-specific resources only. For suite-level resources (Suite CR, workspace CRs, etc.), use the [suite_restore](suite_restore.md) role
 - **Instance ID Match**: The restore must be performed on a cluster with the same MAS instance ID as the backup

--- a/ibm/mas_devops/roles/suite_app_restore/defaults/main.yml
+++ b/ibm/mas_devops/roles/suite_app_restore/defaults/main.yml
@@ -5,7 +5,7 @@
 # General Configuration
 # -----------------------------------------------------------------------------
 mas_instance_id: "{{ lookup('env', 'MAS_INSTANCE_ID') }}"
-mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') }}"
+mas_workspace_id: "{{ lookup('env', 'MAS_WORKSPACE_ID') | default('', true) }}"
 mas_app_id: "{{ lookup('env', 'MAS_APP_ID') }}"
 
 # Restore Configuration

--- a/ibm/mas_devops/roles/suite_app_restore/tasks/facilities/restore-namespace.yml
+++ b/ibm/mas_devops/roles/suite_app_restore/tasks/facilities/restore-namespace.yml
@@ -62,7 +62,23 @@
 
 - name: "Set fact: Facilities workspace CR name"
   set_fact:
-    facilities_workspace_cr_name: "{{ workspace_backup_cr.metadata.name}}"
+    facilities_workspace_cr_name: "{{ workspace_backup_cr.metadata.name }}"
+
+- name: "Set fact: mas_workspace_id from FacilitiesWorkspace backup CR label"
+  set_fact:
+    mas_workspace_id: "{{ workspace_backup_cr.metadata.labels['mas.ibm.com/workspaceId'] }}"
+  when: mas_workspace_id == '' or mas_workspace_id is not defined
+
+- name: "Fail if mas_workspace_id could not be determined"
+  fail:
+    msg: >-
+      mas_workspace_id could not be determined. The FacilitiesWorkspace backup CR at
+      {{ instance_files[0] }} does not have the label 'mas.ibm.com/workspaceId'.
+  when: mas_workspace_id == '' or mas_workspace_id is not defined
+
+- name: "Display resolved mas_workspace_id"
+  debug:
+    msg: "Workspace ID resolved to: {{ mas_workspace_id }}"
 
 # 3.1. Determine storage class override settings
 # ---------------------------------------------------------------------

--- a/ibm/mas_devops/roles/suite_app_restore/tasks/manage/restore-namespace.yml
+++ b/ibm/mas_devops/roles/suite_app_restore/tasks/manage/restore-namespace.yml
@@ -91,7 +91,23 @@
 
 - name: "Set fact: Manage workspace CR name"
   set_fact:
-    manage_workspace_cr_name: "{{ workspace_backup_cr.metadata.name}}"
+    manage_workspace_cr_name: "{{ workspace_backup_cr.metadata.name }}"
+
+- name: "Set fact: mas_workspace_id from ManageWorkspace backup CR label"
+  set_fact:
+    mas_workspace_id: "{{ workspace_backup_cr.metadata.labels['mas.ibm.com/workspaceId'] }}"
+  when: mas_workspace_id == '' or mas_workspace_id is not defined
+
+- name: "Fail if mas_workspace_id could not be determined"
+  fail:
+    msg: >-
+      mas_workspace_id could not be determined. The ManageWorkspace backup CR at
+      {{ instance_files[0] }} does not have the label 'mas.ibm.com/workspaceId'.
+  when: mas_workspace_id == '' or mas_workspace_id is not defined
+
+- name: "Display resolved mas_workspace_id"
+  debug:
+    msg: "Workspace ID resolved to: {{ mas_workspace_id }}"
 
 # 4. Restore resources until ManageApp CR (excluding ManageWorkspace)
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Case Number - TS022937546 
DT475696
Fixes:
- suite_app_restore role is supposed to auto-discover workspace ID from the workspace backup resource which is used in restore-pvc for Manage app. and this auto-discover wasn't working.
So for Manage, when creating pvc to restore data, the workspace id in pvc name convention was empty, this was leading to creation of wrong pvc name where the pvc data was restored.
- Also fixed README to show MAS_WORKSPACE_ID is optional for suite_app_retsore 

## Test Results
<img width="1058" height="288" alt="Screenshot 2026-09-04 at 11 33 20" src="https://github.com/user-attachments/assets/0d9019f9-ee5c-41b9-b518-86070876f7be" />


<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
