### PR TITLE
[patch] fix nfd port collision by disabling internal nfd deployment

### DIFF
--- a/ibm/mas_devops/roles/nvidia_gpu/templates/clusterpolicy-customversion.yml.j2
+++ b/ibm/mas_devops/roles/nvidia_gpu/templates/clusterpolicy-customversion.yml.j2
@@ -4,6 +4,8 @@ kind: ClusterPolicy
 metadata:
   name: gpu-cluster-policy
 spec:
+  nfd:
+    enabled: false
   hostPaths:
     rootFS: /
     driverInstallDir: /run/nvidia/driver

--- a/ibm/mas_devops/roles/nvidia_gpu/templates/clusterpolicy-v2.yml.j2
+++ b/ibm/mas_devops/roles/nvidia_gpu/templates/clusterpolicy-v2.yml.j2
@@ -4,6 +4,8 @@ kind: ClusterPolicy
 metadata:
   name: gpu-cluster-policy
 spec:
+  nfd:
+    enabled: false
   driver:
     enabled: true
     upgradePolicy:

--- a/ibm/mas_devops/roles/nvidia_gpu/templates/clusterpolicy-v3.yml.j2
+++ b/ibm/mas_devops/roles/nvidia_gpu/templates/clusterpolicy-v3.yml.j2
@@ -4,6 +4,8 @@ kind: ClusterPolicy
 metadata:
   name: gpu-cluster-policy
 spec:
+  nfd:
+    enabled: false
   hostPaths:
     rootFS: /
     driverInstallDir: /run/nvidia/driver


### PR DESCRIPTION
## Description
This PR addresses a port collision issue that causes the nfd-worker pod to fall into a CrashLoopBackOff state (listen tcp :8082: bind: address already in use).

What changed: Explicitly disabled the NVIDIA GPU Operator's internal Node Feature Discovery (NFD) deployment by setting nfd.enabled: false in all ClusterPolicy templates (v2, v3, and customversion).

Why it's needed: In PR #2402, the GPU Operator was bumped to channel v26.3. In this version, the GPU Operator attempts to deploy its own NFD worker by default if it is not explicitly disabled. Since the ibm.mas_devops.nvidia_gpu Ansible role already manages and deploys a separate NFD instance in the openshift-nfd namespace, this resulted in two NFD workers trying to run on the same node and colliding on port 8082. This change ensures we solely rely on the manually deployed NFD instance.
