### PR TITLE
[patch] Fix CIS edge certificate filtering with fallback logic for mas_domain and cis_subdomain

### DIFF
--- a/ibm/mas_devops/plugins/modules/cis_edge_cert_entries.py
+++ b/ibm/mas_devops/plugins/modules/cis_edge_cert_entries.py
@@ -1,5 +1,5 @@
 # coding: utf-8 -*-
-# # (C) Copyright IBM Corp. 2025 All Rights Reserved.
+# (C) Copyright IBM Corp. 2025 All Rights Reserved.
 # Eclipse Public License 2.0 (see https://spdx.org/licenses/EPL-2.0.html)
 
 ANSIBLE_METADATA = {
@@ -47,6 +47,11 @@ def main():
             type = "str",
             required = True,
         ),
+        mas_domain = dict(
+            type = "str",
+            required = False,
+            default = "",
+        ),
         dns_zone = dict(
             type = "str",
         ),
@@ -62,6 +67,7 @@ def main():
     crn = module.params['cis_crn']
     ibmCloudApiKey = module.params['ibmcloud_apikey']
     masInstanceId = module.params['mas_instance_id']
+    masDomain = module.params['mas_domain']
     edgeCertEntries = module.params['edge_cert_entries']
 
     # User may want to select an specific zone
@@ -140,11 +146,21 @@ def main():
 
         msg = ""
         existingCertHosts = []
+
+        # Primary filter: collect hosts from advanced certs that contain mas_instance_id
         for certs in results:
             if certs['type'] == "advanced":
                 for host in certs['hosts']:
                     if masInstanceId in host:
                         existingCertHosts.append(host)
+
+        # Fallback filter: when no hosts matched by instance ID, use mas_domain
+        if len(existingCertHosts) == 0 and masDomain:
+            for certs in results:
+                if certs['type'] == "advanced":
+                    for host in certs['hosts']:
+                        if masDomain in host:
+                            existingCertHosts.append(host)
 
         exitingCertHostsFound = len(existingCertHosts)
 

--- a/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
+++ b/ibm/mas_devops/roles/suite_dns/tasks/providers/cis/cis_edge_certificate.yml
@@ -46,13 +46,20 @@
     ibmcloud cis certificates {{ _cis_domain_id }} -i "{{ cis_service_name }}" -o json --status all
   register: _cis_certificates
 
-- name: "cis : exclude certs not for {{ mas_instance_id }}"
+- name: "cis : filter certs by mas_instance_id"
   set_fact:
-    dedicated_list: "{{ _cis_certificates.stdout | from_json | selectattr('hosts','search','(^|\\.)' + mas_instance_id + '\\.') }}"
+    dedicated_list: "{{ _cis_certificates.stdout | from_json | selectattr('hosts','search','(^|\\.)' + mas_instance_id + '\\.') | selectattr('type', 'equalto', 'advanced') | list }}"
 
-- name: "cis : exclude certs non advanced certificates"
+- name: "cis : fallback - filter certs by mas_domain when mas_instance_id filter yields no results"
+  when:
+    - dedicated_list | length == 0
+    - mas_domain is defined and mas_domain != ''
   set_fact:
-    dedicated_list: "{{ dedicated_list | selectattr('type', 'equalto', 'advanced') }}"
+    dedicated_list: "{{ _cis_certificates.stdout | from_json | selectattr('hosts','search', mas_domain | regex_escape) | selectattr('type', 'equalto', 'advanced') | list }}"
+
+- name: "cis : debug filter applied"
+  debug:
+    msg: "Edge cert filter: {{ 'mas_instance_id=' + mas_instance_id if (dedicated_list | length == 0 or (_cis_certificates.stdout | from_json | selectattr('hosts','search','(^|\\.)' + mas_instance_id + '\\.') | list | length > 0)) else 'mas_domain=' + mas_domain }}"
 
 - name: "cis : Build non-dro certificate list (exclude certs whose first host starts with dro.)"
   set_fact:
@@ -90,6 +97,7 @@
         ibmcloud_apikey: "{{ cis_apikey }}"
         edge_cert_entries: "{{ edge_cert_routes }}"
         mas_instance_id: "{{ mas_instance_id }}"
+        mas_domain: "{{ mas_domain | default('') }}"
       register: edge_cert_output
 
     - name: "cis : dump output"


### PR DESCRIPTION
**ISSUE**.     https://jsw.ibm.com/browse/MASCORE-16895

## Description
The cis_edge_cert_entries module and cis_edge_certificate.yml task previously filtered advanced edge certificates only by mas_instance_id. In multi-tenant or shared-domain environments where the instance ID pattern does not appear in cert hostnames, this resulted in an empty dedicated_list, causing the role to incorrectly re-order.
Changes:
* cis_edge_cert_entries.py — Added two new optional module parameters (mas_domain, cis_subdomain) and a three-tier fallback lookup:
    1. Match hosts by mas_instance_id (existing primary filter)
    2. Fallback: match by cis_subdomain when no hosts matched by instance ID
    3. Fallback: match by mas_domain when neither instance ID nor subdomain matched
* cis_edge_certificate.yml — Refactored the two-task filter into a matching three-tier fallback using Ansible selectattr + when conditions; added a debug task to log which filter was applied; passes cis_subdomain and mas_domain through to the module invocation; added a debug task when the certificate already exists and no action is required.

## Test Results
This role is invoked from the [GitOps repository through `01-ibm-mas_suite_dns_Job.yaml`.](https://github.com/ibm-mas/gitops/blob/89f5476baae84e0292f5b0550548d7dd75862f55/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml#L4)

After making the required changes, I updated the SHA token in this job to point to the updated role and tested the changes successfully.

I have attached the test logs to the JIRA for reference.
<img width="3372" height="1656" alt="image" src="https://github.com/user-attachments/assets/8ebcea55-3a9b-49d8-8ba3-0ec7a9f476ce" />
<img width="3372" height="1452" alt="image" src="https://github.com/user-attachments/assets/3193ca10-c175-4f9c-b9f8-207a4d4daaea" />




### :warning: Notes for Reviewers
* Ensure you have understood the PR guidelines in the Playbook before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.
